### PR TITLE
fix(extensions): 将默认url从localhost:8080改为api.open-aaas.com

### DIFF
--- a/client-extension/kimi-plugin/cancel_task.py
+++ b/client-extension/kimi-plugin/cancel_task.py
@@ -107,7 +107,7 @@ def main():
             sys.exit(1)
         
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
         
         # 执行取消

--- a/client-extension/kimi-plugin/config.json.example
+++ b/client-extension/kimi-plugin/config.json.example
@@ -1,7 +1,7 @@
 {
   "servers": {
     "default": {
-      "server_url": "http://localhost:8080",
+      "server_url": "https://api.open-aaas.com",
       "api_key": "your_api_key_here",
       "client_id": "your_client_id_here"
     }

--- a/client-extension/kimi-plugin/discover.py
+++ b/client-extension/kimi-plugin/discover.py
@@ -62,7 +62,7 @@ def main():
         config = load_config()
         server_name = params.get("server_name", "")
         active_conf = config.get("servers", {}).get(server_name or config.get("default_server", "default"), {})
-        server_url = params.get("server_url", active_conf.get("server_url", config.get("server_url", "http://localhost:8080")))
+        server_url = params.get("server_url", active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com")))
         
         # 执行发现
         result = discover(server_url)

--- a/client-extension/kimi-plugin/download_result.py
+++ b/client-extension/kimi-plugin/download_result.py
@@ -348,7 +348,7 @@ def main():
             sys.exit(1)
 
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
 
         # 获取可选参数

--- a/client-extension/kimi-plugin/get_service_usage.py
+++ b/client-extension/kimi-plugin/get_service_usage.py
@@ -87,7 +87,7 @@ def main():
             sys.exit(1)
 
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
 
         result = get_service_usage(server_url, api_key, service_id)

--- a/client-extension/kimi-plugin/get_task.py
+++ b/client-extension/kimi-plugin/get_task.py
@@ -189,7 +189,7 @@ def main():
             sys.exit(1)
         
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
         
         # 执行查询

--- a/client-extension/kimi-plugin/list_files.py
+++ b/client-extension/kimi-plugin/list_files.py
@@ -101,7 +101,7 @@ def main():
             sys.exit(1)
 
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
 
         result = list_files(server_url, api_key, task_id)

--- a/client-extension/kimi-plugin/list_services.py
+++ b/client-extension/kimi-plugin/list_services.py
@@ -96,7 +96,7 @@ def main():
             sys.exit(1)
         
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
         
         # 执行查询

--- a/client-extension/kimi-plugin/plugin.json
+++ b/client-extension/kimi-plugin/plugin.json
@@ -18,7 +18,7 @@
           },
           "server_url": {
             "type": "string",
-            "description": "服务端地址，如 http://localhost:8080"
+            "description": "服务端地址，如 https://api.open-aaas.com"
           },
           "api_key": {
             "type": "string",

--- a/client-extension/kimi-plugin/register.py
+++ b/client-extension/kimi-plugin/register.py
@@ -132,7 +132,7 @@ def main():
         # 获取参数
         config = load_config()
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url") or config.get("server_url") or "http://localhost:8080"
+        server_url = active_conf.get("server_url") or config.get("server_url") or "https://api.open-aaas.com"
         if not server_url:
             print(json.dumps({"error": "缺少服务端地址，请先使用 set_server_url 设置服务器地址"}, ensure_ascii=False))
             sys.exit(1)

--- a/client-extension/kimi-plugin/submit_task.py
+++ b/client-extension/kimi-plugin/submit_task.py
@@ -180,7 +180,7 @@ def main():
             sys.exit(1)
         
         active_conf = config.get("servers", {}).get(config.get("default_server", "default"), {})
-        server_url = active_conf.get("server_url", config.get("server_url", "http://localhost:8080"))
+        server_url = active_conf.get("server_url", config.get("server_url", "https://api.open-aaas.com"))
         api_key = active_conf.get("api_key", config.get("api_key", ""))
         
         # 获取可选参数

--- a/client-extension/kimi-plugin/update_profile.py
+++ b/client-extension/kimi-plugin/update_profile.py
@@ -137,7 +137,7 @@ def main():
             sys.exit(1)
         
         active_conf = config.get("servers", {}).get(default_server, {})
-        server_url = active_conf.get("server_url") or config.get("server_url") or "http://localhost:8080"
+        server_url = active_conf.get("server_url") or config.get("server_url") or "https://api.open-aaas.com"
         api_key = active_conf.get("api_key", config.get("api_key", ""))
         
         # 执行更新

--- a/client-extension/kimi-plugin/utils.py
+++ b/client-extension/kimi-plugin/utils.py
@@ -21,12 +21,12 @@ def load_config():
             if not isinstance(config, dict):
                 return {
                     "error": f"config.json 格式错误: 期望 JSON 对象，实际为 {type(config).__name__}",
-                    "server_url": "http://localhost:8080",
+                    "server_url": "https://api.open-aaas.com",
                     "api_key": "",
                     "client_id": "",
                     "servers": {
                         "default": {
-                            "server_url": "http://localhost:8080",
+                            "server_url": "https://api.open-aaas.com",
                             "api_key": "",
                             "client_id": ""
                         }
@@ -36,12 +36,12 @@ def load_config():
     except Exception as e:
         return {
             "error": f"无法读取 config.json: {str(e)}",
-            "server_url": "http://localhost:8080",
+            "server_url": "https://api.open-aaas.com",
             "api_key": "",
             "client_id": "",
             "servers": {
                 "default": {
-                    "server_url": "http://localhost:8080",
+                    "server_url": "https://api.open-aaas.com",
                     "api_key": "",
                     "client_id": ""
                 }
@@ -52,12 +52,12 @@ def load_config():
     # 兼容旧格式：单服务器配置
     if "servers" not in config and "server_url" in config:
         config = {
-            "server_url": config.get("server_url", "http://localhost:8080"),
+            "server_url": config.get("server_url", "https://api.open-aaas.com"),
             "api_key": config.get("api_key", ""),
             "client_id": config.get("client_id", ""),
             "servers": {
                 "default": {
-                    "server_url": config.get("server_url", "http://localhost:8080"),
+                    "server_url": config.get("server_url", "https://api.open-aaas.com"),
                     "api_key": config.get("api_key", ""),
                     "client_id": config.get("client_id", "")
                 }

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -97,7 +97,7 @@ uv run openaaas-mcp-adapter
 {
   "servers": {
     "default": {
-      "server_url": "http://localhost:8080",
+      "server_url": "https://api.open-aaas.com",
       "api_key": "",
       "client_id": "",
       "name": ""
@@ -224,7 +224,7 @@ list_servers()
 
 ### 标准使用流程
 
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 localhost）
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
 2. `register` — 注册获取 api_key（仅需一次）
 3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
 4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
@@ -267,7 +267,7 @@ list_servers()
 
 ### 基础流程
 
-1. **设置服务器地址**（可选，默认 http://localhost:8080）：
+1. **设置服务器地址**（可选，默认 https://api.open-aaas.com）：
    ```
    set_server_url(server_url: "https://api.open-aaas.com")
    ```

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/config.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/config.py
@@ -8,7 +8,7 @@ from typing import Any
 DEFAULT_CONFIG: dict[str, Any] = {
     "servers": {
         "default": {
-            "server_url": "http://localhost:8080",
+            "server_url": "https://api.open-aaas.com",
             "api_key": "",
             "client_id": "",
             "name": "",
@@ -64,7 +64,7 @@ def load_config() -> dict[str, Any]:
         parsed = {
             "servers": {
                 "default": {
-                    "server_url": parsed.get("server_url", "http://localhost:8080"),
+                    "server_url": parsed.get("server_url", "https://api.open-aaas.com"),
                     "api_key": parsed.get("api_key", ""),
                     "client_id": parsed.get("client_id", ""),
                     "name": parsed.get("name", ""),

--- a/client-extension/pi-extension/README.md
+++ b/client-extension/pi-extension/README.md
@@ -29,7 +29,7 @@ npm install
 {
   "servers": {
     "default": {
-      "server_url": "http://localhost:8080"
+      "server_url": "https://api.open-aaas.com"
     }
   },
   "default_server": "default"
@@ -120,7 +120,7 @@ OpenAaaS(action: "list_servers")
 本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
 
 **标准使用流程**：
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 localhost）
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
 2. `register` — 注册获取 api_key（仅需一次）
 3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
 4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
@@ -164,7 +164,7 @@ OpenAaaS(action: "list_servers")
 
 ## 使用示例
 
-1. 设置服务器地址（可选，默认 http://localhost:8080）：
+1. 设置服务器地址（可选，默认 https://api.open-aaas.com）：
    ```
    OpenAaaS(action: "set_server_url", server_url: "https://www.open-aaas.com")
    ```

--- a/client-extension/pi-extension/index.ts
+++ b/client-extension/pi-extension/index.ts
@@ -68,7 +68,7 @@ function ensureConfigDir() {
 function loadConfig(): AppConfig {
   ensureConfigDir();
   const defaultConfig: AppConfig = {
-    servers: { default: { server_url: "http://localhost:8080" } },
+    servers: { default: { server_url: "https://api.open-aaas.com" } },
     default_server: "default",
   };
   if (!existsSync(CONFIG_PATH)) {


### PR DESCRIPTION
## Description

将默认url从localhost:8080改为api.open-aaas.com

## Checklist

- [ ] 代码改动已测试通过
- [ ] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
