### PR TITLE
docs: translate remaining READMEs to English

### DIFF
--- a/agent-core/executor-example/README.md
+++ b/agent-core/executor-example/README.md
@@ -1,104 +1,106 @@
 # OpenAaaS Executor Example
 
-这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-Agent Core 通过 Docker 容器隔离执行任务。这个示例展示了**最小的交互契约**：容器读取 `task.json`，执行任务，将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
+This is **a sample Docker executor image for OpenAaaS**.
 
----
-
-## 交互契约
-
-这是 Agent Core 与容器之间的唯一约定。无论你是否基于本示例修改，只要遵守这个契约，Agent Core 就能正确调度你的镜像。
-
-### 输入
-
-Agent Core 启动容器时，会完成以下准备：
-
-- 将 `task.json` 放在容器的 `/workspace/task.json`
-- 将输入文件放在 `/workspace/input/`
-- 传入两个环境变量：`TASK_ID`（任务 ID）和 `TIMEOUT`（超时秒数）
-
-`task.json` 包含以下字段：
-
-| 字段 | 说明 |
-|------|------|
-| `task_id` | 任务唯一标识 |
-| `task_prompt` | 用户原始任务描述 |
-| `prompt` | 同 `task_prompt`，向后兼容 |
-| `output_prompt` | 对输出格式/内容的要求 |
-| `session_id` | 会话标识 |
-| `input_files` | 输入文件名列表 |
-
-### 输出
-
-执行完成后，把结果文件放在 workspace 下即可（推荐放在 `/workspace/output/` 下）。Agent Core 会扫描 workspace 下所有文件（排除 `task.json` 和 `input/`），作为输出文件上报 Server。
+Agent Core executes tasks in isolated Docker containers. This example demonstrates the **minimal interaction contract**: the container reads `task.json`, executes the task, and writes result files to the workspace. You can directly modify based on it, or write your own image entirely — as long as it satisfies the same input/output protocol.
 
 ---
 
-## 架构概述
+## Interaction Contract
+
+This is the only agreement between Agent Core and the container. Whether or not you modify based on this example, as long as you follow this contract, Agent Core can correctly schedule your image.
+
+### Input
+
+When Agent Core starts the container, it completes the following preparations:
+
+- Places `task.json` at the container's `/workspace/task.json`
+- Places input files in `/workspace/input/`
+- Passes two environment variables: `TASK_ID` (task ID) and `TIMEOUT` (timeout in seconds)
+
+`task.json` contains the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `task_id` | Unique task identifier |
+| `task_prompt` | User's original task description |
+| `prompt` | Same as `task_prompt`, for backward compatibility |
+| `output_prompt` | Requirements for output format/content |
+| `session_id` | Session identifier |
+| `input_files` | List of input file names |
+
+### Output
+
+After execution is complete, simply place result files under the workspace (recommended under `/workspace/output/`). Agent Core will scan all files under the workspace (excluding `task.json` and `input/`), and report them as output files to the Server.
+
+---
+
+## Architecture Overview
 
 ```
-Agent Core  →  创建 workspace + task.json + input/  →  docker run
+Agent Core  →  Create workspace + task.json + input/  →  docker run
                                                        │
                                                        ▼
-                                                  容器执行
+                                                  Container Execution
                                                        │
                                                        ▼
-Agent Core  ←  扫描输出文件上报 Server  ←  结果写入 workspace
+Agent Core  ←  Scan output files to report to Server  ←  Results written to workspace
 ```
 
 ---
 
-## 构建示例镜像
+## Build Example Image
 
 ```bash
 cd OpenAaaS/agent-core/executor-example
 docker build -t open-aaas-executor:latest .
 ```
 
-> 镜像名（如 `open-aaas-executor:latest`）需要与 `agent-core` 的 `config.toml` 中 `executor.image` 配置保持一致，否则 Agent Core 无法正确调度。
+> The image name (e.g. `open-aaas-executor:latest`) must match the `executor.image` configuration in `agent-core`'s `config.toml`; otherwise Agent Core cannot correctly schedule it.
 
 ---
 
-## 本示例包含什么
+## What's Included in This Example
 
-| 文件 | 说明 |
-|------|------|
-| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装了 `jq`/`git`/`python3` 等常用工具 |
-| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用执行脚本 |
-| `run.sh` | **示例的执行逻辑**。本示例中用它调用 pi-coding-agent 这个 agent 框架处理任务，你可以直接替换为其他 agent 框架 |
-| `main-agent.md` | `run.sh` 中给 pi 追加的系统提示词。如果你不用 pi，这个文件可以忽略 |
-| `pi/` | pi-coding-agent 的配置目录。如果你不用 pi，可以删除 |
-
----
-
-## 自定义
-
-### 方式一：基于本示例修改
-
-这是最快的上手方式：
-
-- **修改 `run.sh`**：替换执行逻辑，比如使用其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
-- **修改 `Dockerfile`**：增减依赖、换基础镜像
-- **删除不需要的文件**：如果不用 pi，删掉 `pi/` 目录和 `main-agent.md`
-
-### 方式二：从零构建自己的镜像
-
-你也可以完全自己写一个镜像，只需要满足交互契约即可：
-
-1. 写一个 Dockerfile，安装你需要的运行环境和 Agent 框架
-2. 写一个入口脚本（或直接写 ENTRYPOINT），让 agent 读取 `/workspace/task.json` 并执行任务
-3. 核心要求：agent 执行完成后，将结果文件写入 workspace
-
-Agent Core 不关心容器内部怎么实现，只关心输出文件是否按要求出现在 workspace 中。
+| File | Description |
+|------|-------------|
+| `Dockerfile` | Example image definition. Based on `node:22-slim`, installs `jq`/`git`/`python3` and other common tools |
+| `entrypoint.sh` | Container entry script, checks for `task.json` existence then calls the execution script |
+| `run.sh` | **Example execution logic**. In this example, it calls the pi-coding-agent agent framework to process tasks; you can directly replace it with other agent frameworks |
+| `main-agent.md` | System prompt appended to pi in `run.sh`. If you don't use pi, this file can be ignored |
+| `pi/` | Configuration directory for pi-coding-agent. If you don't use pi, you can delete it |
 
 ---
 
-## 安全提醒
+## Customization
 
-`pi/agent/models.json` 包含敏感 API key，**不要提交到 Git**。
+### Method 1: Modify Based on This Example
 
-推荐通过 `agent-core` 的 `config.toml` 在运行时注入：
+This is the fastest way to get started:
+
+- **Modify `run.sh`**: Replace execution logic, such as using other Agent frameworks (e.g. Kimi Cli, Open Code, Codex, etc.)
+- **Modify `Dockerfile`**: Add or remove dependencies, change base image
+- **Delete unnecessary files**: If not using pi, delete the `pi/` directory and `main-agent.md`
+
+### Method 2: Build Your Own Image from Scratch
+
+You can also write your own image entirely; just satisfy the interaction contract:
+
+1. Write a Dockerfile, install the runtime environment and Agent framework you need
+2. Write an entry script (or directly write ENTRYPOINT), have the agent read `/workspace/task.json` and execute the task
+3. Core requirement: after the agent finishes executing, write result files to the workspace
+
+Agent Core doesn't care about the internal implementation of the container; it only cares whether output files appear in the workspace as required.
+
+---
+
+## Security Reminder
+
+`pi/agent/models.json` contains sensitive API keys, **do not commit to Git**.
+
+Recommended to inject at runtime via `agent-core`'s `config.toml`:
 
 ```toml
 [[paths.mounts]]
@@ -107,4 +109,4 @@ container = "/home/executor/.pi/agent/models.json"
 readonly = true
 ```
 
-这样可以避免将 API key 打包进镜像，确保密钥与镜像分离。
+This avoids packaging API keys into the image, ensuring keys are separate from the image.

