### PR TITLE
feat: support ~/ prefix in skill paths

### DIFF
--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/index.ts
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/index.ts
@@ -410,7 +410,11 @@ async function runSingleAgent(
 		if (agent.skills.length > 0) {
 			const baseDir = cwd ?? defaultCwd;
 			for (const skillPath of agent.skills) {
-				const resolved = path.isAbsolute(skillPath) ? skillPath : path.resolve(baseDir, skillPath);
+				const resolved = skillPath.startsWith("~/")
+				    ? path.join(os.homedir(), skillPath.slice(2))
+				    : path.isAbsolute(skillPath)
+				        ? skillPath
+				        : path.resolve(baseDir, skillPath);
 				args.push("--skill", resolved);
 			}
 		}


### PR DESCRIPTION
## 变更

为 subagent-isolation 扩展的 skill path 解析增加对 `~/`（用户主目录）前缀的支持。

当 agent frontmatter 中的 `skills` 字段包含以 `~/` 开头的路径时，自动解析为用户主目录下的路径，而不是相对于工作目录或当作绝对路径处理。

### 示例

```yaml
---
name: coder
skills: ~/.pi/agent/skills/my-skill
---
```

此前 `~/.pi/agent/skills/my-skill` 会被当作相对路径解析为 `{cwd}/~/.pi/agent/skills/my-skill`，导致找不到 skill 文件。现在会正确解析为 `/home/user/.pi/agent/skills/my-skill`。

### 变更范围
- 仅修改 `agent-core/executor-example/pi/agent/extensions/subagent-isolation/index.ts`
- 在 `path.isAbsolute` 判断之前增加 `skillPath.startsWith("~/")` 分支
- 使用 `os.homedir()` 获取用户主目录