### PR TITLE
Add glama.json and Dockerfile for Glama MCP verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install package, create non-root user, fix permissions in one layer
+RUN pip install --no-cache-dir openaaas-mcp-adapter==0.1.1 && \
+    useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
+ENTRYPOINT ["openaaas-mcp-adapter"]

--- a/client-extension/openaaas-mcp-adapter/Dockerfile
+++ b/client-extension/openaaas-mcp-adapter/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install package, create non-root user, fix permissions in one layer
+RUN pip install --no-cache-dir openaaas-mcp-adapter==0.1.1 && \
+    useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
+ENTRYPOINT ["openaaas-mcp-adapter"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Wolido"]
+}


### PR DESCRIPTION
Add files needed for Glama platform to verify and list the openaaas-mcp-adapter.

- glama.json: Glama auto-discovery configuration
- Dockerfile: Container image for MCP server introspection checks