### PR TITLE
Fix/client app output prompt placeholder

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-10
+
+### Fixed
+- 修复output_prompt填写逻辑
+
 ## [0.1.0] - 2026-05-09
 
 ### Added

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.1.0"
+version = "0.1.1"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src/views/SubmitTaskView.vue
+++ b/client-app/src/views/SubmitTaskView.vue
@@ -53,7 +53,7 @@ async function submit() {
       serviceName: service.value.name,
       title: title.value || '未命名任务',
       taskPrompt: taskPrompt.value,
-      outputPrompt: outputPrompt.value,
+      outputPrompt: outputPrompt.value.trim() || '将结果写入response.md',
       files: files.value ? Array.from(files.value) : undefined,
     })
     uiStore.addToast('任务提交成功', 'success')
@@ -70,10 +70,6 @@ function nextStep() {
   if (step.value === 1) {
     if (!taskPrompt.value.trim()) {
       uiStore.addToast('任务描述不能为空', 'error')
-      return
-    }
-    if (!outputPrompt.value.trim()) {
-      uiStore.addToast('输出要求不能为空', 'error')
       return
     }
   }
@@ -161,12 +157,12 @@ onMounted(async () => {
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">输出要求 (output_prompt)</label>
+            <label class="block text-sm font-medium text-text-secondary mb-1">输出要求 (output_prompt) - 可选</label>
             <textarea
               v-model="outputPrompt"
               rows="3"
               class="w-full px-3 py-2 bg-bg-primary border border-border rounded-md text-sm focus:border-accent focus:outline-none resize-y"
-              placeholder="描述您期望的输出格式..."
+              placeholder="描述您期望的输出格式，留空则默认：将结果写入response.md"
             />
           </div>
           <div


### PR DESCRIPTION

## Description

- client-app中，output_prompt非必填
- 添加placeholder
- 添加默认值

## Checklist

- [ ] 代码改动已测试通过
- [x] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
