### PR TITLE
docs: add design blog link to README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,6 +16,10 @@
   <a href="./client-app/README.en.md">Desktop Client</a>
 </p>
 
+<p align="center">
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.Skill</b></a>
+</p>
+
 ---
 
 **Intelligence flows, data stays still — bring AI to the data, instead of handing data over to AI.**

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
   <a href="./client-app/README.md">桌面客户端</a>
 </p>
 
+<p align="center">
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员</b></a>
+</p>
+
 ---
 
 **智能流动，数据静止 —— 让 AI 走到数据身边，而不是把数据交给 AI。**


### PR DESCRIPTION
在 README 顶部导航栏下方新增一行醒目的设计博客链接，指向 GitHub Discussion #57。

变更内容：
- README.md: 新增居中粗体链接「设计博客：不搬数据，蒸馏管理员」
- README.en.md: 新增居中粗体链接「Design Blog: Don't Move Data, Distill an Administrator.Skill」

同时移除了导航栏中重复的「设计博客」小链接，避免重复。