### PR TITLE
fix(mcp-adapter): multipart boundary and default server fallback

### DIFF
--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/http_client.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/http_client.py
@@ -1,6 +1,7 @@
 """HTTP 客户端：基于 httpx 的安全请求与错误处理"""
 
 import json
+import uuid
 from typing import Any
 
 import httpx
@@ -26,6 +27,58 @@ def _extract_error_message(response: httpx.Response) -> str:
     except json.JSONDecodeError:
         pass
     return text
+
+
+def _escape_quotes(value: str) -> str:
+    """转义字符串中的反斜杠和双引号，用于 multipart Content-Disposition 头。"""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _build_multipart_body(
+    data: dict[str, str],
+    files: list[tuple[str, tuple[str, bytes, str]]],
+) -> tuple[bytes, str]:
+    """手动构建 multipart/form-data 请求体，绕过 httpx 自动生成的 boundary 解析问题。
+
+    Args:
+        data: 普通表单字段，键值对字典。
+        files: 文件列表，每项格式为 (field_name, (filename, content_bytes, mime_type))。
+
+    Returns:
+        (body_bytes, boundary_string): 构建好的请求体字节串和 boundary 字符串。
+    """
+    boundary = f"----openaaas-{uuid.uuid4().hex}"
+    lines: list[bytes] = []
+
+    def add_field(key: str, value: str) -> None:
+        escaped_key = _escape_quotes(key)
+        lines.append(f"--{boundary}\r\n".encode("utf-8"))
+        lines.append(
+            f'Content-Disposition: form-data; name="{escaped_key}"\r\n\r\n'.encode("utf-8")
+        )
+        lines.append(value.encode("utf-8"))
+        lines.append(b"\r\n")
+
+    for key, value in data.items():
+        add_field(key, value)
+
+    for field_name, (filename, payload, content_type) in files:
+        escaped_field = _escape_quotes(field_name)
+        escaped_filename = _escape_quotes(filename)
+        lines.append(f"--{boundary}\r\n".encode("utf-8"))
+        lines.append(
+            (
+                f'Content-Disposition: form-data; name="{escaped_field}"; '
+                f'filename="{escaped_filename}"\r\n'
+            ).encode("utf-8")
+        )
+        lines.append(f"Content-Type: {content_type}\r\n\r\n".encode("utf-8"))
+        lines.append(payload)
+        lines.append(b"\r\n")
+
+    lines.append(f"--{boundary}--\r\n".encode("utf-8"))
+    body = b"".join(lines)
+    return body, boundary
 
 
 def _map_exception(exc: Exception, url: str) -> OpenAaaSError:
