### PR TITLE
chore(mcp-adapter): bump version to 0.2.0

### DIFF
--- a/client-extension/openaaas-mcp-adapter/pyproject.toml
+++ b/client-extension/openaaas-mcp-adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openaaas-mcp-adapter"
-version = "0.1.1"
+version = "0.2.0"
 description = "OpenAaaS MCP adapter — connect Claude Desktop, Cursor, Cline to OpenAaaS Server"
 readme = "PYPI_README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump openaaas-mcp-adapter version from 0.1.1 to 0.2.0.