### PR TITLE
fix(client-app): 修复文件下载后缺少完成反馈的问题 (#44)

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-11
+
+### Fixed
+- 修复文件下载后缺少完成反馈的问题（#44）
+- 使用 Tauri dialog + fs 插件让用户选择保存路径，保存完成后显示完整路径的 toast 提示
+
 ## [0.3.2] - 2026-05-11
 
 ### Fixed

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openaaas-client",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openaaas-client",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.3.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-http": "^2",
         "dompurify": "^3",
         "marked": "^13",
@@ -1263,6 +1265,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-fs": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz",
+      "integrity": "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-http": {

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-http": "^2",
     "dompurify": "^3",
     "marked": "^13",

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -11,6 +11,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-http = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.3.2"
+version = "0.4.0"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src-tauri/capabilities/default.json
+++ b/client-app/src-tauri/capabilities/default.json
@@ -5,6 +5,12 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:default",
+    "fs:default",
+    {
+      "identifier": "fs:allow-write-file",
+      "allow": [{ "path": "$HOME/**" }, { "path": "$DOWNLOAD/**" }]
+    },
     {
       "identifier": "http:default",
       "allow": [{ "url": "https://*" }, { "url": "http://*" }]

--- a/client-app/src-tauri/src/lib.rs
+++ b/client-app/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/client-app/src-tauri/tauri.conf.json
+++ b/client-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenAaaS Client",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "com.openaaas.client",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/client-app/src/stores/ui.ts
+++ b/client-app/src/stores/ui.ts
@@ -22,10 +22,10 @@ export const useUiStore = defineStore('ui', () => {
     isLoading.value = loadingCount.value > 0
   }
 
-  function addToast(message: string, type: ToastType = 'info') {
+  function addToast(message: string, type: ToastType = 'info', duration?: number) {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
     toastQueue.value.push({ id, message, type, createdAt: Date.now() })
-    setTimeout(() => removeToast(id), 4000)
+    setTimeout(() => removeToast(id), Math.max(1000, duration ?? 4000))
   }
 
   function removeToast(id: string) {

--- a/client-app/src/views/TaskDetailView.vue
+++ b/client-app/src/views/TaskDetailView.vue
@@ -8,6 +8,8 @@ import Skeleton from '@/components/Skeleton.vue'
 import { useUiStore } from '@/stores/ui'
 import { useServerStore } from '@/stores/server'
 import { httpFetch } from '@/composables/useHttp'
+import { save } from '@tauri-apps/plugin-dialog'
+import { writeFile } from '@tauri-apps/plugin-fs'
 
 const route = useRoute()
 const router = useRouter()
@@ -128,15 +130,28 @@ async function downloadFile(file: TaskFile) {
     })
     if (!res.ok) throw new Error(`下载失败: ${res.status}`)
     const blob = await res.blob()
-    const objectUrl = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = objectUrl
-    a.download = file.filename
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    setTimeout(() => URL.revokeObjectURL(objectUrl), 60000)
-    uiStore.addToast('下载开始', 'success')
+
+    try {
+      const safeName = file.filename.replace(/[/\\]/g, '_')
+      const filePath = await save({ defaultPath: safeName })
+      if (!filePath) {
+        uiStore.addToast('已取消保存', 'info')
+        return
+      }
+      const arrayBuffer = await blob.arrayBuffer()
+      await writeFile(filePath, new Uint8Array(arrayBuffer))
+      uiStore.addToast(`文件已保存: ${filePath}`, 'success', 6000)
+    } catch {
+      const objectUrl = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = objectUrl
+      a.download = file.filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 60000)
+      uiStore.addToast('文件已开始下载，请查看系统下载文件夹', 'info', 5000)
+    }
   } catch (err) {
     uiStore.addToast(err instanceof Error ? err.message : String(err), 'error')
   } finally {


### PR DESCRIPTION
## 修复内容

解决 issue #44：client-app 中文件下载完成后没有任何后续 UI 反馈，用户不知道文件保存到了哪里。

## 变更

- 下载逻辑优先使用 Tauri 的 dialog + fs 插件，弹出系统保存对话框让用户选择保存路径
- 保存完成后 toast 提示文件完整保存路径（停留 6 秒）
- 若 Tauri 插件不可用，自动降级为浏览器原生 <a> 标签下载，并提示查看系统下载文件夹
- 对 `file.filename` 做路径净化（替换 `/` 和 `\\` 为 `_`），防止目录穿越风险
- `uiStore.addToast` 新增可选 `duration` 参数，防止短文本瞬间消失
- 追加 `fs:allow-write-file` 权限（带 scope 限制 `$HOME/**` 和 `$DOWNLOAD/**`）

Fixes #44