@@ -74,7 +127,7 @@ def safe_request(
         method: HTTP 方法 (GET/POST/PUT/DELETE)
         url: 请求 URL
         headers: 请求头
-        data: JSON 请求体（会被序列化为 JSON）
+        data: 请求体数据（普通请求时序列化为 JSON；multipart 上传时转为字符串表单字段）
         files: 文件列表，格式 [(field_name, (filename, content, mime_type)), ...]
         timeout: 超时秒数
         max_redirects: 最大重定向次数
@@ -97,13 +150,20 @@ def safe_request(
                 req_headers = dict(headers)
                 current_host = httpx.URL(current_url).host
                 if current_host != original_host:
-                    req_headers.pop("Authorization", None)
+                    for h in list(req_headers.keys()):
+                        if h.lower() == "authorization":
+                            req_headers.pop(h)
 
                 if files is not None:
-                    # multipart upload: data for form fields, files for uploads
+                    # multipart upload: manually build body to avoid boundary parsing issues
                     form_data = {k: str(v) for k, v in (data or {}).items()}
+                    body, boundary = _build_multipart_body(form_data, files)
+                    for h in list(req_headers.keys()):
+                        if h.lower() == "content-type":
+                            req_headers.pop(h)
+                    req_headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
                     response = client.request(
-                        method, current_url, headers=req_headers, data=form_data, files=files
+                        method, current_url, headers=req_headers, content=body
                     )
                 elif data:
                     if "Content-Type" not in req_headers:

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
@@ -285,7 +285,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 2. set_server_url
     # ------------------------------------------------------------------
     @mcp.tool()
-    def set_server_url(server_url: str, server: str = "default") -> str:
+    def set_server_url(server_url: str, server: str = "") -> str:
         """设置服务器地址并保存到配置文件"""
         server_url = server_url.strip()
         if not server_url:
@@ -351,7 +351,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 3. register
     # ------------------------------------------------------------------
     @mcp.tool()
-    def register(name: str, server: str = "default") -> str:
+    def register(name: str, server: str = "") -> str:
         """注册客户端账号，获取 api_key（仅需一次）"""
         name = name.strip()
         if not name:
@@ -434,7 +434,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 4. update_profile
     # ------------------------------------------------------------------
     @mcp.tool()
-    def update_profile(name: str, server: str = "default") -> str:
+    def update_profile(name: str, server: str = "") -> str:
         """修改当前客户端用户名"""
         name = name.strip()
         if not name:
@@ -484,7 +484,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 5. list_services
     # ------------------------------------------------------------------
     @mcp.tool()
-    def list_services(server: str = "default") -> str:
+    def list_services(server: str = "") -> str:
         """获取可用的 Agent 服务列表（轻量摘要）"""
         try:
             sc = get_server_config(server)
@@ -540,7 +540,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 6. get_service_usage
     # ------------------------------------------------------------------
     @mcp.tool()
-    def get_service_usage(service_id: str, server: str = "default") -> str:
+    def get_service_usage(service_id: str, server: str = "") -> str:
         """获取指定服务的详细用法说明（能力范围、调用规范、返回格式、限制条件）"""
         if not service_id:
             return "❌ 缺少必填参数: service_id"
@@ -576,7 +576,7 @@ def register_tools(mcp: FastMCP) -> None:
         output_prompt: str = "",
         input_files: list[str] | None = None,
         session_id: str = "",
-        server: str = "default",
+        server: str = "",
     ) -> str:
         """
         提交任务到远程 Agent（支持文件上传）
@@ -683,7 +683,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 8. get_task
     # ------------------------------------------------------------------
     @mcp.tool()
-    def get_task(task_id: str, server: str = "default") -> str:
+    def get_task(task_id: str, server: str = "") -> str:
         """查询任务状态和最终结果"""
         if not task_id:
             return "❌ 缺少必填参数: task_id"
@@ -756,7 +756,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 9. cancel_task
     # ------------------------------------------------------------------
     @mcp.tool()
-    def cancel_task(task_id: str, server: str = "default") -> str:
+    def cancel_task(task_id: str, server: str = "") -> str:
         """取消执行中的任务"""
         if not task_id:
             return "❌ 缺少必填参数: task_id"
@@ -799,7 +799,7 @@ def register_tools(mcp: FastMCP) -> None:
     # 10. list_files
     # ------------------------------------------------------------------
     @mcp.tool()
-    def list_files(task_id: str, server: str = "default") -> str:
+    def list_files(task_id: str, server: str = "") -> str:
         """列出任务的结果文件"""
         if not task_id:
             return "❌ 缺少必填参数: task_id"
@@ -845,7 +845,7 @@ def register_tools(mcp: FastMCP) -> None:
         task_id: str,
         file_id: str = "",
         download_all: bool = False,
-        server: str = "default",
+        server: str = "",
     ) -> str:
         """
         下载任务结果文件

--- a/client-extension/openaaas-mcp-adapter/tests/test_config.py
+++ b/client-extension/openaaas-mcp-adapter/tests/test_config.py
@@ -200,6 +200,21 @@ class TestGetServerConfig:
         with pytest.raises(RuntimeError, match='服务器别名 "missing" 不存在'):
             get_server_config("missing")
 
+    def test_get_server_config_empty_alias_fallback_to_default_server(self, tmp_path, monkeypatch):
+        """当 alias 为空字符串时，应 fallback 到配置中的 default_server"""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config = {
+            "servers": {
+                "default": {"server_url": "https://a.com", "api_key": "k1"},
+                "prod": {"server_url": "https://b.com", "api_key": "k2"},
+            },
+            "default_server": "prod",
+        }
+        save_config(config)
+        sc = get_server_config("")  # 空字符串
+        assert sc["alias"] == "prod"
+        assert sc["server_url"] == "https://b.com"
+
 
 class TestRequireApiKey:
     """Tests for require_api_key."""

--- a/client-extension/openaaas-mcp-adapter/tests/test_http_client.py
+++ b/client-extension/openaaas-mcp-adapter/tests/test_http_client.py
@@ -193,10 +193,90 @@ class TestSafeRequest:
             "POST", "http://example.com/upload", data={"name": "test"}, files=files
         )
         assert result == {"uploaded": True}
-        # Verify multipart form data was used
+        # Verify multipart body was built manually and sent via content
         call_kwargs = mock_client.request.call_args[1]
