### PR TITLE
fix(servers): 修复server删除服务时日志记录缺失

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - 修复server中测试代码里存在的unused问题
+- 修复server删除服务时日志记录缺失
 
 ## [0.6.0] - 2026-05-19
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-25
+
 ### Fixed
 - 修复server中测试代码里存在的unused问题
 - 修复server删除服务时日志记录缺失
@@ -67,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.6.1]: https://github.com/Wolido/OpenAaaS/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Wolido/OpenAaaS/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Wolido/OpenAaaS/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Wolido/OpenAaaS/compare/v0.4.1...v0.5.0

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/server/src/handlers/services.rs
+++ b/server/src/handlers/services.rs
@@ -208,7 +208,11 @@ pub async fn delete_service(
 
         tx.commit().await.map_err(AppError::Database)?;
 
-        tracing::info!("删除服务: service_id={}, tasks_cancelled={}", id, tasks_cancelled);
+        tracing::info!(
+            "删除服务: service_id={}, mode=force, tasks_cancelled={}, tasks_retained={}",
+            id, tasks_cancelled, tasks_retained
+        );
+
 
         Ok(Json(DeleteServiceResponse {
             deleted: true,
@@ -239,6 +243,8 @@ pub async fn delete_service(
             .map_err(AppError::Database)?;
 
         tx.commit().await.map_err(AppError::Database)?;
+        
+        tracing::info!("删除服务: service_id={}, mode=normal", id);
 
         Ok(Json(DeleteServiceResponse {
             deleted: true,

--- a/server/src/handlers/services.rs
+++ b/server/src/handlers/services.rs
@@ -213,7 +213,6 @@ pub async fn delete_service(
             id, tasks_cancelled, tasks_retained
         );
 
-
         Ok(Json(DeleteServiceResponse {
             deleted: true,
             tasks_cancelled,
@@ -243,8 +242,11 @@ pub async fn delete_service(
             .map_err(AppError::Database)?;
 
         tx.commit().await.map_err(AppError::Database)?;
-        
-        tracing::info!("删除服务: service_id={}, mode=normal", id);
+
+        tracing::info!(
+            "删除服务: service_id={}, mode=normal, tasks_cancelled=0, tasks_retained=0",
+            id
+        );
 
         Ok(Json(DeleteServiceResponse {
             deleted: true,


### PR DESCRIPTION
## Description
修复了server在删除服务的时候，server run不显示，server run-detached不记录的问题

代码改动细节：

改动了services.rs文件

在此处将
tracing::info!("删除服务: service_id={}, tasks_cancelled={}", id, tasks_cancelled);
改为
tracing::info!("删除服务: service_id={}, mode=force, tasks_cancelled={}, tasks_retained={}", id, tasks_cancelled, tasks_retained);
<img width="856" height="148" alt="image" src="https://github.com/user-attachments/assets/42144b74-6d11-449d-8358-a94aec346b2d" />

在此处添加tracing::info!("删除服务: service_id={}, mode=normal", id);
<img width="786" height="120" alt="image" src="https://github.com/user-attachments/assets/1ae0961f-b13b-49fb-83e7-5891e6030a00" />

更新了CHANGELOG.md文件
<img width="880" height="393" alt="image" src="https://github.com/user-attachments/assets/a3fcaf1f-4d10-4cb8-a6ce-79e2d3985cd4" />

代码通过了cargo check、cargo build、cargo test

## Checklist

- [x] 代码改动已测试通过
- [x] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
