### PR TITLE
fix: handle HTML error pages gracefully in pi extension (#62)

### DIFF
--- a/client-extension/pi-extension/index.ts
+++ b/client-extension/pi-extension/index.ts
@@ -360,18 +360,38 @@ function stringifyValue(val: unknown): string {
   }
 }
 
+function looksLikeHtml(text: string): boolean {
+  const snippet = text.trimStart().slice(0, 200).toLowerCase();
+  return (
+    snippet.includes("<html") ||
+    snippet.includes("<!doctype html") ||
+    snippet.includes("<head") ||
+    snippet.includes("<body")
+  );
+}
+
 async function readErrorBody(response: Response): Promise<string> {
+  const contentType = response.headers.get("content-type") || "";
+  if (contentType.toLowerCase().includes("text/html")) {
+    return `HTTP ${response.status} ${response.statusText}`;
+  }
+
   const text = await response.text().catch(() => "");
   try {
     const data = JSON.parse(text);
     if (data && typeof data === "object") {
-      if ("error" in data) return stringifyValue((data as Record<string, unknown>).error);
-      if ("message" in data) return stringifyValue((data as Record<string, unknown>).message);
+      const obj = data as Record<string, unknown>;
+      if ("error" in obj) return stringifyValue(obj.error);
+      if ("message" in obj) return stringifyValue(obj.message);
     }
-    return text || response.statusText;
   } catch {
-    return text || response.statusText;
+    /* 非 JSON，继续检测 HTML */
   }
+
+  if (looksLikeHtml(text)) {
+    return `HTTP ${response.status} ${response.statusText}`;
+  }
+  return text || response.statusText;
 }
 
 async function downloadSingleFile(


### PR DESCRIPTION
## 修复内容

当 server 离线返回 HTML 错误页面（如 nginx 502 Bad Gateway）时，pi mono 插件会直接将 HTML 源码输出到终端，导致显示异常。

## 变更

- 新增 `looksLikeHtml()` 辅助函数，通过检测常见 HTML 标签识别 HTML 内容
- 增强 `readErrorBody()`：当响应 content-type 为 text/html 或内容看起来像 HTML 时，返回简洁的 HTTP 状态描述，而非完整 HTML 源码
- content-type 检查改为大小写不敏感
- HTML 检测前去除前导空白/BOM

Fixes #62