### PR TITLE
fix(extension): auto-decompress gzip/deflate/br responses in pi-extension

### DIFF
--- a/client-extension/kimi-plugin/utils.py
+++ b/client-extension/kimi-plugin/utils.py
@@ -4,12 +4,21 @@ OpenAaaS 插件 - 公共工具模块
 提供配置管理、HTTP 请求等通用功能
 """
 
+import base64
+import gzip
 import json
 import os
 import sys
 import urllib.request
 import urllib.error
 import urllib.parse
+import zlib
+
+try:
+    import brotli
+    _has_brotli = True
+except ImportError:
+    _has_brotli = False
 
 
 def load_config():
@@ -86,6 +95,39 @@ def save_config(config):
         return False
 
 
+def _decompress_body(raw_body, headers):
+    """根据 Content-Encoding 解压响应体，失败时返回原始 bytes"""
+    if not raw_body:
+        return raw_body
+    encoding = (headers or {}).get("Content-Encoding", "").lower().strip()
+    if not encoding:
+        return raw_body
+    _excepted = (OSError, zlib.error, EOFError)
+    if _has_brotli:
+        _excepted = _excepted + (brotli.error,)
+    try:
+        if encoding == "gzip":
+            return gzip.decompress(raw_body)
+        elif encoding == "deflate":
+            try:
+                return zlib.decompress(raw_body)
+            except zlib.error:
+                try:
+                    return zlib.decompress(raw_body, -15)
+                except zlib.error:
+                    return raw_body
+        elif encoding == "br":
+            if _has_brotli:
+                return brotli.decompress(raw_body)
+            else:
+                # brotli not available, return raw and let caller handle
+                return raw_body
+    except _excepted:
+        # decompression failed, return raw body for best-effort handling
+        return raw_body
+    return raw_body
+
+
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     """禁用自动重定向，让调用方手动处理 3xx"""
     def http_error_302(self, req, fp, code, msg, headers):
@@ -122,12 +164,24 @@ def safe_request(url, headers=None, data=None, method="GET", timeout=30, max_red
                             continue
                         return False, "请求被多次重定向，请直接使用 HTTPS URL", status
 
-                body = response.read().decode("utf-8")
+                raw_body = response.read()
+                raw_body = _decompress_body(raw_body, response.headers)
+                try:
+                    body = raw_body.decode("utf-8")
+                except UnicodeDecodeError:
+                    truncated = raw_body[:512]
+                    return False, f"响应体解码失败（非 UTF-8 文本，前 {len(truncated)} 字节 base64）: {base64.b64encode(truncated).decode('ascii')}...", status
                 result = json.loads(body)
                 return True, result, status
 
     except urllib.error.HTTPError as e:
-        error_body = e.read().decode("utf-8")
+        error_raw = e.read()
+        error_raw = _decompress_body(error_raw, e.headers)
+        try:
+            error_body = error_raw.decode("utf-8")
+        except UnicodeDecodeError:
+            truncated = error_raw[:512]
+            error_body = f"响应体解码失败（非 UTF-8 文本，前 {len(truncated)} 字节 base64）: {base64.b64encode(truncated).decode('ascii')}..."
         try:
             error_data = json.loads(error_body)
             error_msg = error_data.get("error") or error_data.get("message") or error_body

--- a/client-extension/pi-extension/index.ts
+++ b/client-extension/pi-extension/index.ts
@@ -16,6 +16,7 @@ import { resolve, basename, sep, relative, isAbsolute } from "node:path";
 import { homedir } from "node:os";
 import AdmZip from "adm-zip";
 import { lookup } from "mime-types";
+import { gunzipSync, inflateSync, inflateRawSync, brotliDecompressSync } from "node:zlib";
 
 const EXTENSION_NAME = basename(__dirname);
 const CONFIG_DIR = resolve(homedir(), ".pi/agent/extensions", EXTENSION_NAME);
@@ -191,6 +192,87 @@ function combineSignals(signals: AbortSignal[]): AbortSignal {
   return controller.signal;
 }
 
+async function maybeDecompress(response: Response): Promise<Response> {
+  const encoding = response.headers.get("content-encoding")?.toLowerCase() || "";
+  const contentType = response.headers.get("content-type")?.toLowerCase() || "";
+  const isJson = contentType.includes("application/json");
+
+  let body: Buffer;
+  try {
+    body = Buffer.from(await response.arrayBuffer());
+  } catch {
+    return response;
+  }
+  if (body.length === 0) {
+    return response;
+  }
+
+  // Fast-path: skip leading whitespace and check if body already looks like plain JSON.
+  let idx = 0;
+  while (idx < body.length && (body[idx] === 0x20 || body[idx] === 0x09 || body[idx] === 0x0a || body[idx] === 0x0d)) {
+    idx++;
+  }
+  if (isJson && (body[idx] === 0x7b || body[idx] === 0x5b)) {
+    const headers = new Headers(response.headers);
+    headers.delete("content-encoding");
+    headers.set("content-length", String(body.length));
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  let decompressed: Buffer | undefined;
+
+  if (encoding.includes("gzip") || (body[0] === 0x1f && body[1] === 0x8b)) {
+    try {
+      decompressed = gunzipSync(body);
+    } catch {
+      // not actually gzip
+    }
+  } else if (encoding.includes("deflate")) {
+    try {
+      decompressed = inflateSync(body);
+    } catch {
+      // not actually zlib-wrapped deflate; try raw deflate
+      try {
+        decompressed = inflateRawSync(body);
+      } catch {
+        // not deflate either
+      }
+    }
+  } else if (encoding.includes("br")) {
+    try {
+      decompressed = brotliDecompressSync(body);
+    } catch {
+      // not actually brotli
+    }
+  }
+
+  // Fallback: if decompression failed but it's supposed to be JSON, try raw body
+  if (!decompressed && isJson) {
+    try {
+      JSON.parse(body.toString("utf8"));
+      decompressed = body; // already valid JSON, use as-is
+    } catch {
+      // not JSON
+    }
+  }
+
+  const finalBody = decompressed ?? body;
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  headers.set("content-length", String(finalBody.length));
+
+  return new Response(finalBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 async function safeFetch(
   url: string,
   init?: RequestInit,
@@ -248,7 +330,7 @@ async function safeFetch(
           continue;
         }
       }
-      return response;
+      return await maybeDecompress(response);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (err instanceof TypeError) {


### PR DESCRIPTION
## 问题

OpenAaaS 服务端启用了 gzip 压缩（`CompressionLayer::new()`），但部分客户端扩展未正确处理 `Content-Encoding: gzip` 响应，导致收到乱码（`Unexpected token '', "\u001f\u008b"... is not valid JSON`）。

受影响组件：
- **pi-extension**（TypeScript）：`fetch` 在 HTTP/2 下可能不自动解压
- **kimi-plugin**（Python）：`urllib.request` 不会自动解压 gzip

## 解决方案

### pi-extension
在 `safeFetch` 返回前增加 `maybeDecompress` 中间层：
- Fast-path：响应体已是明文 JSON 时直接返回
- 解压支持：gzip（含 magic number 兜底）、deflate（含 raw deflate fallback）、brotli
- 容错 fallback：解压失败但声明为 JSON 时，尝试 `JSON.parse` 兜底
- 清除 `content-encoding` 头，重置 `content-length`

### kimi-plugin
在 `utils.py` 中新增 `_decompress_body` 辅助函数：
- 统一处理 gzip、deflate（含 raw deflate fallback `-15`）、brotli
- 所有解压异常内部捕获，失败时返回原始 body
- `decode("utf-8")` 失败时返回前 512 字节 base64，保留 HTTP 状态码
- 成功路径和错误路径共用同一套解压逻辑

## 变更文件
- `client-extension/pi-extension/index.ts`
- `client-extension/kimi-plugin/utils.py`

## 测试
- 已在本地验证：连接 `https://open-aaas.wolido.xyz`（HTTP/2 + gzip）时，`list_services` 正常解析 JSON，不再返回乱码。