### PR TITLE
fix(client-app): 修复长任务轮询因失败阈值过低而永久停止的问题 (#37)

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-11
+
+### Fixed
+- 修复长任务轮询因失败阈值过低而永久停止的问题
+
 ## [0.3.0] - 2026-05-11
 
 ### Fixed

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src/stores/task.ts
+++ b/client-app/src/stores/task.ts
@@ -35,11 +35,12 @@ export interface Task {
   resultFetched?: boolean
   fetchError?: string
   isFetchingResult?: boolean
+  pollError?: string
 }
 
 const FIRST_POLL_MS = 5000
 const POLL_INTERVAL_MS = 30000
-const MAX_POLL_FAIL = 3
+const MAX_POLL_FAIL = 20
 
 function isActiveStatus(status: TaskStatus): boolean {
   return ['pending', 'running', 'cancelling'].includes(status)
@@ -176,6 +177,7 @@ export const useTaskStore = defineStore('task', () => {
     }
 
     try {
+      if (!task.isPolling) return
       const baseUrl = server.serverUrl.replace(/\/$/, '')
       const url = `${baseUrl}/api/v1/client/tasks/${encodeURIComponent(taskId)}`
       const res = await httpFetch(url, {
@@ -190,6 +192,7 @@ export const useTaskStore = defineStore('task', () => {
       const patch: Partial<Task> = {
         status: newStatus,
         pollFailCount: 0,
+        pollError: undefined,
         isPolling: !isTerminalStatus(newStatus),
       }
       if (data.started_at) patch.startedAt = data.started_at
@@ -220,7 +223,11 @@ export const useTaskStore = defineStore('task', () => {
       if (isTerminalStatus(newStatus)) {
         stopPolling(taskId)
         if (newStatus === 'completed') {
-          await fetchResult(taskId)
+          try {
+            await fetchResult(taskId)
+          } catch {
+            // fetchResult 内部已处理错误，此处静默忽略
+          }
         }
       } else {
         const delay = isFirst ? FIRST_POLL_MS : POLL_INTERVAL_MS
@@ -228,13 +235,17 @@ export const useTaskStore = defineStore('task', () => {
         pollTimers.set(taskId, timer)
       }
     } catch (err) {
-      const failCount = (task.pollFailCount || 0) + 1
+      const currentTask = getTask(taskId)
+      if (!currentTask) return
+      if (isTerminalStatus(currentTask.status) || !currentTask.isPolling) return
+      const failCount = (currentTask.pollFailCount || 0) + 1
       updateTask(taskId, { pollFailCount: failCount })
       if (failCount >= MAX_POLL_FAIL) {
         stopPolling(taskId)
-        updateTask(taskId, { isPolling: false, errorMessage: '轮询失败次数过多，已停止' })
+        updateTask(taskId, { pollError: '轮询失败次数过多，已停止' })
       } else {
-        const timer = window.setTimeout(() => doPoll(taskId, false), POLL_INTERVAL_MS)
+        const delay = Math.min(POLL_INTERVAL_MS * 2 ** (failCount - 1), 300000)
+        const timer = window.setTimeout(() => doPoll(taskId, false), delay)
         pollTimers.set(taskId, timer)
       }
     }
@@ -242,7 +253,7 @@ export const useTaskStore = defineStore('task', () => {
 
   function startPolling(taskId: string) {
     stopPolling(taskId)
-    updateTask(taskId, { isPolling: true })
+    updateTask(taskId, { isPolling: true, pollFailCount: 0, pollError: undefined })
     const timer = window.setTimeout(() => doPoll(taskId, true), FIRST_POLL_MS)
     pollTimers.set(taskId, timer)
   }
@@ -352,6 +363,10 @@ export const useTaskStore = defineStore('task', () => {
     }
   }
 
+  function resumePollingForTask(taskId: string) {
+    startPolling(taskId)
+  }
+
   return {
     tasks,
     activeTasks,
@@ -367,5 +382,6 @@ export const useTaskStore = defineStore('task', () => {
     removeTask,
     updateTask,
     resumePolling,
+    resumePollingForTask,
   }
 })

--- a/client-app/src/views/TaskDetailView.vue
+++ b/client-app/src/views/TaskDetailView.vue
@@ -91,6 +91,20 @@ function handleResubmit() {
   router.push(`/submit/${task.value.serviceId}`)
 }
 
+async function handleResumePolling() {
+  if (!task.value) return
+  try {
+    uiStore.setLoading(true)
+    taskStore.resumePollingForTask(task.value.id)
+    uiStore.addToast('已恢复轮询', 'success')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    uiStore.addToast(msg, 'error')
+  } finally {
+    uiStore.setLoading(false)
+  }
+}
+
 const renderedResult = computed(() => {
   if (!task.value?.result) return ''
   const html = marked.parse(task.value.result, { async: false }) as string
@@ -220,6 +234,13 @@ watch(() => route.params.id, () => {
         </div>
       </div>
 
+      <!-- Poll Error -->
+      <div v-if="task.pollError" class="mb-6">
+        <div class="bg-danger/5 border border-danger/20 rounded-md p-3 text-sm text-danger">
+          {{ task.pollError }}
+        </div>
+      </div>
+
       <!-- Actions -->
       <div class="flex gap-3">
         <button
@@ -228,6 +249,13 @@ watch(() => route.params.id, () => {
           @click="handleCancel"
         >
           取消任务
+        </button>
+        <button
+          v-if="canCancel && task.pollError"
+          class="px-4 py-2 bg-accent text-white rounded-md text-sm font-medium hover:bg-accent-hover transition-colors"
+          @click="handleResumePolling"
+        >
+          恢复轮询
         </button>
         <button
           v-if="isTerminal"


### PR DESCRIPTION
修复 issue #37：client-app 长任务轮询因失败阈值过低而永久停止。

### 变更内容
- 将 MAX_POLL_FAIL 从 3 提高到 20
- 轮询失败重试间隔改为指数退避（上限 5 分钟）
- 新增 pollError 字段，与服务器返回的 errorMessage 分离
- 新增 resumePollingForTask 方法及 UI"恢复轮询"按钮
- 修复多处竞态条件

Fixes #37