--- a/agent-core/executor-example/README.zh.md
+++ b/agent-core/executor-example/README.zh.md
@@ -1,0 +1,112 @@
+# OpenAaaS Executor Example
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
+
+Agent Core 通过 Docker 容器隔离执行任务。这个示例展示了**最小的交互契约**：容器读取 `task.json`，执行任务，将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
+
+---
+
+## 交互契约
+
+这是 Agent Core 与容器之间的唯一约定。无论你是否基于本示例修改，只要遵守这个契约，Agent Core 就能正确调度你的镜像。
+
+### 输入
+
+Agent Core 启动容器时，会完成以下准备：
+
+- 将 `task.json` 放在容器的 `/workspace/task.json`
+- 将输入文件放在 `/workspace/input/`
+- 传入两个环境变量：`TASK_ID`（任务 ID）和 `TIMEOUT`（超时秒数）
+
+`task.json` 包含以下字段：
+
+| 字段 | 说明 |
+|------|------|
+| `task_id` | 任务唯一标识 |
+| `task_prompt` | 用户原始任务描述 |
+| `prompt` | 同 `task_prompt`，向后兼容 |
+| `output_prompt` | 对输出格式/内容的要求 |
+| `session_id` | 会话标识 |
+| `input_files` | 输入文件名列表 |
+
+### 输出
+
+执行完成后，把结果文件放在 workspace 下即可（推荐放在 `/workspace/output/` 下）。Agent Core 会扫描 workspace 下所有文件（排除 `task.json` 和 `input/`），作为输出文件上报 Server。
+
+---
+
+## 架构概述
+
+```
+Agent Core  →  创建 workspace + task.json + input/  →  docker run
+                                                       │
+                                                       ▼
+                                                  容器执行
+                                                       │
+                                                       ▼
+Agent Core  ←  扫描输出文件上报 Server  ←  结果写入 workspace
+```
+
+---
+
+## 构建示例镜像
+
+```bash
+cd OpenAaaS/agent-core/executor-example
+docker build -t open-aaas-executor:latest .
+```
+
+> 镜像名（如 `open-aaas-executor:latest`）需要与 `agent-core` 的 `config.toml` 中 `executor.image` 配置保持一致，否则 Agent Core 无法正确调度。
+
+---
+
+## 本示例包含什么
+
+| 文件 | 说明 |
+|------|------|
+| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装了 `jq`/`git`/`python3` 等常用工具 |
+| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用执行脚本 |
+| `run.sh` | **示例的执行逻辑**。本示例中用它调用 pi-coding-agent 这个 agent 框架处理任务，你可以直接替换为其他 agent 框架 |
+| `main-agent.md` | `run.sh` 中给 pi 追加的系统提示词。如果你不用 pi，这个文件可以忽略 |
+| `pi/` | pi-coding-agent 的配置目录。如果你不用 pi，可以删除 |
+
+---
+
+## 自定义
+
+### 方式一：基于本示例修改
+
+这是最快的上手方式：
+
+- **修改 `run.sh`**：替换执行逻辑，比如使用其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
+- **修改 `Dockerfile`**：增减依赖、换基础镜像
+- **删除不需要的文件**：如果不用 pi，删掉 `pi/` 目录和 `main-agent.md`
+
+### 方式二：从零构建自己的镜像
+
+你也可以完全自己写一个镜像，只需要满足交互契约即可：
+
+1. 写一个 Dockerfile，安装你需要的运行环境和 Agent 框架
+2. 写一个入口脚本（或直接写 ENTRYPOINT），让 agent 读取 `/workspace/task.json` 并执行任务
+3. 核心要求：agent 执行完成后，将结果文件写入 workspace
+
+Agent Core 不关心容器内部怎么实现，只关心输出文件是否按要求出现在 workspace 中。
+
+---
+
+## 安全提醒
+
+`pi/agent/models.json` 包含敏感 API key，**不要提交到 Git**。
+
+推荐通过 `agent-core` 的 `config.toml` 在运行时注入：
+
+```toml
+[[paths.mounts]]
+host = "~/.pi/agent/models.json"
+container = "/home/executor/.pi/agent/models.json"
+readonly = true
+```
+
+这样可以避免将 API key 打包进镜像，确保密钥与镜像分离。

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
@@ -1,3 +1,5 @@
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+
 # subagent-isolation
 
 > A `pi` extension that delegates tasks to specialized subagents in isolated `pi` processes, giving each subagent its own clean context window.

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.zh.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.zh.md
@@ -1,0 +1,138 @@
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+# subagent-isolation
+
+> 一个 `pi` 扩展，将任务委托给专门的 subagent，在隔离的 `pi` 进程中运行，让每个 subagent 拥有独立的干净上下文窗口。
+
+## 功能特性
+
+- **三种调用模式**
+  - `single` - 调用一个 agent 执行单个任务
+  - `parallel` - 最多并发运行 8 个任务（每次最多 4 个）
+  - `chain` - 按顺序运行多个 agent，通过 `{previous}` 注入上一步的输出
+- **Agent 发现与作用域**
+  - `user` agents 来自 `~/.pi/agent/agents/`
+  - `project` agents 来自 `.pi/agents/`（从工作目录向上搜索）
+  - `both` — 合并两个作用域（项目名称冲突时 project 覆盖 user）
+  - 运行仓库本地 agent 前可选 `confirmProjectAgents` 确认提示
+  - 运行时 `agentScope` 默认为 `"both"`
+- **进程隔离与深度控制**
+  - 每个 subagent 都会启动一个全新的 `pi --mode json` 进程
+  - 每个 subagent 的 system prompt 被写入临时文件，并通过 `--append-system-prompt` 传入
+  - 最大递归深度：`2`
+  - 在 frontmatter 中设置 per-agent `canDelegate: false` 可阻止进一步委托
+- **Skill 隔离**
+  - 可使用 `--no-skills` 清除全局 skills
+  - per-agent `skills` 列表仅注入指定的 skill，通过 `--skill <path>` 传入
+- **超时与优雅终止**
+  - 静默超时：15 分钟（stdout 空闲时终止）
+  - 硬超时：1 小时
+  - `AbortSignal` 触发 `SIGTERM` → 5 秒后 `SIGKILL`
+- **TUI 渲染**
+  - 实时状态，支持可折叠输出（`Ctrl+O`）
+  - Token 用量统计：input / output / cacheRead / cacheWrite / cost / model / turns
+
+## 安装
+
+需要已安装 `pi` 并使其在 `$PATH` 中可用。
+
+将扩展克隆（或复制）到 `pi` 的扩展目录：
+
+```bash
+git clone https://github.com/your-username/subagent-isolation.git \
+  ~/.pi/agent/extensions/subagent-isolation
+```
+
+或手动放置文件，确保 `~/.pi/agent/extensions/subagent-isolation/index.ts` 存在。
+
+## 使用示例
+
+通过 `subagent` 工具调用 agent。必须且只能提供 `agent`/`task`、`tasks` 或 `chain` 中的一种。
+
+### Single 模式
+
+```json
+{
+  "agent": "coder",
+  "task": "Refactor the auth middleware to use async/await.",
+  "cwd": "/optional/working/dir"
+}
+```
+
+### Parallel 模式
+
+```json
+{
+  "tasks": [
+    { "agent": "reviewer", "task": "Review src/auth.ts", "cwd": "src" },
+    { "agent": "reviewer", "task": "Review src/db.ts" },
+    { "agent": "tester",   "task": "Write unit tests for auth.js" }
+  ],
+  "agentScope": "both"
+}
+```
+
+### Chain 模式
+
+```json
+{
+  "chain": [
+    { "agent": "planner", "task": "Design a REST API for user profiles.", "cwd": "src" },
+    { "agent": "coder",   "task": "Implement the API based on this plan: {previous}" },
+    { "agent": "reviewer", "task": "Review the implementation: {previous}" }
+  ]
+}
+```
+
+如果 chain 中的任何一步失败，执行会立即停止，剩余的步骤不会运行。
+
+## Agent 定义格式
+
+Agent 以 Markdown 文件（`.md`）形式定义在 agents 目录中。Frontmatter 描述 agent 属性；正文内容作为 system prompt。
+
+```markdown
+---
+name: coder
+description: Writes clean TypeScript and handles refactors.
+tools: read,edit,write,bash
+model: claude-3-7-sonnet
+skills: /path/to/skill1, /path/to/skill2
+---
+
+You are a senior TypeScript engineer. Prefer async/await, avoid callbacks.
+```
+
+### Frontmatter 字段
+
+| 字段 | 类型 | 说明 |
+|-------|------|-------------|
+| `name` | `string` | **必填。** 在工具调用中使用的唯一标识符。 |
+| `description` | `string` | **必填。** 在发现 / 错误消息中显示的简短摘要。 |
+| `tools` | `string[]`（逗号分隔） | 可选的 subagent 工具白名单。 |
+| `model` | `string` | 可选的模型覆盖（例如 `claude-3-7-sonnet`）。 |
+| `skills` | `string[]`（逗号分隔） | 可选的 skill 路径列表。如果存在，全局 skills 会被禁用，仅加载指定的 skills。路径可以是绝对路径或相对于工作目录的路径。 |
+| `canDelegate` | `boolean` | 默认为 `true`。设置为 `false` 可阻止该 agent 启动进一步的 subagent。 |
+
+## 环境变量
+
+这些变量控制运行时行为。它们会自动传播到每个 subagent 进程中。
+
+| 变量 | 默认值 | 说明 |
+|----------|---------|-------------|
+| `PI_SUBAGENT_DEPTH` | `0` | 当前递归深度。每次嵌套调用自动递增。硬上限为 `2`。 |
+| `PI_CAN_DELEGATE` | `true` | 当前 agent 是否允许委托。派生自 agent 的 `canDelegate` frontmatter。 |
+| `PI_CURRENT_AGENT_NAME` | — | 当前 agent 的名称，注入到每个 subagent 进程中。 |
+| `PI_SUBAGENT_SILENCE_TIMEOUT_MS` | `900000`（15 分钟） | stdout 空闲时允许的最大时间，超过则终止 subagent。 |
+| `PI_SUBAGENT_HARD_TIMEOUT_MS` | `3600000`（1 小时） | 单次 subagent 调用的绝对最大运行时间。 |
+
+## 项目结构
+
+```
+~/.pi/agent/extensions/subagent-isolation/
+├── index.ts      # 主扩展源码（约 1,280 行）
+└── README.md     # 本文件
+```
+
+## 许可证
+
+MIT

--- a/client-extension/README.md
+++ b/client-extension/README.md
@@ -1,20 +1,22 @@
 ## Client Extensions
 
-`client-extension/` 是 OpenAaaS 的客户端扩展集合，让不同的 Agent 客户端（pi、Kimi 等）能够连接到 OpenAaaS 网络，发现远程服务、提交任务并获取结果。
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-目前包含三个扩展：
+`client-extension/` is the collection of client extensions for OpenAaaS, enabling different Agent clients (pi, Kimi, etc.) to connect to the OpenAaaS network, discover remote services, submit tasks, and retrieve results.
+
+Currently includes three extensions:
 
 ### pi-extension
 
