### PR TITLE
docs: add PyPI badge and explicit PyPI mention in READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,12 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/openaaas-mcp-adapter/">
+    <img src="https://img.shields.io/pypi/v/openaaas-mcp-adapter?label=PyPI&color=blue" alt="PyPI">
+  </a>
+</p>
+
+<p align="center">
   📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.Skill</b></a>
 </p>
 
@@ -164,7 +170,7 @@ The client Agent will automatically complete registration, service discovery, ta
 
 ### Using an MCP Client
 
-If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.
+`openaaas-mcp-adapter` is available on PyPI. If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 </p>
 
 <p align="center">
+  <a href="https://pypi.org/project/openaaas-mcp-adapter/">
+    <img src="https://img.shields.io/pypi/v/openaaas-mcp-adapter?label=PyPI&color=blue" alt="PyPI">
+  </a>
+</p>
+
+<p align="center">
   📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员</b></a>
 </p>
 
@@ -163,7 +169,7 @@ Rust + Docker — 部署在数据本地
 
 ### 用 MCP 客户端
 
-如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。
+`openaaas-mcp-adapter` 已发布至 PyPI。如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。
 
 ```json
 {


### PR DESCRIPTION
## 变更

- 在 README.md 和 README.en.md 顶部导航栏下方新增 PyPI 版本 badge（shields.io），点击可跳转到 PyPI 页面
- 在 MCP 客户端接入段落开头显式声明 `openaaas-mcp-adapter` 已发布至 PyPI`，增强用户认知

这两处改动让用户在进入 GitHub 页面时，能在 3 秒内识别到该项目有 PyPI 包可用。