### PR TITLE
docs: add terminal demo video to README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -147,6 +147,8 @@ Just say in the conversation:
 
 The client Agent will automatically complete registration, service discovery, task submission, and result retrieval.
 
+<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
+
 ### Using an MCP Client
 
 If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Rust + Docker — 部署在数据本地
 
 客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
 
+<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
+
 ### 用 MCP 客户端
 
 如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。


### PR DESCRIPTION
Add a terminal demo video to both README.md and README.en.md to showcase the OpenAaaS quick-start experience.