-面向 [pi](https://github.com/badlogic/pi-mono) 的 TypeScript 扩展。提供统一的 `OpenAaaS` 入口工具，通过 `action` 参数调用不同功能。支持多服务器配置、自动任务监控（widget + toast 通知）、Session 持久化与重建提醒。
+A TypeScript extension for [pi](https://github.com/badlogic/pi-mono). Provides a unified `OpenAaaS` entry tool with different functionalities invoked via the `action` parameter. Supports multi-server configuration, automatic task monitoring (widget + toast notifications), Session persistence, and reconstruction reminders.
 
 ### kimi-plugin
 
-面向 Kimi 的 Python 插件。通过 `plugin.json` 定义多个独立工具，支持多服务器管理、渐进式信息获取。包含完整的测试套件。
+A Python plugin for Kimi. Defines multiple independent tools via `plugin.json`, supports multi-server management, and progressive information retrieval. Includes a complete test suite.
 
 ### openaaas-mcp-adapter
 
-面向 Claude Desktop、Cursor、Cline 等 MCP 客户端的 Python 适配器。基于 MCP SDK 构建，Transport 为 `stdio`，提供 14 个核心 Tool，支持文件上传下载、多服务器配置、路径遍历与 zip 炸弹防护。
+A Python adapter for MCP clients such as Claude Desktop, Cursor, and Cline. Built on the MCP SDK, with `stdio` Transport, providing 14 core Tools, supporting file upload/download, multi-server configuration, path traversal, and zip bomb protection.
 
 ---
 
@@ -29,7 +31,7 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-在 pi 中执行 `/reload` 加载扩展。首次使用时会自动创建默认配置文件，然后即可通过对话调用：
+Execute `/reload` in pi to load the extension. A default configuration file will be created automatically on first use. Then you can invoke via conversation:
 
 ```
 OpenAaaS(action: "set_server_url", server_url: "https://api.open-aaas.com")
@@ -39,13 +41,13 @@ OpenAaaS(action: "list_services")
 
 ### openaaas-mcp-adapter
 
-使用 uvx 零安装运行（需已安装 [uv](https://docs.astral.sh/uv/)）：
+Run with zero installation using uvx (requires [uv](https://docs.astral.sh/uv/)):
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-或在 Claude Desktop 的 `claude_desktop_config.json` 中添加：
+Or add to Claude Desktop's `claude_desktop_config.json`:
 
 ```json
 {
@@ -58,7 +60,7 @@ uvx openaaas-mcp-adapter
 }
 ```
 
-配置完成后重启 Claude Desktop，即可在对话中调用工具：
+After configuration, restart Claude Desktop, then invoke tools in conversation:
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com")
@@ -68,22 +70,22 @@ list_services()
 
 ### kimi-plugin
 
-将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在其根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
+Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create `config.json` in its root directory (refer to `config.json.example`), then load the plugin in Kimi to use it.
 
 ---
 
 ## Standard Workflow
 
-无论你使用哪个客户端扩展，与 OpenAaaS 交互的标准流程一致：
+Regardless of which client extension you use, the standard interaction flow with OpenAaaS is consistent:
 
-1. **设置服务器** — 配置目标 OpenAaaS 服务器地址
-2. **注册** — 向服务器注册客户端，获取并保存 `api_key`（每个服务器仅需一次）
-3. **浏览服务** — `list_services` 获取可用服务的轻量摘要，筛选候选服务
-4. **获取用法** — `get_service_usage` 查看目标服务的详细能力范围、调用规范和返回格式
-5. **提交任务** — `submit_task` 构造 `task_prompt` 和 `output_prompt`，保存返回的 `task_id`
-6. **查询结果** — 仅在用户明确要求时调用 `get_task` 查询任务状态和结果（不要主动轮询）
-7. **下载结果** — `download_result` 获取任务输出的文件
+1. **Set up server** — Configure the target OpenAaaS server address
+2. **Register** — Register the client with the server, obtain and save the `api_key` (only once per server)
+3. **Browse services** — Use `list_services` to get lightweight summaries of available services and filter candidates
+4. **Get usage** — Use `get_service_usage` to view the detailed capabilities, calling conventions, and return format of the target service
+5. **Submit task** — Use `submit_task` to construct `task_prompt` and `output_prompt`, save the returned `task_id`
+6. **Query result** — Only call `get_task` to query task status and results when the user explicitly requests it (do not poll actively)
+7. **Download result** — Use `download_result` to retrieve task output files
 
-> **注意**：pi-extension 额外支持 `list_history` 用于查询当前 Session 的任务历史，实现会话中断后的上下文重建。
+> **Note**: The pi-extension additionally supports `list_history` for querying the current Session's task history, enabling context reconstruction after session interruption.
 
-遵循渐进式披露原则：先浏览轻量服务列表筛选候选，再按需获取详细用法，避免一次性加载所有服务的完整文档导致上下文溢出。
+Follow the principle of progressive disclosure: first browse the lightweight service list to filter candidates, then get detailed usage on demand, to avoid loading complete documentation for all services at once, which could cause context overflow.

--- a/client-extension/README.zh.md
+++ b/client-extension/README.zh.md
@@ -1,0 +1,91 @@
+## Client Extensions
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+`client-extension/` 是 OpenAaaS 的客户端扩展集合，让不同的 Agent 客户端（pi、Kimi 等）能够连接到 OpenAaaS 网络，发现远程服务、提交任务并获取结果。
+
+目前包含三个扩展：
+
+### pi-extension
+
+面向 [pi](https://github.com/badlogic/pi-mono) 的 TypeScript 扩展。提供统一的 `OpenAaaS` 入口工具，通过 `action` 参数调用不同功能。支持多服务器配置、自动任务监控（widget + toast 通知）、Session 持久化与重建提醒。
+
+### kimi-plugin
+
+面向 Kimi 的 Python 插件。通过 `plugin.json` 定义多个独立工具，支持多服务器管理、渐进式信息获取。包含完整的测试套件。
+
+### openaaas-mcp-adapter
+
+面向 Claude Desktop、Cursor、Cline 等 MCP 客户端的 Python 适配器。基于 MCP SDK 构建，Transport 为 `stdio`，提供 14 个核心 Tool，支持文件上传下载、多服务器配置、路径遍历与 zip 炸弹防护。
+
+---
+
+## Quick Start
+
+### pi-extension
+
+```bash
+mkdir -p ~/.pi/agent/extensions/OpenAaaS
+cp -r pi-extension/* ~/.pi/agent/extensions/OpenAaaS/
+cd ~/.pi/agent/extensions/OpenAaaS
+npm install
+```
+
+在 pi 中执行 `/reload` 加载扩展。首次使用时会自动创建默认配置文件，然后即可通过对话调用：
+
+```
+OpenAaaS(action: "set_server_url", server_url: "https://api.open-aaas.com")
+OpenAaaS(action: "register", name: "my-client")
+OpenAaaS(action: "list_services")
+```
+
+### openaaas-mcp-adapter
+
+使用 uvx 零安装运行（需已安装 [uv](https://docs.astral.sh/uv/)）：
+
+```bash
+uvx openaaas-mcp-adapter
+```
+
+或在 Claude Desktop 的 `claude_desktop_config.json` 中添加：
+
+```json
+{
+  "mcpServers": {
+    "openaaas": {
+      "command": "uvx",
+      "args": ["openaaas-mcp-adapter"]
+    }
+  }
+}
+```
+
+配置完成后重启 Claude Desktop，即可在对话中调用工具：
+
+```
+set_server_url(server_url: "https://api.open-aaas.com")
+register(name: "my-client")
+list_services()
+```
+
+### kimi-plugin
+
+将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在其根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
+
+---
+
+## Standard Workflow
+
+无论你使用哪个客户端扩展，与 OpenAaaS 交互的标准流程一致：
+
+1. **设置服务器** — 配置目标 OpenAaaS 服务器地址
+2. **注册** — 向服务器注册客户端，获取并保存 `api_key`（每个服务器仅需一次）
+3. **浏览服务** — `list_services` 获取可用服务的轻量摘要，筛选候选服务
+4. **获取用法** — `get_service_usage` 查看目标服务的详细能力范围、调用规范和返回格式
+5. **提交任务** — `submit_task` 构造 `task_prompt` 和 `output_prompt`，保存返回的 `task_id`
+6. **查询结果** — 仅在用户明确要求时调用 `get_task` 查询任务状态和结果（不要主动轮询）
+7. **下载结果** — `download_result` 获取任务输出的文件
+
+> **注意**：pi-extension 额外支持 `list_history` 用于查询当前 Session 的任务历史，实现会话中断后的上下文重建。
+
+遵循渐进式披露原则：先浏览轻量服务列表筛选候选，再按需获取详细用法，避免一次性加载所有服务的完整文档导致上下文溢出。

--- a/client-extension/kimi-plugin/README.md
+++ b/client-extension/kimi-plugin/README.md
@@ -1,0 +1,47 @@
+# OpenAaaS Kimi Plugin
+
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+
+A Kimi Code plugin for OpenAaaS, enabling Kimi to connect to the OpenAaaS network, discover remote Agent services, submit tasks, and retrieve results.
+
+## Features
+
+- **Service Discovery** — `discover` to get server API info, available services, and authentication methods
+- **Multi-Server Management** — `set_server_url`, `list_servers`, and `remove_server` for managing multiple server configurations
+- **Client Registration** — `register` to obtain and persist `api_key` automatically
+- **Service Browsing** — `list_services` for lightweight summaries, `get_service_usage` for detailed capabilities
+- **Task Lifecycle** — `submit_task`, `get_task`, `cancel_task`, `list_files`, and `download_result` for full task management
+- **Progressive Disclosure** — Follows the principle of browsing lightweight summaries first, then retrieving detailed usage on demand
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `discover` | Discover server API information |
+| `set_server_url` | Configure server URL |
+| `list_servers` | List all configured servers |
+| `remove_server` | Remove a server configuration |
+| `register` | Register client and save API key |
+| `update_profile` | Update client profile name |
+| `list_services` | List available Agent services |
+| `get_service_usage` | Get detailed usage for a service |
+| `submit_task` | Submit a task to a remote Agent |
+| `get_task` | Query task status and results |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for a task |
+| `download_result` | Download task result files |
+
+## Installation
+
+Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create a `config.json` in the root (refer to `config.json.example`), then load the plugin in Kimi.
+
+## Standard Workflow
+
+1. `set_server_url` — Configure the target OpenAaaS server
+2. `register` — Register the client to obtain `api_key` (once per server)
+3. `list_services` — Browse available services and filter candidates
+4. `get_service_usage` — Get detailed usage for selected services
+5. `submit_task` — Submit a task with `task_prompt` and `output_prompt`
+6. `get_task` / `download_result` — Query status and download results
+
+> **Note**: Do not poll `get_task` actively. Wait for the user to request status updates.

--- a/client-extension/kimi-plugin/README.zh.md
+++ b/client-extension/kimi-plugin/README.zh.md
@@ -1,0 +1,47 @@
+# OpenAaaS Kimi 插件
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+OpenAaaS 的 Kimi Code 插件，让 Kimi 能够连接 OpenAaaS 网络，发现远程 Agent 服务、提交任务并获取结果。
+
+## 功能
+
+- **服务发现** — `discover` 获取服务端 API 信息、可用服务列表和认证方式
+- **多服务器管理** — `set_server_url`、`list_servers`、`remove_server` 管理多服务器配置
+- **客户端注册** — `register` 自动获取并持久化 `api_key`
+- **服务浏览** — `list_services` 获取轻量摘要，`get_service_usage` 获取详细能力说明
+- **任务全生命周期** — `submit_task`、`get_task`、`cancel_task`、`list_files`、`download_result` 完整任务管理
+- **渐进式披露** — 遵循先浏览轻量摘要，再按需获取详细用法的原则
+
+## 工具列表
+
+| 工具 | 说明 |
+|------|------|
+| `discover` | 发现服务端 API 信息 |
+| `set_server_url` | 配置服务器地址 |
+| `list_servers` | 列出所有已配置的服务器 |
+| `remove_server` | 移除服务器配置 |
+| `register` | 注册客户端并保存 API key |
+| `update_profile` | 更新客户端名称 |
+| `list_services` | 列出可用 Agent 服务 |
+| `get_service_usage` | 获取指定服务的详细用法 |
+| `submit_task` | 向远程 Agent 提交任务 |
+| `get_task` | 查询任务状态和结果 |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务结果文件 |
+| `download_result` | 下载任务结果文件 |
+
+## 安装
+
+将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
+
+## 标准流程
+
+1. `set_server_url` — 配置目标 OpenAaaS 服务器
+2. `register` — 注册客户端获取 `api_key`（每个服务器仅需一次）
+3. `list_services` — 浏览可用服务并筛选候选
+4. `get_service_usage` — 获取候选服务的详细用法
+5. `submit_task` — 使用 `task_prompt` 和 `output_prompt` 提交任务
+6. `get_task` / `download_result` — 查询状态并下载结果
+
+> **注意**：不要主动轮询 `get_task`，等待用户要求查询状态时再调用。

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -1,30 +1,32 @@
 # OpenAaaS MCP Adapter
 
-OpenAaaS 的 MCP（Model Context Protocol）适配器，让 Claude Desktop、Cursor、Cline 等支持 MCP 的 AI 客户端能够连接 OpenAaaS Server，发现远程服务、提交任务并获取结果。
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-基于 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) 构建，提供 14 个核心 Tool，覆盖完整的客户端能力：服务发现、注册认证、任务提交、结果下载及多服务器管理。
+The MCP (Model Context Protocol) adapter for OpenAaaS, enabling MCP-enabled AI clients such as Claude Desktop, Cursor, and Cline to connect to the OpenAaaS Server, discover remote services, submit tasks, and retrieve results.
+
+Built on the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), providing 14 core Tools covering the complete client capabilities: service discovery, registration and authentication, task submission, result download, and multi-server management.
 
 ---
 
-## 快速开始
+## Quick Start
 
-### 推荐：uvx（零安装，无需下载到本地）
+### Recommended: uvx (Zero Install, No Local Download)
 
-安装 [uv](https://docs.astral.sh/uv/) 后，直接运行，无需把包下载到本地：
+After installing [uv](https://docs.astral.sh/uv/), run directly without downloading the package locally:
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-`uv` 会自动从 PyPI 拉取并创建临时虚拟环境运行，用完即走，不会在系统中留下任何文件。
+`uv` will automatically pull from PyPI and create a temporary virtual environment to run, cleaning up afterward without leaving any files on the system.
 
-这是**最推荐的方式**，适合所有用户。
+This is the **most recommended method**, suitable for all users.
 
 ---
 
-### 客户端配置
+### Client Configuration
 
-配置 Claude Desktop、Cursor 或 Cline：
+Configure Claude Desktop, Cursor, or Cline:
 
 ```json
 {
@@ -37,22 +39,22 @@ uvx openaaas-mcp-adapter
 }
 ```
 
-配置修改后，重启客户端即可生效。
+After modifying the configuration, restart the client for it to take effect.
 
 ---
 
-### 其他安装方式（可选）
+### Other Installation Methods (Optional)
 
 <details>
-<summary>点击查看其他安装方式</summary>
+<summary>Click to view other installation methods</summary>
 
-#### pipx（全局安装）
+#### pipx (Global Install)
 
 ```bash
 pipx install openaaas-mcp-adapter
 ```
 
-MCP 配置改为：
+MCP configuration changes to:
 ```json
 {
   "mcpServers": {
@@ -63,13 +65,13 @@ MCP 配置改为：
 }
 ```
 
-#### pip 安装
+#### pip Install
 
 ```bash
 pip install openaaas-mcp-adapter
 ```
 
-#### 本地源码运行（开发）
+#### Local Source Run (Development)
 
 ```bash
 cd openaaas-mcp-adapter
@@ -81,17 +83,15 @@ uv run openaaas-mcp-adapter
 
 ---
 
+## Configuration File
 
-
-## 配置文件
-
-配置文件保存在用户主目录下：
+The configuration file is saved in the user's home directory:
 
 ```
 ~/.openaaas-mcp-adapter/config.json
 ```
 
-首次运行时若不存在，会自动创建默认配置：
+If it does not exist on first run, a default configuration will be created automatically:
 
 ```json
 {
@@ -107,7 +107,7 @@ uv run openaaas-mcp-adapter
 }
 ```
 
-注册成功后的配置示例：
+Example configuration after successful registration:
 
 ```json
 {
@@ -123,39 +123,39 @@ uv run openaaas-mcp-adapter
 }
 ```
 
-运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
 
 ---
 
-## 多服务器配置
+## Multi-Server Configuration
 
-支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
 
-### 为多个服务器分别注册
+### Register for Multiple Servers Separately
 
-每个服务器别名有独立的注册信息：
+Each server alias has independent registration information:
 
 ```
 register(name: "my-prod-client", server: "prod")
 register(name: "my-local-client", server: "local")
 ```
 
-两个服务器会分别保存各自的 api_key，互不干扰。
+The two servers will save their respective api_keys independently without interference.
 
-### 设置服务器地址
+### Set Server URL
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com", server: "prod")
 set_server_url(server_url: "http://127.0.0.1:8080", server: "local")
 ```
 
-### 切换默认服务器
+### Switch Default Server
 
 ```
 set_default_server(server: "prod")
 ```
 
-### 列出所有配置的服务器
+### List All Configured Servers
 
 ```
 list_servers()
@@ -163,176 +163,176 @@ list_servers()
 
 ---
 
-## 可用工具
+## Available Tools
 
-| 工具名 | 功能描述 |
-|--------|----------|
-| `discover` | 发现服务端 API 信息（返回服务端版本、Base URL、认证方式、可用端点列表、已注册服务列表） |
-| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
-| `register` | 注册客户端，自动保存 api_key（仅需一次） |
-| `update_profile` | 修改用户名 |
-| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
-| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
-| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
-| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
-| `cancel_task` | 取消执行中的任务 |
-| `list_files` | 列出任务的结果文件列表 |
-| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
-| `list_servers` | 列出所有已配置的服务器 |
-| `set_default_server` | 切换默认服务器 |
-| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+| Tool Name | Function Description |
+|-----------|----------------------|
+| `discover` | Discover server API information (returns server version, supported API endpoints, available service list, authentication method, etc. Recommended to call when connecting to a new server for the first time) |
+| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
+| `register` | Register client, automatically save api_key (only once) |
+| `update_profile` | Modify user name |
+| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
+| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
+| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
+| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for the task |
+| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
+| `list_servers` | List all configured servers |
+| `set_default_server` | Switch default server |
+| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
 
-### 参数说明
+### Parameter Description
 
-| 工具名 | 参数 | 必填 | 说明 |
-|--------|------|------|------|
-| `discover` | `server_url` | ✅ | 目标服务器地址 |
-| `set_server_url` | `server_url` | ✅ | 服务器地址（以 http:// 或 https:// 开头） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `register` | `name` | ✅ | 客户端名称（长度 ≤64，不含 ASCII 控制字符、Unicode 控制字符及 `/\<>\|&;$`） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `update_profile` | `name` | ✅ | 新用户名（同上约束） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_services` | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `get_service_usage` | `service_id` | ✅ | 目标服务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `submit_task` | `service_id` | ✅ | 目标服务 ID |
-| | `task_prompt` | ✅ | 任务描述 prompt |
-| | `output_prompt` | ❌ | 输出格式要求，默认 `""` |
-| | `input_files` | ❌ | 本地文件路径列表（最多 10 个，单文件 ≤100MB，仅限当前工作目录） |
-| | `session_id` | ❌ | 会话 ID，用于保持对话上下文 |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `get_task` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `cancel_task` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_files` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `download_result` | `task_id` | ✅ | 任务 ID |
-| | `file_id` | ❌ | 指定文件 ID，默认 `""` |
-| | `download_all` | ❌ | 是否下载全部文件，默认 `false` |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_servers` | — | — | 无参数 |
-| `set_default_server` | `server` | ✅ | 要设为默认的服务器别名 |
-| `remove_server` | `server` | ✅ | 要删除的服务器别名 |
-
----
-
-## 渐进式信息获取
-
-本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
-
-### 标准使用流程
-
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
-2. `register` — 注册获取 api_key（仅需一次）
-3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
-4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
-5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
-6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
-7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-8. `download_result` — 任务完成后下载结果文件
-
-### 为什么这样设计
-
-- `list_services` 返回轻量摘要，不占用 LLM 上下文
-- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
-- 避免一次性加载所有服务的完整文档导致上下文溢出
+| Tool Name | Parameter | Required | Description |
+|-----------|-----------|----------|-------------|
+| `discover` | `server_url` | ✅ | Target server URL |
+| `set_server_url` | `server_url` | ✅ | Server URL (must start with http:// or https://) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `register` | `name` | ✅ | Client name (length ≤64, no ASCII control characters, Unicode control characters, or `\/<>|&;$`) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `update_profile` | `name` | ✅ | New user name (same constraints) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_services` | `server` | ❌ | Server alias, default `"default"` |
+| `get_service_usage` | `service_id` | ✅ | Target service ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `submit_task` | `service_id` | ✅ | Target service ID |
+| | `task_prompt` | ✅ | Task description prompt |
+| | `output_prompt` | ❌ | Output format requirement, default `""` |
+| | `input_files` | ❌ | Local file path list (up to 10 files, single file ≤100MB, current working directory only) |
+| | `session_id` | ❌ | Session ID, for maintaining conversation context |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `get_task` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `cancel_task` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_files` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `download_result` | `task_id` | ✅ | Task ID |
+| | `file_id` | ❌ | Specify file ID, default `""` |
+| | `download_all` | ❌ | Whether to download all files, default `false` |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_servers` | — | — | No parameters |
+| `set_default_server` | `server` | ✅ | Server alias to set as default |
+| `remove_server` | `server` | ✅ | Server alias to delete |
 
 ---
 
-## MCP 传输说明
+## Progressive Information Retrieval
 
-- **MCP Transport**：`stdio`（标准输入输出），适配器作为子进程由 MCP 客户端启动，所有 tool 调用通过 JSON-RPC 在 stdio 上通信
-- **文件传输**：文件上传和下载不走 MCP 协议，而是通过独立的 **HTTP（multipart/form-data）** 直连 OpenAaaS Server：
-  - `submit_task` 中的 `input_files` 通过 HTTP multipart 上传
-  - `download_result` 通过 HTTP GET 下载文件
-- 这样设计避免了通过 MCP stdio 传输大体积二进制数据，保证性能和稳定性
+This adapter follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
+
+### Standard Usage Flow
+
+1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
+2. `register` — Register to get api_key (only once)
+3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
+4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
+5. Based on usage content, construct correct `task_prompt` and `output_prompt`
+6. `submit_task` — Submit task (with optional files), save returned `task_id`
+7. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
+8. `download_result` — Download result files after task completion
+
+### Why This Design
+
+- `list_services` returns a lightweight summary, not occupying LLM context
+- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
+- Avoid loading complete documentation for all services at once, which could cause context overflow
 
 ---
 
-## 注册约束
+## MCP Transport Description
 
-- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
-- 如需修改用户名，请使用 `update_profile`（示例：`update_profile(name: "new-name")`）
-- **`name` 参数约束**：长度不超过 64 个字符，不含 ASCII 控制字符、Unicode 控制字符及 `\ / < > | & ; $`
-- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
-- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
-- **跨别名重复注册检查**：如果某个 `server_url` 已被其他 `server` 别名注册过（即该 URL 已有 api_key），则新别名无法再次注册或设置该地址，防止同一服务器被多个别名重复记录
-- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+- **MCP Transport**: `stdio` (standard input/output). The adapter is launched as a child process by the MCP client; all tool calls communicate via JSON-RPC over stdio
+- **File Transfer**: File upload and download do not go through the MCP protocol, but instead use independent **HTTP (multipart/form-data)** direct connection to the OpenAaaS Server:
+  - `input_files` in `submit_task` are uploaded via HTTP multipart
+  - `download_result` downloads files via HTTP GET
+- This design avoids transferring large binary data through MCP stdio, ensuring performance and stability
 
 ---
 
-## 使用示例
+## Registration Constraints
 
-### 基础流程
+- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
+- To modify the user name, use `update_profile` (example: `update_profile(name: "new-name")`)
+- **`name` parameter constraint**: Length does not exceed 64 characters, no ASCII control characters, Unicode control characters, or `\ / < > | & ; $`
+- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
+- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
+- **Cross-alias duplicate registration check**: If a `server_url` has already been registered under another `server` alias (i.e. the URL already has an api_key), the new alias cannot register or set that address again, preventing the same server from being recorded multiple times under different aliases
+- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
 
-1. **设置服务器地址**（可选，默认 https://api.open-aaas.com）：
+---
+
+## Usage Examples
+
+### Basic Flow
+
+1. **Set server URL** (optional, default https://api.open-aaas.com):
    ```
    set_server_url(server_url: "https://api.open-aaas.com")
    ```
 
-   可选：发现服务端信息：
+   Optional: Discover server information:
    ```
    discover(server_url: "https://api.open-aaas.com")
    ```
 
-2. **注册客户端**：
+2. **Register client**:
    ```
    register(name: "my-client")
    ```
 
-3. **列出服务并筛选候选**：
+3. **List services and filter candidates**:
    ```
    list_services()
    ```
 
-4. **对目标服务获取详细 usage**：
+4. **Get detailed usage for the target service**:
    ```
    get_service_usage(service_id: "my-service")
    ```
 
-5. **提交任务**：
+5. **Submit task**:
    ```
    submit_task(
      service_id: "my-service",
-     task_prompt: "分析数据并生成报告",
-     output_prompt: "返回 Markdown 格式的分析报告"
+     task_prompt: "Analyze data and generate report",
+     output_prompt: "Return analysis report in Markdown format"
    )
    ```
 
-6. **查询任务**（仅在用户要求时调用）：
+6. **Query task** (only call when the user requests it):
    ```
    get_task(task_id: "xxx")
    ```
 
-7. **下载结果**：
+7. **Download result**:
    ```
    download_result(task_id: "xxx")
    ```
 
-### 带文件上传的任务
+### Task with File Upload
 
 ```
 submit_task(
   service_id: "data-analysis-agent",
-  task_prompt: "分析附件中的销售数据，找出增长趋势",
-  output_prompt: "返回 JSON 格式的分析结果，包含 trend 和 insights 字段",
+  task_prompt: "Analyze sales data in the attachment and identify growth trends",
+  output_prompt: "Return analysis results in JSON format, containing trend and insights fields",
   input_files: ["./sales_data.csv", "./notes.txt"],
-  session_id: "可选，用于保持对话上下文"
+  session_id: "Optional, for maintaining conversation context"
 )
 ```
 
-文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
 
-### 多服务器切换
+### Multi-Server Switching
 
 ```
 list_services(server: "prod")
 submit_task(server: "local", service_id: "my-service", task_prompt: "...")
 ```
 
-### 删除服务器配置
+### Delete Server Configuration
 
 ```
 remove_server(server: "old-server")
@@ -340,19 +340,19 @@ remove_server(server: "old-server")
 
 ---
 
-## 安全特性
+## Security Features
 
-- **路径遍历防护**：文件上传仅限当前工作目录下；zip 解压逐文件验证路径，防止 `../` 路径穿越
-- **zip 炸弹防护**：最大压缩比 500、解压后总大小 100MB、最大文件数 1000、单文件最大 50MB
-- **符号链接拒绝**：上传文件和 zip 中的符号链接均被直接拒绝
-- **原子写入**：配置文件使用临时文件 + `replace` 保证写入过程不损坏
-- **下载限制**：单文件下载不超过 100MB
+- **Path traversal protection**: File uploads are limited to the current working directory; zip extraction validates paths file by file, preventing `../` path traversal
+- **Zip bomb protection**: Maximum compression ratio 500, total size after extraction 100MB, maximum file count 1000, single file maximum 50MB
+- **Symbolic link rejection**: Symbolic links in uploaded files and zip archives are directly rejected
+- **Atomic write**: Configuration files use temporary file + `replace` to ensure the write process does not corrupt data
+- **Download limit**: Single file download does not exceed 100MB
 
 ---
 
-## 开发
+## Development
 
-本地开发运行方式：
+Local development run method:
 
 ```bash
 cd openaaas-mcp-adapter
@@ -360,7 +360,7 @@ uv sync
 uv run openaaas-mcp-adapter
 ```
 
-或使用 Python 模块方式：
+Or using Python module mode:
 
 ```bash
 uv run python -m openaaas_mcp_adapter
@@ -368,13 +368,13 @@ uv run python -m openaaas_mcp_adapter
 
 ---
 
-## 链接
+## Links
 
 - GitHub: [https://github.com/Wolido/OpenAaaS](https://github.com/Wolido/OpenAaaS)
-- 官网: [https://www.open-aaas.com](https://www.open-aaas.com)
+- Website: [https://www.open-aaas.com](https://www.open-aaas.com)
 
 ---
 
-## 许可证
+## License
 
 MIT License

--- a/client-extension/openaaas-mcp-adapter/README.zh.md
+++ b/client-extension/openaaas-mcp-adapter/README.zh.md
@@ -1,0 +1,380 @@
+# OpenAaaS MCP Adapter
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+OpenAaaS 的 MCP（Model Context Protocol）适配器，让 Claude Desktop、Cursor、Cline 等支持 MCP 的 AI 客户端能够连接 OpenAaaS Server，发现远程服务、提交任务并获取结果。
+
+基于 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) 构建，提供 14 个核心 Tool，覆盖完整的客户端能力：服务发现、注册认证、任务提交、结果下载及多服务器管理。
+
+---
+
+## 快速开始
+
+### 推荐：uvx（零安装，无需下载到本地）
+
+安装 [uv](https://docs.astral.sh/uv/) 后，直接运行，无需把包下载到本地：
+
+```bash
+uvx openaaas-mcp-adapter
+```
+
+`uv` 会自动从 PyPI 拉取并创建临时虚拟环境运行，用完即走，不会在系统中留下任何文件。
+
+这是**最推荐的方式**，适合所有用户。
+
+---
+
+### 客户端配置
+
+配置 Claude Desktop、Cursor 或 Cline：
+
+```json
+{
+  "mcpServers": {
+    "openaaas": {
+      "command": "uvx",
+      "args": ["openaaas-mcp-adapter"]
+    }
+  }
+}
+```
+
+配置修改后，重启客户端即可生效。
+
+---
+
+### 其他安装方式（可选）
+
+<details>
+<summary>点击查看其他安装方式</summary>
+
+#### pipx（全局安装）
+
+```bash
+pipx install openaaas-mcp-adapter
+```
+
+MCP 配置改为：
+```json
+{
+  "mcpServers": {
+    "openaaas": {
+      "command": "openaaas-mcp-adapter"
+    }
+  }
+}
+```
+
+#### pip 安装
+
+```bash
+pip install openaaas-mcp-adapter
+```
+
+#### 本地源码运行（开发）
+
+```bash
+cd openaaas-mcp-adapter
+uv sync
+uv run openaaas-mcp-adapter
+```
+
+</details>
+
+---
+
+## 配置文件
+
+配置文件保存在用户主目录下：
+
+```
+~/.openaaas-mcp-adapter/config.json
+```
+
+首次运行时若不存在，会自动创建默认配置：
+
+```json
+{
+  "servers": {
+    "default": {
+      "server_url": "https://api.open-aaas.com",
+      "api_key": "",
+      "client_id": "",
+      "name": ""
+    }
+  },
+  "default_server": "default"
+}
+```
+
+注册成功后的配置示例：
+
+```json
+{
+  "servers": {
+    "default": {
+      "server_url": "https://api.open-aaas.com",
+      "api_key": "ak_client_xxx",
+      "client_id": "xxx",
+      "name": "my-client"
+    }
+  },
+  "default_server": "default"
+}
+```
+
+运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+
+---
+
+## 多服务器配置
+
+支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+
+### 为多个服务器分别注册
+
+每个服务器别名有独立的注册信息：
+
+```
+register(name: "my-prod-client", server: "prod")
+register(name: "my-local-client", server: "local")
+```
+
+两个服务器会分别保存各自的 api_key，互不干扰。
+
+### 设置服务器地址
+
+```
+set_server_url(server_url: "https://api.open-aaas.com", server: "prod")
+set_server_url(server_url: "http://127.0.0.1:8080", server: "local")
+```
+
+### 切换默认服务器
+
+```
+set_default_server(server: "prod")
+```
+
+### 列出所有配置的服务器
+
+```
+list_servers()
+```
+
+---
+
+## 可用工具
+
+| 工具名 | 功能描述 |
+|--------|----------|
+| `discover` | 发现服务端 API 信息（返回服务端版本、支持的 API 端点、可用服务列表、认证方式等。建议在首次连接新服务器时调用） |
+| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
+| `register` | 注册客户端，自动保存 api_key（仅需一次） |
+| `update_profile` | 修改用户名 |
+| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
+| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
+| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
+| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务的结果文件列表 |
+| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
+| `list_servers` | 列出所有已配置的服务器 |
+| `set_default_server` | 切换默认服务器 |
+| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+
+### 参数说明
+
+| 工具名 | 参数 | 必填 | 说明 |
+|--------|------|------|------|
+| `discover` | `server_url` | ✅ | 目标服务器地址 |
+| `set_server_url` | `server_url` | ✅ | 服务器地址（以 http:// 或 https:// 开头） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `register` | `name` | ✅ | 客户端名称（长度 ≤64，不含 ASCII 控制字符、Unicode 控制字符及 `\/<>|&;$`） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `update_profile` | `name` | ✅ | 新用户名（同上约束） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_services` | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `get_service_usage` | `service_id` | ✅ | 目标服务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `submit_task` | `service_id` | ✅ | 目标服务 ID |
+| | `task_prompt` | ✅ | 任务描述 prompt |
+| | `output_prompt` | ❌ | 输出格式要求，默认 `""` |
+| | `input_files` | ❌ | 本地文件路径列表（最多 10 个，单文件 ≤100MB，仅限当前工作目录） |
+| | `session_id` | ❌ | 会话 ID，用于保持对话上下文 |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `get_task` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `cancel_task` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_files` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `download_result` | `task_id` | ✅ | 任务 ID |
+| | `file_id` | ❌ | 指定文件 ID，默认 `""` |
+| | `download_all` | ❌ | 是否下载所有文件，默认 `false` |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_servers` | — | — | 无参数 |
+| `set_default_server` | `server` | ✅ | 要设为默认的服务器别名 |
+| `remove_server` | `server` | ✅ | 要删除的服务器别名 |
+
+---
+
+## 渐进式信息获取
+
+本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
+
+### 标准使用流程
+
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
+2. `register` — 注册获取 api_key（仅需一次）
+3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
+4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
+5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
+6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
+7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
+8. `download_result` — 任务完成后下载结果文件
+
+### 为什么这样设计
+
+- `list_services` 返回轻量摘要，不占用 LLM 上下文
+- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
+- 避免一次性加载所有服务的完整文档导致上下文溢出
+
+---
+
+## MCP 传输说明
+
+- **MCP Transport**：`stdio`（标准输入输出），适配器作为子进程由 MCP 客户端启动，所有 tool 调用通过 JSON-RPC 在 stdio 上通信
+- **文件传输**：文件上传和下载不走 MCP 协议，而是通过独立的 **HTTP（multipart/form-data）** 直连 OpenAaaS Server：
+  - `submit_task` 中的 `input_files` 通过 HTTP multipart 上传
+  - `download_result` 通过 HTTP GET 下载文件
+- 这样设计避免了通过 MCP stdio 传输大体积二进制数据，保证性能和稳定性
+
+---
+
+## 注册约束
+
+- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
+- 如需修改用户名，请使用 `update_profile`（示例：`update_profile(name: "new-name")`）
+- **`name` 参数约束**：长度不超过 64 个字符，不含 ASCII 控制字符、Unicode 控制字符及 `\ / < > | & ; $`
+- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
+- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
+- **跨别名重复注册检查**：如果某个 `server_url` 已被其他 `server` 别名注册过（即该 URL 已有 api_key），则新别名无法再次注册或设置该地址，防止同一服务器被多个别名重复记录
+- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+
+---
+
+## 使用示例
+
+### 基础流程
+
+1. **设置服务器地址**（可选，默认 https://api.open-aaas.com）：
+   ```
+   set_server_url(server_url: "https://api.open-aaas.com")
+   ```
+
+   可选：发现服务端信息：
+   ```
+   discover(server_url: "https://api.open-aaas.com")
+   ```
+
+2. **注册客户端**：
+   ```
+   register(name: "my-client")
+   ```
+
+3. **列出服务并筛选候选**：
+   ```
+   list_services()
+   ```
+
+4. **对目标服务获取详细 usage**：
+   ```
+   get_service_usage(service_id: "my-service")
+   ```
+
+5. **提交任务**：
+   ```
+   submit_task(
+     service_id: "my-service",
+     task_prompt: "分析数据并生成报告",
+     output_prompt: "返回 Markdown 格式的分析报告"
+   )
+   ```
+
+6. **查询任务**（仅在用户要求时调用）：
+   ```
+   get_task(task_id: "xxx")
+   ```
+
+7. **下载结果**：
+   ```
+   download_result(task_id: "xxx")
+   ```
+
+### 带文件上传的任务
+
+```
+submit_task(
+  service_id: "data-analysis-agent",
+  task_prompt: "分析附件中的销售数据，找出增长趋势",
+  output_prompt: "返回 JSON 格式的分析结果，包含 trend 和 insights 字段",
+  input_files: ["./sales_data.csv", "./notes.txt"],
+  session_id: "可选，用于保持对话上下文"
+)
+```
+
+文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+
+### 多服务器切换
+
+```
+list_services(server: "prod")
+submit_task(server: "local", service_id: "my-service", task_prompt: "...")
+```
+
+### 删除服务器配置
+
+```
+remove_server(server: "old-server")
+```
+
+---
+
+## 安全特性
+
+- **路径遍历防护**：文件上传仅限当前工作目录下；zip 解压逐文件验证路径，防止 `../` 路径穿越
+- **zip 炸弹防护**：最大压缩比 500、解压后总大小 100MB、最大文件数 1000、单文件最大 50MB
+- **符号链接拒绝**：上传文件和 zip 中的符号链接均被直接拒绝
+- **原子写入**：配置文件使用临时文件 + `replace` 保证写入过程不损坏
+- **下载限制**：单文件下载不超过 100MB
+
+---
+
+## 开发
+
+本地开发运行方式：
+
+```bash
+cd openaaas-mcp-adapter
+uv sync
+uv run openaaas-mcp-adapter
+```
+
+或使用 Python 模块方式：
+
+```bash
+uv run python -m openaaas_mcp_adapter
+```
+
+---
+
+## 链接
+
+- GitHub: [https://github.com/Wolido/OpenAaaS](https://github.com/Wolido/OpenAaaS)
+- 官网: [https://www.open-aaas.com](https://www.open-aaas.com)
+
+---
+
+## 许可证
+
+MIT License

--- a/client-extension/pi-extension/README.md
+++ b/client-extension/pi-extension/README.md
@@ -1,10 +1,12 @@
 # OpenAaaS pi Extension
 
-为 [pi](https://github.com/badlogic/pi-mono) 开发的 OpenAaaS 扩展，提供统一的 `OpenAaaS` 工具，用于服务发现、客户端注册、任务提交及结果下载。
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-## 安装
+An OpenAaaS extension for [pi](https://github.com/badlogic/pi-mono), providing a unified `OpenAaaS` tool for service discovery, client registration, task submission, and result download.
 
-将扩展目录复制到 pi 全局扩展目录，目录名即为扩展名：
+## Installation
+
+Copy the extension directory to pi's global extension directory. The directory name becomes the extension name:
 
 ```bash
 mkdir -p ~/.pi/agent/extensions/OpenAaaS
@@ -13,17 +15,17 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-安装后，在 pi 中执行 `/reload` 即可自动加载扩展。
+After installation, execute `/reload` in pi to load the extension automatically.
 
-## 配置文件
+## Configuration
 
-配置文件保存在扩展目录下，路径为动态路径：
+The configuration file is saved in the extension directory, at a dynamic path:
 
 ```
-~/.pi/agent/extensions/<扩展目录名>/config.json
+~/.pi/agent/extensions/<extension-directory-name>/config.json
 ```
 
-首次加载时若不存在，会自动创建默认配置：
+If it does not exist on first load, a default configuration will be created automatically:
 
 ```json
 {
@@ -36,7 +38,7 @@ npm install
 }
 ```
 
-注册成功后的配置示例：
+Example configuration after successful registration:
 
 ```json
 {
@@ -52,178 +54,178 @@ npm install
 }
 ```
 
-运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
 
-## 多服务器配置
+## Multi-Server Configuration
 
-支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
 
-### 为多个服务器分别注册
+### Register for Multiple Servers Separately
 
-每个服务器别名有独立的注册信息：
+Each server alias has independent registration information:
 
 ```bash
-# 在 prod 服务器注册
+# Register on the prod server
 OpenAaaS(action: "register", server: "prod", name: "my-prod-client")
 
-# 在 local 服务器注册
+# Register on the local server
 OpenAaaS(action: "register", server: "local", name: "my-local-client")
 ```
 
-两个服务器会分别保存各自的 api_key，互不干扰。
+The two servers will save their respective api_keys independently without interference.
 
-### 设置服务器地址
+### Set Server URL
 
 ```
 OpenAaaS(action: "set_server_url", server: "prod", server_url: "https://api.open-aaas.com")
 OpenAaaS(action: "set_server_url", server: "local", server_url: "http://127.0.0.1:8080")
 ```
 
-切换默认服务器：
+Switch default server:
 ```
 OpenAaaS(action: "set_default_server", server: "prod")
 ```
 
-列出所有配置的服务器：
+List all configured servers:
 ```
 OpenAaaS(action: "list_servers")
 ```
 
-## 可用工具
+## Available Tools
 
-| 工具名 | 功能 |
-|--------|------|
-| `OpenAaaS` | 统一入口工具，通过 `action` 参数调用不同功能 |
+| Tool Name | Function |
+|-----------|----------|
+| `OpenAaaS` | Unified entry tool, invoking different functionalities via the `action` parameter |
 
-### 支持的 action
+### Supported Actions
 
-| action | 功能 |
-|--------|------|
-| `discover` | 发现服务端 API 信息（返回服务端版本、Base URL、认证方式、可用端点列表、已注册服务列表） |
-| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
-| `register` | 注册客户端，自动保存 api_key（仅需一次） |
-| `update_profile` | 修改用户名 |
-| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
-| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
-| `list_history` | 列出当前 Session 中所有 OpenAaaS 任务历史 |
-| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
-| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
-| `cancel_task` | 取消执行中的任务 |
-| `list_files` | 列出任务的结果文件列表 |
-| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件，单文件下载不超过 100MB，解压后总大小不超过 300MB（Zip 炸弹防护） |
-| `list_servers` | 列出所有已配置的服务器 |
-| `set_default_server` | 切换默认服务器 |
-| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+| Action | Function |
+|--------|----------|
+| `discover` | Discover server API information (returns server version, Base URL, authentication method, available endpoint list, registered service list) |
+| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
+| `register` | Register client, automatically save api_key (only once) |
+| `update_profile` | Modify user name |
+| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
+| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
+| `list_history` | List all OpenAaaS task history in the current Session |
+| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
+| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for the task |
+| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files. Single file download does not exceed 100MB, total size after extraction does not exceed 300MB (zip bomb protection) |
+| `list_servers` | List all configured servers |
+| `set_default_server` | Switch default server |
+| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
 
-## 渐进式信息获取
+## Progressive Information Retrieval
 
-本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
+This extension follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
 
-**标准使用流程**：
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
-2. `register` — 注册获取 api_key（仅需一次）
-3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
-4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
-5. 根据 usage 内容，构造正确的 task_prompt 和 output_prompt
-6. `submit_task` — 提交任务（可附带文件），保存返回的 task_id
-7. `list_history` — 查看当前 Session 中所有任务历史（上下文压缩后可用来恢复记忆）
-8. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-9. `download_result` — 任务完成后下载结果文件
+**Standard Usage Flow**:
+1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
+2. `register` — Register to get api_key (only once)
+3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
+4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
+5. Based on usage content, construct correct task_prompt and output_prompt
+6. `submit_task` — Submit task (with optional files), save returned task_id
+7. `list_history` — View all task history in the current Session (can be used to restore memory after context compression)
+8. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
+9. `download_result` — Download result files after task completion
 
-**为什么这样设计**：
-- `list_services` 返回轻量摘要，不占用 LLM 上下文
-- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
-- 避免一次性加载所有服务的完整文档导致上下文溢出
+**Why this design**:
+- `list_services` returns a lightweight summary, not occupying LLM context
+- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
+- Avoid loading complete documentation for all services at once, which could cause context overflow
 
-## 自动监控
+## Automatic Monitoring
 
-调用 `submit_task` 提交任务后，扩展会自动在后台监控任务状态：
+After calling `submit_task` to submit a task, the extension will automatically monitor task status in the background:
 
-- **Widget 实时显示**：在编辑器下方显示活跃任务（pending / accepted / running / cancelling）的统计信息和任务列表，状态变更时自动刷新
-- **UI 通知**：任务完成、失败或取消时自动推送通知
-- **无需轮询**：LLM 不需要主动调用 `get_task` 轮询状态，等待用户告知任务完成后再获取结果即可
-- **Widget 可见性约束**：widget 实时显示的任务状态仅对用户可见，你无法直接看到。如果你需要回答用户关于某个任务当前状态的任何问题（例如"任务现在是什么状态""完成了吗"），必须先调用 `get_task` 重新查询最新状态，不要引用之前调用返回的旧状态
-- **轮询间隔**：首次 10 秒，后续 30 秒
-- **Session 持久化**：任务状态会保存到当前会话中，切换会话树后自动重建监控
-- **Session 重建自动提醒**：当 session 被压缩重建后，扩展会自动发送消息到对话中，告知当前有哪些任务仍在监控，防止 LLM 失忆
+- **Widget real-time display**: Shows active task (pending / accepted / running / cancelling) statistics and task list below the editor, automatically refreshing on status changes
+- **UI notifications**: Automatically push notifications when tasks complete, fail, or are cancelled
+- **No polling needed**: The LLM does not need to actively call `get_task` to poll status; wait for the user to inform that the task is complete before retrieving results
+- **Widget visibility constraint**: The widget's real-time task status is only visible to the user; you cannot see it directly. If you need to answer the user about any task's current status (e.g. "What is the task status now?" "Is it complete?"), you must call `get_task` to re-query the latest status, do not reference the old status returned by previous calls
+- **Polling interval**: First 10 seconds, then 30 seconds
+- **Session persistence**: Task status is saved to the current session, and monitoring is automatically reconstructed after switching the session tree
+- **Session reconstruction reminder**: After the session is compressed and reconstructed, the extension will automatically send a message to the conversation, informing which tasks are still being monitored, to prevent LLM amnesia
 
-## 命令
+## Commands
 
 ### `/OpenAaaS-tasks`
 
-弹出面板显示当前会话中的任务（包括终态任务，最多 20 个），按 `Escape` 或 `Ctrl+C` 关闭，30 秒无操作自动关闭。
+Pops up a panel showing tasks in the current session (including terminal tasks, up to 20), press `Escape` or `Ctrl+C` to close, automatically closes after 30 seconds of inactivity.
 
-## 注册约束
+## Registration Constraints
 
-- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
-- 如需修改用户名，请使用 `update_profile`（示例：`OpenAaaS(action: "update_profile", name: "new-name")`）
-- **`name` 参数约束**：长度不超过 64 个字符，不能包含控制字符及以下非法字符：`/ \ < > | & ; $`
-- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
-- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
-- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
+- To modify the user name, use `update_profile` (example: `OpenAaaS(action: "update_profile", name: "new-name")`)
+- **`name` parameter constraint**: Length does not exceed 64 characters, cannot contain control characters and the following illegal characters: `/ \ < > | & ; $`
+- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
+- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
+- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
 
-## 使用示例
+## Usage Examples
 
-1. 设置服务器地址（可选，默认 https://api.open-aaas.com）：
+1. Set server URL (optional, default https://api.open-aaas.com):
    ```
    OpenAaaS(action: "set_server_url", server_url: "https://www.open-aaas.com")
    ```
 
-   可选：发现服务端信息：
+   Optional: Discover server information:
    ```
    OpenAaaS(action: "discover")
    ```
 
-1.5. 切换到其他服务器操作：
+1.5. Switch to another server for operations:
    ```
    OpenAaaS(action: "list_services", server: "prod")
    OpenAaaS(action: "submit_task", server: "local", service_id: "my-service", task_prompt: "...")
    ```
 
-2. 注册客户端：
+2. Register client:
    ```
    OpenAaaS(action: "register", name: "my-client")
    ```
 
-3. 列出服务并筛选候选：
+3. List services and filter candidates:
    ```
    OpenAaaS(action: "list_services")
    ```
 
-4. 对目标服务获取详细 usage：
+4. Get detailed usage for the target service:
    ```
    OpenAaaS(action: "get_service_usage", service_id: "my-service")
    ```
 
-5. 提交任务（带文件上传）：
+5. Submit task (with file upload):
    ```
    OpenAaaS(
      action: "submit_task",
      service_id: "my-service",
-     task_prompt: "分析数据",
-     output_prompt: "返回 JSON",
+     task_prompt: "Analyze data",
+     output_prompt: "Return JSON",
      input_files: ["./data.csv"],
-     session_id: "可选，用于保持对话上下文"
+     session_id: "Optional, for maintaining conversation context"
    )
    ```
-   文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+   File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
 
-6. 列出当前 Session 任务历史：
+6. List current Session task history:
    ```
    OpenAaaS(action: "list_history")
    ```
 
-7. 查询任务（仅在用户要求时调用）：
+7. Query task (only call when the user requests it):
    ```
    OpenAaaS(action: "get_task", task_id: "xxx")
    ```
 
-8. 下载结果：
+8. Download result:
    ```
    OpenAaaS(action: "download_result", task_id: "xxx")
    ```
 
-9. 删除服务器配置：
+9. Delete server configuration:
    ```
    OpenAaaS(action: "remove_server", server: "old-server")
    ```

--- a/client-extension/pi-extension/README.zh.md
+++ b/client-extension/pi-extension/README.zh.md
@@ -1,0 +1,231 @@
+# OpenAaaS pi Extension
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+为 [pi](https://github.com/badlogic/pi-mono) 开发的 OpenAaaS 扩展，提供统一的 `OpenAaaS` 工具，用于服务发现、客户端注册、任务提交及结果下载。
+
+## 安装
+
+将扩展目录复制到 pi 全局扩展目录，目录名即为扩展名：
+
+```bash
+mkdir -p ~/.pi/agent/extensions/OpenAaaS
+cp -r /path/to/pi-extension/* ~/.pi/agent/extensions/OpenAaaS/
+cd ~/.pi/agent/extensions/OpenAaaS
+npm install
+```
+
+安装后，在 pi 中执行 `/reload` 即可自动加载扩展。
+
+## 配置文件
+
+配置文件保存在扩展目录下，路径为动态路径：
+
+```
+~/.pi/agent/extensions/<扩展目录名>/config.json
+```
+
+首次加载时若不存在，会自动创建默认配置：
+
+```json
+{
+  "servers": {
+    "default": {
+      "server_url": "https://api.open-aaas.com"
+    }
+  },
+  "default_server": "default"
+}
+```
+
+注册成功后的配置示例：
+
+```json
+{
+  "servers": {
+    "default": {
+      "server_url": "https://api.open-aaas.com",
+      "api_key": "ak_client_xxx",
+      "client_id": "xxx",
+      "name": "my-client"
+    }
+  },
+  "default_server": "default"
+}
+```
+
+运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+
+## 多服务器配置
+
+支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+
+### 为多个服务器分别注册
+
+每个服务器别名有独立的注册信息：
+
+```bash
+# 在 prod 服务器注册
+OpenAaaS(action: "register", server: "prod", name: "my-prod-client")
+
+# 在 local 服务器注册
+OpenAaaS(action: "register", server: "local", name: "my-local-client")
+```
+
+两个服务器会分别保存各自的 api_key，互不干扰。
+
+### 设置服务器地址
+
+```
+OpenAaaS(action: "set_server_url", server: "prod", server_url: "https://api.open-aaas.com")
+OpenAaaS(action: "set_server_url", server: "local", server_url: "http://127.0.0.1:8080")
+```
+
+切换默认服务器：
+```
+OpenAaaS(action: "set_default_server", server: "prod")
+```
+
+列出所有配置的服务器：
+```
+OpenAaaS(action: "list_servers")
+```
+
+## 可用工具
+
+| 工具名 | 功能 |
+|--------|------|
+| `OpenAaaS` | 统一入口工具，通过 `action` 参数调用不同功能 |
+
+### 支持的 action
+
+| action | 功能 |
+|--------|------|
+| `discover` | 发现服务端 API 信息（返回服务端版本、Base URL、认证方式、可用端点列表、已注册服务列表） |
+| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
+| `register` | 注册客户端，自动保存 api_key（仅需一次） |
+| `update_profile` | 修改用户名 |
+| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
+| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
+| `list_history` | 列出当前 Session 中所有 OpenAaaS 任务历史 |
+| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
+| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务的结果文件列表 |
+| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件，单文件下载不超过 100MB，解压后总大小不超过 300MB（Zip 炸弹防护） |
+| `list_servers` | 列出所有已配置的服务器 |
+| `set_default_server` | 切换默认服务器 |
+| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+
+## 渐进式信息获取
+
+本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
+
+**标准使用流程**：
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
+2. `register` — 注册获取 api_key（仅需一次）
+3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
+4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
+5. 根据 usage 内容，构造正确的 task_prompt 和 output_prompt
+6. `submit_task` — 提交任务（可附带文件），保存返回的 task_id
+7. `list_history` — 查看当前 Session 中所有任务历史（上下文压缩后可用来恢复记忆）
+8. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
+9. `download_result` — 任务完成后下载结果文件
+
+**为什么这样设计**：
+- `list_services` 返回轻量摘要，不占用 LLM 上下文
+- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
+- 避免一次性加载所有服务的完整文档导致上下文溢出
+
+## 自动监控
+
+调用 `submit_task` 提交任务后，扩展会自动在后台监控任务状态：
+
+- **Widget 实时显示**：在编辑器下方显示活跃任务（pending / accepted / running / cancelling）的统计信息和任务列表，状态变更时自动刷新
+- **UI 通知**：任务完成、失败或取消时自动推送通知
+- **无需轮询**：LLM 不需要主动调用 `get_task` 轮询状态，等待用户告知任务完成后再获取结果即可
+- **Widget 可见性约束**：widget 实时显示的任务状态仅对用户可见，你无法直接看到。如果你需要回答用户关于某个任务当前状态的任何问题（例如"任务现在是什么状态""完成了吗"），必须先调用 `get_task` 重新查询最新状态，不要引用之前调用返回的旧状态
+- **轮询间隔**：首次 10 秒，后续 30 秒
+- **Session 持久化**：任务状态会保存到当前会话中，切换会话树后自动重建监控
+- **Session 重建自动提醒**：当 session 被压缩重建后，扩展会自动发送消息到对话中，告知当前有哪些任务仍在监控，防止 LLM 失忆
+
+## 命令
+
+### `/OpenAaaS-tasks`
+
+弹出面板显示当前会话中的任务（包括终态任务，最多 20 个），按 `Escape` 或 `Ctrl+C` 关闭，30 秒无操作自动关闭。
+
+## 注册约束
+
+- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
+- 如需修改用户名，请使用 `update_profile`（示例：`OpenAaaS(action: "update_profile", name: "new-name")`）
+- **`name` 参数约束**：长度不超过 64 个字符，不能包含控制字符及以下非法字符：`/ \ < > | & ; $`
+- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
+- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
+- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+
+## 使用示例
+
+1. 设置服务器地址（可选，默认 https://api.open-aaas.com）：
+   ```
+   OpenAaaS(action: "set_server_url", server_url: "https://www.open-aaas.com")
+   ```
+
+   可选：发现服务端信息：
+   ```
+   OpenAaaS(action: "discover")
+   ```
+
+1.5. 切换到其他服务器操作：
+   ```
+   OpenAaaS(action: "list_services", server: "prod")
+   OpenAaaS(action: "submit_task", server: "local", service_id: "my-service", task_prompt: "...")
+   ```
+
+2. 注册客户端：
+   ```
+   OpenAaaS(action: "register", name: "my-client")
+   ```
+
+3. 列出服务并筛选候选：
+   ```
+   OpenAaaS(action: "list_services")
+   ```
+
+4. 对目标服务获取详细 usage：
+   ```
+   OpenAaaS(action: "get_service_usage", service_id: "my-service")
+   ```
+
+5. 提交任务（带文件上传）：
+   ```
+   OpenAaaS(
+     action: "submit_task",
+     service_id: "my-service",
+     task_prompt: "分析数据",
+     output_prompt: "返回 JSON",
+     input_files: ["./data.csv"],
+     session_id: "可选，用于保持对话上下文"
+   )
+   ```
+   文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+
+6. 列出当前 Session 任务历史：
+   ```
+   OpenAaaS(action: "list_history")
+   ```
+
+7. 查询任务（仅在用户要求时调用）：
+   ```
+   OpenAaaS(action: "get_task", task_id: "xxx")
+   ```
+
+8. 下载结果：
+   ```
+   OpenAaaS(action: "download_result", task_id: "xxx")
+   ```
+
+9. 删除服务器配置：
+   ```
+   OpenAaaS(action: "remove_server", server: "old-server")
+   ```

--- a/dash/README.md
+++ b/dash/README.md
@@ -1,16 +1,18 @@
 # OpenAaaS Dashboard
 
-> **⚠️ 定位说明**：这是一个面向开发者和系统管理员的**调试与管理员控制工具**，用于监控和管理 OpenAaaS 的任务与系统状态。**它不是 OpenAaaS 的用户界面 / 主界面（Main UI）**。
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+
+> **⚠️ Positioning Note**: This is a **debugging and admin control tool** for developers and system administrators, used for monitoring and managing OpenAaaS tasks and system status. **It is NOT the OpenAaaS user interface / main UI (Main UI)**.
 
 A Streamlit-based web UI for debugging, monitoring and administering OpenAaaS tasks.
 
 ## Features
 
-- 📊 **任务概览与调试**：以卡片布局查看所有任务，查看任务详情（输入/输出/文件等），支持取消任务
-- 🔧 **管理员视图**：查看所有用户任务，按用户筛选任务
-- 🔄 **自动刷新**：实时更新，支持可配置刷新间隔
-- 🔍 **状态过滤**：按状态筛选任务（All/Pending/Running/Completed/Failed/Cancelled/Cancelling）
-- ⚙️ **灵活配置**：支持 CLI 参数、环境变量和配置文件
+- 📊 **Task Overview & Debugging**: View all tasks in a card layout, inspect task details (input/output/files, etc.), and cancel tasks
+- 🔧 **Admin View**: View all user tasks, filter tasks by user
+- 🔄 **Auto Refresh**: Real-time updates with configurable refresh interval
+- 🔍 **Status Filtering**: Filter tasks by status (All/Pending/Running/Completed/Failed/Cancelled/Cancelling)
+- ⚙️ **Flexible Configuration**: Supports CLI arguments, environment variables, and configuration files
 
 ## Installation
 

--- a/dash/README.zh.md
+++ b/dash/README.zh.md
@@ -1,0 +1,81 @@
+# OpenAaaS Dashboard
+
+<p align="right"><a href="./README.md">English</a> | 中文</p>
+
+> **⚠️ 定位说明**：这是一个面向开发者和系统管理员的**调试与管理员控制工具**，用于监控和管理 OpenAaaS 的任务与系统状态。**它不是 OpenAaaS 的用户界面 / 主界面（Main UI）**。
+
+基于 Streamlit 的 Web UI，用于调试、监控和管理 OpenAaaS 任务。
+
+## 功能特性
+
+- 📊 **任务概览与调试**：以卡片布局查看所有任务，查看任务详情（输入/输出/文件等），支持取消任务
+- 🔧 **管理员视图**：查看所有用户任务，按用户筛选任务
+- 🔄 **自动刷新**：实时更新，支持可配置刷新间隔
+- 🔍 **状态过滤**：按状态筛选任务（All/Pending/Running/Completed/Failed/Cancelled/Cancelling）
+- ⚙️ **灵活配置**：支持 CLI 参数、环境变量和配置文件
+
+## 安装
+
+### Using `uv` (recommended)
+
+```bash
+uv tool install open-aaas-dashboard
+```
+
+### Using `pip`
+
+```bash
+pip install open-aaas-dashboard
+```
+
+### 开发安装
+
+```bash
+cd OpenAaaS/dash
+pip install -e .
+```
+
+## 用法
+
+### 命令行
+
+```bash
+# With command line arguments
+aaas-dashboard --server-url http://localhost:8080 --api-key ak_xxx
+
+# With environment variables
+export OAAS_SERVER_URL=http://localhost:8080
+export OAAS_API_KEY=ak_xxx
+aaas-dashboard
+```
+
+### 配置优先级
+
+配置按以下优先级加载（从高到低）：
+
+1. **命令行参数**：`--server-url`, `--api-key`
+2. **环境变量**：`OAAS_SERVER_URL`, `OAAS_API_KEY`
+3. **配置文件**：`~/.config/aaas-dashboard/config.toml`
+
+### 配置文件格式
+
+创建 `~/.config/aaas-dashboard/config.toml`：
+
+```toml
+server_url = "http://localhost:8080"
+api_key = "ak_xxx"
+```
+
+## 开发
+
+```bash
+# Install dependencies
+pip install -e ".[dev]"
+
+# Run the dashboard
+streamlit run src/aaas_dashboard/app.py
+```
+
+## 许可证
+
+MIT 许可证


### PR DESCRIPTION
将剩余子目录的 README 翻译为英文，原中文内容保存为 README.zh.md。

涉及目录：
- agent-core/executor-example
- agent-core/executor-example/pi/agent/extensions/subagent-isolation
- client-extension
- client-extension/kimi-plugin
- client-extension/openaaas-mcp-adapter
- client-extension/pi-extension
- dash