### PR TITLE
fix(client-app): 修复任务返回结果的Markdown渲染问题 (#41)

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-11
+
+### Fixed
+- 修复任务返回结果的Markdown渲染问题（表格、标题、换行等格式异常）
+
 ## [0.3.1] - 2026-05-11
 
 ### Fixed

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openaaas-client",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openaaas-client",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-http": "^2",
@@ -17,6 +17,7 @@
         "vue-router": "^4"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@tauri-apps/cli": "^2.11.1",
         "@types/dompurify": "^3",
         "@types/node": "^22",
@@ -994,6 +995,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.0",

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -21,6 +21,7 @@
     "vue-router": "^4"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/cli": "^2.11.1",
     "@types/dompurify": "^3",
     "@types/node": "^22",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.3.1"
+version = "0.3.2"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src-tauri/tauri.conf.json
+++ b/client-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenAaaS Client",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "identifier": "com.openaaas.client",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/client-app/src/views/ServiceDetailView.vue
+++ b/client-app/src/views/ServiceDetailView.vue
@@ -30,7 +30,7 @@ const load = ref<{
 const usage = ref<string | null | undefined>(undefined)
 const usageHtml = computed(() => {
   if (!usage.value) return ''
-  const html = marked.parse(usage.value, { async: false }) as string
+  const html = marked.parse(usage.value, { async: false, breaks: true }) as string
   return DOMPurify.sanitize(html)
 })
 
@@ -141,7 +141,7 @@ watch(() => route.params.id, () => {
 
       <div v-if="usage !== undefined && usage !== null" class="mt-4 p-3 bg-bg-primary border border-border rounded-md">
         <p class="text-sm font-medium mb-1">使用说明</p>
-        <div class="text-sm leading-relaxed prose prose-invert max-w-none" v-html="usageHtml" />
+        <div class="text-sm leading-relaxed prose max-w-none" v-html="usageHtml" />
       </div>
       <div v-else-if="usage === null" class="mt-4 p-3 bg-bg-primary border border-border rounded-md">
         <p class="text-sm font-medium mb-1">使用说明</p>

--- a/client-app/src/views/TaskDetailView.vue
+++ b/client-app/src/views/TaskDetailView.vue
@@ -107,7 +107,7 @@ async function handleResumePolling() {
 
 const renderedResult = computed(() => {
   if (!task.value?.result) return ''
-  const html = marked.parse(task.value.result, { async: false }) as string
+  const html = marked.parse(task.value.result, { async: false, breaks: true }) as string
   return DOMPurify.sanitize(html)
 })
 
@@ -195,7 +195,7 @@ watch(() => route.params.id, () => {
       <!-- Result area -->
       <div v-if="task.result != null" class="mb-6">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-text-secondary mb-2">结果</h3>
-        <div class="bg-bg-primary border border-border rounded-md p-4 text-sm leading-relaxed" v-html="renderedResult" />
+        <div class="bg-bg-primary border border-border rounded-md p-4 text-sm leading-relaxed prose max-w-none" v-html="renderedResult" />
       </div>
       <div v-else-if="task.status === 'completed' && task.isFetchingResult" class="mb-6">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-text-secondary mb-2">结果</h3>

--- a/client-app/tailwind.config.js
+++ b/client-app/tailwind.config.js
@@ -23,5 +23,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## 修复内容

修复 client-app 中任务返回结果无法正确渲染 Markdown 的问题（表格、标题等格式异常）。

## 变更

- 安装 `@tailwindcss/typography` 插件并在 Tailwind 配置中启用
- 为 `TaskDetailView.vue` 的结果渲染区域添加 `prose max-w-none` 样式
- 移除 `ServiceDetailView.vue` 中不适配浅色主题的 `prose-invert`

Fixes #41