### PR TITLE
fix(client-app): 修复服务授权状态不刷新 (#48)

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-12
+
+### Fixed
+- 修复服务授权状态不刷新的问题（#48）
+- HomeView 添加手动刷新按钮，支持刷新服务列表和授权状态
+- ServiceDetailView 进入页面及路由切换时自动刷新服务列表
+
 ## [0.4.0] - 2026-05-11
 
 ### Fixed

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openaaas-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openaaas-client",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.4.0"
+version = "0.5.0"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src-tauri/tauri.conf.json
+++ b/client-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenAaaS Client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.openaaas.client",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/client-app/src/views/HomeView.vue
+++ b/client-app/src/views/HomeView.vue
@@ -19,10 +19,13 @@ const loads = ref<Record<string, {
   running_tasks?: number
 } | null>>({})
 const fetchError = ref<string | null>(null)
+const isRefreshing = ref(false)
 
 async function retryFetch() {
+  if (isRefreshing.value) return
   if (!hasServers.value || !serverStore.defaultServer) return
   try {
+    isRefreshing.value = true
     uiStore.setLoading(true)
     fetchError.value = null
     await serverStore.fetchServices()
@@ -31,6 +34,7 @@ async function retryFetch() {
     fetchError.value = err instanceof Error ? err.message : '获取服务列表失败'
   } finally {
     uiStore.setLoading(false)
+    isRefreshing.value = false
   }
 }
 
@@ -77,6 +81,17 @@ onMounted(async () => {
   <div class="max-w-5xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <h1 class="text-2xl font-bold">服务市场</h1>
+      <button
+        class="p-1 text-text-secondary hover:text-text-primary transition-colors"
+        :class="{ 'animate-spin': isRefreshing }"
+        title="刷新"
+        aria-label="刷新服务列表"
+        @click="retryFetch"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+      </button>
     </div>
 
     <!-- Empty state: no servers -->

--- a/client-app/src/views/ServiceDetailView.vue
+++ b/client-app/src/views/ServiceDetailView.vue
@@ -72,12 +72,22 @@ async function fetchServiceData() {
 
 onMounted(() => {
   fetchServiceData()
+
+  const server = serverStore.defaultServer
+  if (server?.apiKey) {
+    serverStore.fetchServices().catch((err) => {
+      console.warn('刷新服务列表失败', err)
+    })
+  }
 })
 
 watch(() => route.params.id, () => {
   load.value = undefined
   usage.value = undefined
   fetchServiceData()
+  serverStore.fetchServices().catch((err) => {
+    console.warn('刷新服务列表失败', err)
+  })
 })
 </script>
 


### PR DESCRIPTION
## 修复内容

修复 client-app 中服务授权状态不及时刷新的问题。

## 变更

- **HomeView.vue**: 添加手动刷新按钮，用户可主动刷新服务列表和授权状态
- **ServiceDetailView.vue**: 进入页面及路由切换时自动刷新服务列表，确保 `hasPermission` 等字段及时更新
- 添加 `isRefreshing` 并发保护，防止快速点击导致重复请求
- 优化错误处理：使用 `console.warn` 输出刷新失败信息
- 提升无障碍支持：刷新按钮添加 `aria-label`

Fixes #48