### PR TITLE
feat(db): enable SQLite WAL mode and fix integration test cleanup

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-19
+
+### Added
+- 启用 SQLite WAL 模式，提升高并发写场景下数据库读写性能
+
 ## [0.5.1] - 2026-05-16
 
 ### Changed
@@ -58,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.6.0]: https://github.com/Wolido/OpenAaaS/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Wolido/OpenAaaS/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Wolido/OpenAaaS/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Wolido/OpenAaaS/compare/v0.4.0...v0.4.1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,6 +1,6 @@
 //! 数据库连接和初始化管理
 
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -14,7 +14,8 @@ impl Database {
     /// 创建新的数据库连接
     pub async fn new(database_url: &str) -> anyhow::Result<Self> {
         let options = SqliteConnectOptions::from_str(database_url)?
-            .create_if_missing(true);
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal);
         
         let pool = SqlitePoolOptions::new()
             .max_connections(10)

--- a/server/tests/integration/mod.rs
+++ b/server/tests/integration/mod.rs
@@ -86,6 +86,17 @@ impl TestApp {
         let db_file = db_url.strip_prefix("sqlite:").unwrap_or(db_url);
         let db_file = db_file.strip_prefix("///").unwrap_or(db_file);
         let db_file = db_file.split('?').next().unwrap_or(db_file);
+        // Remove WAL/SHM first, then main db (defensive ordering)
+        if let Err(e) = tokio::fs::remove_file(format!("{}-wal", db_file)).await {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("Warning: failed to remove test db wal file {}-wal: {}", db_file, e);
+            }
+        }
+        if let Err(e) = tokio::fs::remove_file(format!("{}-shm", db_file)).await {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("Warning: failed to remove test db shm file {}-shm: {}", db_file, e);
+            }
+        }
         if let Err(e) = tokio::fs::remove_file(&db_file).await {
             eprintln!("Warning: failed to remove test db file {}: {}", db_file, e);
         }


### PR DESCRIPTION
## Summary
Enable SQLite WAL (Write-Ahead Logging) mode for improved concurrency and write performance, and update integration test cleanup to handle WAL companion files.

## Changes
- **server/src/db.rs**: Set `journal_mode` to `SqliteJournalMode::Wal` in `SqliteConnectOptions`.
- **server/tests/integration/mod.rs**: Remove `-wal` and `-shm` companion files before deleting the main test database file.

## Why WAL?
WAL provides better concurrency (readers do not block writers, and vice versa) and is generally faster than the default DELETE journal mode for write-heavy workloads.

## Backwards Compatibility
- WAL mode is supported by SQLite >= 3.7.0 (widely available on all target platforms).
- The change is transparent to application code. Existing databases automatically switch to WAL on the first connection.
- No migration or schema changes are required.

## Testing
- Existing integration tests are updated to clean up WAL companion files to avoid leftover artifacts and flakiness.