-        assert "data" in call_kwargs
-        assert "files" in call_kwargs
+        assert "content" in call_kwargs
+        assert "data" not in call_kwargs
+        assert "files" not in call_kwargs
+        req_headers = call_kwargs.get("headers", {})
+        content_type = req_headers.get("Content-Type", "")
+        assert "multipart/form-data" in content_type
+        assert "boundary=----openaaas-" in content_type
+        body = call_kwargs["content"]
+        body_str = body.decode("utf-8")
+        assert 'Content-Disposition: form-data; name="name"' in body_str
+        assert 'Content-Disposition: form-data; name="files"; filename="test.txt"' in body_str
+        assert "Content-Type: text/plain" in body_str
+
+    def test_post_multipart_no_files(self, monkeypatch):
+        """Test POST multipart with empty files list still sends multipart."""
+        response = self._make_response(200, json_data={"ok": True})
+        mock_client = self._mock_client(monkeypatch, [response])
+
+        result = safe_request(
+            "POST", "http://example.com/upload", data={"name": "test"}, files=[]
+        )
+        assert result == {"ok": True}
+        call_kwargs = mock_client.request.call_args[1]
+        req_headers = call_kwargs.get("headers", {})
+        content_type = req_headers.get("Content-Type", "")
+        assert "multipart/form-data" in content_type
+        body = call_kwargs["content"]
+        body_str = body.decode("utf-8")
+        assert 'Content-Disposition: form-data; name="name"' in body_str
+        assert "test" in body_str
+        assert "--" in body_str
+
+    def test_post_multipart_multiple_files(self, monkeypatch):
+        """Test POST with multiple files."""
+        response = self._make_response(200, json_data={"uploaded": True})
+        mock_client = self._mock_client(monkeypatch, [response])
+
+        files = [
+            ("files", ("a.txt", b"content_a", "text/plain")),
+            ("files", ("b.txt", b"content_b", "text/plain")),
+        ]
+        result = safe_request(
+            "POST", "http://example.com/upload", data={"name": "multi"}, files=files
+        )
+        assert result == {"uploaded": True}
+        call_kwargs = mock_client.request.call_args[1]
+        body = call_kwargs["content"]
+        body_str = body.decode("utf-8")
+        assert 'filename="a.txt"' in body_str
+        assert 'filename="b.txt"' in body_str
+        assert "content_a" in body_str
+        assert "content_b" in body_str
+
+    def test_post_multipart_special_chars_in_filename(self, monkeypatch):
+        """Test POST with filename containing quotes and backslashes."""
+        response = self._make_response(200, json_data={"uploaded": True})
+        mock_client = self._mock_client(monkeypatch, [response])
+
+        files = [("files", ('say "hello".txt', b"content", "text/plain"))]
+        result = safe_request(
+            "POST", "http://example.com/upload", data={"name": "special"}, files=files
+        )
+        assert result == {"uploaded": True}
+        call_kwargs = mock_client.request.call_args[1]
+        body = call_kwargs["content"]
+        body_str = body.decode("utf-8")
+        assert 'filename="say \\"hello\\".txt"' in body_str
+
+    def test_post_multipart_backslash_in_filename(self, monkeypatch):
+        """Test POST with filename containing backslashes."""
+        response = self._make_response(200, json_data={"uploaded": True})
+        mock_client = self._mock_client(monkeypatch, [response])
+
+        files = [("files", ("path\\\\to\\\\file.txt", b"content", "text/plain"))]
+        result = safe_request(
+            "POST", "http://example.com/upload", data={"name": "backslash"}, files=files
+        )
+        assert result == {"uploaded": True}
+        call_kwargs = mock_client.request.call_args[1]
+        body = call_kwargs["content"]
+        body_str = body.decode("utf-8")
+        assert 'filename="path\\\\\\\\to\\\\\\\\file.txt"' in body_str
 
     def test_redirect_handling(self, monkeypatch):
         """Test following a redirect."""

--- a/client-extension/openaaas-mcp-adapter/tests/test_tools_mcp.py
+++ b/client-extension/openaaas-mcp-adapter/tests/test_tools_mcp.py
@@ -112,6 +112,24 @@ class TestSetServerUrl:
             result = tools["set_server_url"]("https://new.example.com")
         assert "已有注册信息" in result
 
+    def test_set_server_url_uses_configured_default_server(self, tools, tmp_path, monkeypatch):
+        """当 default_server 为自定义 alias 且调用 set_server_url 时不传 server 参数，应写入该 alias"""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        config = {
+            "servers": {
+                "default": {"server_url": "https://a.com", "api_key": "", "client_id": "", "name": ""},
+                "prod": {"server_url": "", "api_key": "", "client_id": "", "name": ""},
+            },
+            "default_server": "prod",
+        }
+        with patch("openaaas_mcp_adapter.tools.load_config", return_value=config):
+            with patch("openaaas_mcp_adapter.tools.save_config") as mock_save:
+                result = tools["set_server_url"]("https://new.example.com")
+        assert "设置成功" in result
+        # 验证 save_config 被调用时，prod 的 server_url 被更新
+        saved = mock_save.call_args[0][0]
+        assert saved["servers"]["prod"]["server_url"] == "https://new.example.com"
+
 
 class TestRegister:
     """Tests for register tool."""


### PR DESCRIPTION
## 修复内容

### 1. Invalid boundary for multipart/form-data request
- `httpx` 自动生成的 multipart boundary 与 axum/multer 解析器不兼容
- 新增 `_build_multipart_body()` 手工构建 multipart 请求体，绕过 httpx 自动生成
- 新增 `_escape_quotes()` 对文件名/字段名中的引号和反斜杠做转义
- Content-Type 和 Authorization header 的清理改为大小写不敏感

### 2. 更换默认 server 无效
- 10 个 MCP 工具的 `server` 参数默认值为硬编码 `'default'`，而非读取配置中的 `default_server`
- 全部改为 `server: str = ''`，使 `get_server_config` 的 `alias or config['default_server']` fallback 生效

### 测试
- 新增 4 个 multipart 相关测试
- 新增 2 个 default_server fallback 回归测试
- 全部 114 个测试通过