### PR TITLE
docs: add more badges and unify .skill suffix in blog titles

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,10 +20,19 @@
   <a href="https://pypi.org/project/openaaas-mcp-adapter/">
     <img src="https://img.shields.io/pypi/v/openaaas-mcp-adapter?label=PyPI&color=blue" alt="PyPI">
   </a>
+  <a href="https://opensource.org/licenses/MIT">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT">
+  </a>
+  <a href="https://github.com/Wolido/OpenAaaS/actions/workflows/ci.yml">
+    <img src="https://github.com/Wolido/OpenAaaS/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <a href="https://rust-edition-guide.rs/editions/2024.html">
+    <img src="https://img.shields.io/badge/rust-2024%20edition-blue.svg" alt="Rust">
+  </a>
 </p>
 
 <p align="center">
-  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.Skill</b></a>
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.skill</b></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,10 +20,19 @@
   <a href="https://pypi.org/project/openaaas-mcp-adapter/">
     <img src="https://img.shields.io/pypi/v/openaaas-mcp-adapter?label=PyPI&color=blue" alt="PyPI">
   </a>
+  <a href="https://opensource.org/licenses/MIT">
+    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT">
+  </a>
+  <a href="https://github.com/Wolido/OpenAaaS/actions/workflows/ci.yml">
+    <img src="https://github.com/Wolido/OpenAaaS/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <a href="https://rust-edition-guide.rs/editions/2024.html">
+    <img src="https://img.shields.io/badge/rust-2024%20edition-blue.svg" alt="Rust">
+  </a>
 </p>
 
 <p align="center">
-  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员</b></a>
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员.skill</b></a>
 </p>
 
 ---


### PR DESCRIPTION
## 变更

- 在 README.md 和 README.en.md 顶部新增 4 个 badge：PyPI、License MIT、CI、Rust 2024 edition
- CI badge 使用 <a> 包裹，与其他 badge 保持一致的点击行为
- 中文版设计博客标题追加 `.skill` 后缀
- 英文版设计博客标题 `.Skill` 统一改为 `.skill`

这些改动让 GitHub 页面在 3 秒内传递更多信息（许可、CI 状态、技术栈），同时统一中英文博客标题的大小写。