### PR TITLE
docs: switch default README to Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="right"><a href="./README.zh.md"> 中文</a> | English</p>
+<p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
 <p align="center">
   <img src="./assets/logo.png" width="360" alt="OpenAaaS Logo">
@@ -7,13 +7,13 @@
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
 <p align="center">
-  <a href="https://www.open-aaas.com">Website</a> ·
-  <a href="https://arxiv.org/abs/2605.13618">Paper</a> ·
-  <a href="./server/README.md">Server Docs</a> ·
-  <a href="./agent-core/README.md">Agent Core Docs</a> ·
-  <a href="#Usage">Usage Guide</a> ·
-  <a href="./client-extension/README.md">Client Extensions</a> ·
-  <a href="./client-app/README.en.md">Desktop Client</a>
+  <a href="https://www.open-aaas.com">官网</a> ·
+  <a href="https://arxiv.org/abs/2605.13618">论文</a> ·
+  <a href="./server/README.md">server 文档</a> ·
+  <a href="./agent-core/README.md">agent-core 文档</a> ·
+  <a href="#使用">使用指南</a> ·
+  <a href="./client-extension/README.md">客户端插件</a> ·
+  <a href="./client-app/README.md">桌面客户端</a>
 </p>
 
 <p align="center">
@@ -32,154 +32,153 @@
 </p>
 
 <p align="center">
-  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.skill</b></a>
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员.skill</b></a>
 </p>
 
 ---
 
-**Intelligence flows, data stays still — bring AI to the data, instead of handing data over to AI.**
+**智能流动，数据静止 —— 让 AI 走到数据身边，而不是把数据交给 AI。**
 
-**OpenAaaS is building a new kind of scientific infrastructure: data stays where it was created, and analytical capabilities flow through the network to reach it.**
+**OpenAaaS 正在构建一种全新的科研基础设施：数据驻留在产生它的原地，分析能力通过网络流动到数据身边。**
 
-The bottleneck of AI has shifted from model capability to the accessibility of scientific capabilities, while "data being forced to migrate" is a harder constraint than models. Every lab has accumulated unique data, algorithms, and workflows, but they are scattered in silos and cannot be discovered or invoked. OpenAaaS distributes Agent capabilities to data nodes locally, enabling any Agent to discover, invoke, and compose capabilities from scientific nodes around the world — data is processed in place, while code and instructions flow through the network.
+AI 的瓶颈已从模型能力转向科研能力的可达性，而"数据被迫迁移"是比模型更硬的约束。每个实验室都沉淀了独特的数据、算法与流程，但它们分散在孤岛中，无法被发现与调用。OpenAaaS 将 Agent 能力分发到数据节点本地，让任意 Agent 都能发现、调用并组合全球科研节点的能力——数据原地处理，代码与指令在网络中流动。
 
-Any Agent — whether Claude Code, pi mono, Kimi Cli, or a self-built system — can discover and compose capabilities from scientific nodes across the network through the web.
+任何 Agent——无论是 Claude Code、pi mono、Kimi Cli 还是自研系统——都可以通过网络发现并组合全球科研节点的能力。
 
-At the same time, we strive to minimize the barrier to using the network, even for general-purpose LLM apps on mobile phones.
+同时，我们致力于让网络的使用门槛降到最低，哪怕是手机上的通用大模型 App。
 
-| Demo Video | Screenshots |
+| 操作视频 | 截图 |
 |:---:|:---:|
-| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **Connect Service**<br><img width="372" height="113" alt="Screenshot 2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**View Service List**<br><img width="379" height="406" alt="Screenshot 2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**Service Result Returned**<br><img width="371" height="391" alt="Screenshot 2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
+| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **接入服务**<br><img width="372" height="113" alt="截屏2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**查看服务列表**<br><img width="379" height="406" alt="截屏2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**服务结果返回**<br><img width="371" height="391" alt="截屏2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
 ---
 
-### 📄 Paper
+### 📄 论文
 
-Technical design and implementation details: [arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
+技术设计与实现细节详见：[arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
 
 ---
 
-## Four Core Propositions
+## 四大核心主张
 
-### Data Stays In Situ, Capabilities Flow Across Nodes
+### 数据原位驻留，能力跨节点流动
 
-The real solution to data silos is not moving all the data into one place — it is bringing analytical capabilities to where the data lives. Every lab's accumulated datasets, algorithmic workflows, and domain expertise become composable capability units that any Agent can directly invoke. Agents need not master the full depth of a field in advance; they simply discover, orchestrate, and invoke services from nodes around the world, continuously expanding their knowledge boundaries across materials science, biomedicine, astronomy, and beyond.
+数据孤岛的真正解决方式，不是把数据搬在一起，而是让分析能力走到数据身边。每个实验室沉淀的数据集、算法流程与领域经验，通过网络化封装成为 Agent 可直接调用的能力单元。Agent 无需预先掌握特定领域的全部知识，只需发现、编排、调用全球节点的服务，即可在材料科学、生物医学、天文观测等垂直领域不断扩展知识边界。
 
-### Zero Data Migration, Eliminating Migration Loss
+### 原生数据零迁移，规避迁移损耗
 
-Traditional solutions demand that data be aggregated into a centralized platform — inevitably introducing format conversion distortion, metadata loss, version divergence, and broken compliance audit chains. OpenAaaS builds no unified data warehouse. Data remains at its point of origin, preserved in its original storage format, directory structure, and access permissions. Analysis tasks arrive remotely as code and instructions; results are sent back. Raw data never leaves.
+传统方案要求数据汇聚到中心化平台，这不可避免地带来格式转换失真、元数据丢失、版本分叉、合规审计链断裂等问题。OpenAaaS 不建立统一的数据仓库，数据始终保留在产生它的位置，维持最初的存储格式、目录结构与访问权限。分析任务以代码和指令的形式远程到达，结果回传，原始数据从未离开本地。
 
-### Schema-Free Onboarding, Raw Format as Service Capability
+### 免规范化接入，原生格式即服务能力
 
-We impose no upfront format requirements on data. JSON, CSV, Excel, MATLAB `.mat`, HDF5, vendor-specific binary formats from instruments — the local parsing and processing scripts on each node are themselves part of the network's capability. Agents invoke a combined "parse + analyze" service, rather than being required to pre-clean, standardize, or structure the data. Whatever format a lab already has, it is service-ready from day one.
+我们不对数据提出任何前置的格式要求。JSON、CSV、Excel、MATLAB `.mat`、HDF5、仪器厂商的专有二进制格式——节点本地的解析与处理脚本本身就是网络能力的一部分。Agent 调用的是"解析+分析"的组合服务，而非要求数据预先被清洗、标准化、结构化。实验室现有的任意数据，接入即服务。
 
-### Near-Data Computing, Data-Movement Cost Approaches Zero
+### 近数据端计算，调用开销趋近于零
 
-Computation happens next to the data, not the other way around. The network only transmits task descriptions and execution results (KB–MB scale); raw data is processed on-site. For TB-scale datasets and regulated sensitive samples, this means no upload wait, no bandwidth bottleneck, and no outbound compliance review — the marginal cost of moving data approaches zero.
+计算发生在数据旁边，而非数据被搬运到计算中心。网络仅传输任务描述与执行结果（KB~MB 级），原始数据就地处理。对于 TB 级数据集和受监管敏感样本，这意味着无需等待上传、无需突破带宽瓶颈、无需面临出域合规审查——数据移动的边际成本趋近于零。
 
-## Core Design Philosophy
+## 核心设计理念
 
-Traditional cloud solutions require data to leave the premises: TB-scale datasets must be migrated and uploaded, sensitive samples are handed to third parties, and lab firewalls are forced to open inbound ports. OpenAaaS takes the opposite approach — deploying Agent execution nodes directly where the data resides. The network only transmits task descriptions, task files, and results; raw data stays in place.
+传统云端方案要求数据离开本地：TB 级数据集必须迁移上传，敏感样本交给第三方，实验室防火墙被迫开放入站端口。OpenAaaS 反其道而行——将 Agent 执行节点直接部署在数据本地，网络只传输任务描述、任务文件及结果，原始数据原地不动。
 
-| | Traditional Cloud Solution | OpenAaaS Near-Data Solution |
+| | 传统云端方案 | OpenAaaS 近数据端方案 |
 |---|---|---|
-| Data Flow | Local → Cloud → Local | **Raw data stays in place** |
-| Network Transfer | Raw data (TB scale) | Task descriptions, task files, and results (KB–MB scale) |
-| Firewall Requirements | Inbound ports required | **Outbound HTTP only** |
-| Sensitive Data | Must leave the domain | **Never leaves the lab** |
-| Latency | Bandwidth-limited | Local compute, extremely low latency |
+| 数据流向 | 本地 → 云端 → 本地 | **原始数据原地不动** |
+| 网络传输 | 原始数据（TB 级） | 任务描述、任务文件及结果（KB~MB 级） |
+| 防火墙要求 | 需开放入站端口 | **仅出站 HTTP 即可** |
+| 敏感数据 | 必须出域 | **不出实验室** |
+| 延迟 | 受带宽限制 | 本地计算，极低延迟 |
 
-## Architecture
+## 架构
 
 ```
-Client Agent
-(pi mono / Claude Code / Kimi Cli / Cline / Custom Agent)
+客户端 Agent
+(pi mono / Claude Code / Kimi Cli / Cline / 自研 Agent)
         ▲
-        │ Control flow: task description, heartbeat, results (KB scale)
+        │ 控制流：任务描述、心跳、结果（KB 级）
         ▼
 ───────────────────────────────────────────────────────────────────
-OpenAaaS Server (Network Hub)
-Rust + SQLite — Lightweight indexing layer
-  • Service registration  • Task routing  • Node heartbeat  • File relay
+OpenAaaS Server（网络枢纽）
+Rust + SQLite — 轻量索引层
+  • 服务注册  • 任务路由  • 节点心跳  • 文件中转
         ▲
-        │ Short polling (unidirectional outbound HTTP)
+        │ 短轮询（单向出站 HTTP）
         ▼
 ───────────────────────────────────────────────────────────────────
-Agent Core (Network Node)
-Rust + Docker — Deployed locally where data resides
-  • Register capabilities to the network  • Poll for tasks
-  • Container sandbox isolation execution  • Report results
+Agent Core（网络节点）
+Rust + Docker — 部署在数据本地
+  • 向网络注册能力  • 轮询认领任务  • 容器沙箱隔离执行  • 上报结果
         │              │                   │
         ▼              ▼                   ▼
-   [Local Dataset]  [Analysis Scripts]  [Specialized Hardware]
-    (TB scale)      (Algorithms/Models)  (GPU/Instruments)
+   [本地数据集]    [分析脚本]         [专用硬件]
+    （TB 级）      （算法/模型）        （GPU/仪器）
 ```
 
-| Layer | Component | Responsibility |
+| 层级 | 组件 | 职责 |
 |------|------|------|
-| Client Agent | pi mono / Kimi Cli / Codex / Open Code / Custom Agent | Understand tasks, discover network nodes, schedule remote capabilities, integrate results |
-| Network Hub | Server — Capability registration and scheduling center (Rust + SQLite) | Service registration, task routing, node heartbeat, file relay |
-| Network Node | agent-core — Capability execution node + Docker | Register capabilities to the network, poll for tasks, execute in sandbox isolation, report results |
+| 客户端 Agent | pi mono / Kimi Cli / Codex / Open Code / 自研 Agent | 理解任务、发现网络节点、调度远端能力、整合结果 |
+| 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 服务注册、任务路由、节点心跳、文件中转 |
+| 网络节点 | agent-core — 能力执行节点 + Docker | 向网络注册自身能力、轮询认领任务、在沙箱中隔离执行、上报结果 |
 
-## Design Rationale
+## 设计思路
 
-| Principle | Description | Effect |
+| 原则 | 说明 | 效果 |
 |------|------|------|
-| Rust + Single Binary | `cargo build --release` produces one executable | Zero-dependency deployment, copy and run |
-| Embedded SQLite | Database starts with the process, no separate service | Zero operations, single node is sufficient |
-| Docker Isolation | Each task runs in an independent container with workspace mounted | Secure and controllable, reproducible environment |
-| Self-Organizing Nodes | Nodes actively register with the network and poll for tasks; Server only maintains an index. Raw data never leaves the domain; task files flow through the Server | Nodes need no public IP; unidirectional outbound is enough to join the network; data is processed on-site, naturally adapting to lab firewall environments |
+| Rust + 单二进制 | `cargo build --release` 得到一个可执行文件 | 零依赖部署，复制即用 |
+| SQLite 嵌入式 | 数据库随进程启动，无单独服务 | 零运维，单节点足够 |
+| Docker 隔离 | 每个任务独立容器，workspace 挂载 | 安全可控，环境可复现 |
+| 节点自组网 | 节点主动向网络注册并轮询任务，Server 仅维护索引。原始数据不出域，任务文件经 Server 流转 | 节点无需公网 IP，单向出站即可加入网络；数据原地处理，天然适应实验室防火墙环境 |
 
-## Features
+## 特性
 
-### Data In-Situ Retention & Cross-Node Capability Flow
+### 数据原位驻留与能力跨节点流动
 
-- **🔌 Zero-Learning-Cost Agent Integration, Self-Describing API Auto-Exposes Service Docs** — No authentication required; returns complete API documentation and usage instructions. Agents can understand and invoke all scientific services without any plugins.
-- **🧩 Progressive Capability Discovery, Avoiding Context Overflow** — Initial queries return lightweight summaries; detailed usage is returned on demand. A progressive disclosure design similar to SKILL.md protects the Agent's context window.
+- **🔌 Agent 零学习成本接入，自描述 API 自动暴露服务文档** — 无需认证，返回完整 API 文档和使用说明。Agent 无需插件即可理解并调用全部科研服务。
+- **🧩 渐进式能力发现，避免上下文溢出** — 初次查询返回轻量摘要，再按需返回详细用法。类似 SKILL.md 的渐进式披露设计，保护 Agent 的上下文窗口。
 
-### Zero Data Migration
+### 原生数据零迁移
 
-- **🔒 Data Never Leaves the Premises** — Agent execution nodes are deployed directly on lab servers or instrument workstations. Raw large datasets are processed in-place via local mounts; sensitive data never crosses the firewall. The network only transmits task descriptions, task files, and results; it never touches raw data.
-- **💾 Single Binary, Zero Operations** — SQLite database + local file storage; no Redis/MySQL required. A single node is enough for deployment, ideal for lab edge nodes.
-- **⚖️ Nodes Join via Reverse Connection, No Public IP Needed** — Nodes self-manage concurrency and task claiming; Server only does lightweight queue management. Lab nodes only need unidirectional outbound access to join; no open ports or SSH required.
+- **🔒 数据不出域** — Agent 执行节点直接部署在实验室服务器或仪器工作站上，原始大数据集通过本地挂载原地处理，敏感数据不离开防火墙。网络只传输任务描述、任务文件及结果，不触碰原始数据。
+- **💾 单二进制零运维** — SQLite 数据库 + 本地文件存储，无需 Redis/MySQL。单节点即可部署，适合实验室边缘节点。
+- **⚖️ 节点反向入网，不需要公网 IP** — 节点自行控制并发和任务认领，Server 只做轻量队列管理。实验室节点只需要单向出站即可接入，无需开放端口或 SSH。
 
-### Schema-Free Onboarding & Near-Data Computing
+### 免规范化接入与近数据端计算
 
-- **🐳 Independent Sandbox per Experiment, Reproducible Results** — Each task runs in an isolated container with workspace mounts for input and output. Environment isolation makes results traceable and reproducible.
-- **🔧 Zero-Config Node Onboarding** — `open-aaas-server run` auto-generates `config.toml`, SQLite database, and keys on first launch. No manual configuration; ready to use out of the box.
-- **🤖 MCP Standard Protocol Compatible** — Through `openaaas-mcp-adapter`, any MCP-compatible client such as Claude Desktop, Cursor, or Cline can connect with one click, without writing any plugins.
+- **🐳 每个实验任务独立沙箱，结果可复现** — 每个任务在独立容器中运行，通过 workspace 挂载实现输入输出。环境隔离，结果可追溯、可复现。
+- **🔧 节点零配置入网** — `open-aaas-server run` 首次启动自动生成 `config.toml`、SQLite 数据库、密钥。无需手动配置，开箱即用。
+- **🤖 MCP 标准协议兼容** — 通过 `openaaas-mcp-adapter`，Claude Desktop、Cursor、Cline 等任意支持 MCP 的客户端均可一键接入，无需编写插件。
 
-## Usage
+## 使用
 
-Public Server: **<https://api.open-aaas.com>**
+公共服务器：**<https://api.open-aaas.com>**
 
-We provide three trial scientific services on the public server:
+我们在公共服务器中提供了三项试用的科研服务：
 
-- IDM-Alpha Metal Materials Literature Research Assistant Based on Hundreds of Thousands of Real Papers
-- Trillion-Scale Hexa-High-Entropy Alloy Descriptor Database
-- Fuyao Multi-Agent Roundtable System
+- 基于数十万真实文献的 IDM-Alpha 金属材料文献研究助手
+- 万亿规模六元高熵合金描述符数据库
+- 扶摇智能体圆桌会议系统
 
-You can have your Agent connect to the public server to use them.
+可以让 Agent 接入公共服务器使用
 
-### Quick Start
+### 快速开始
 
-**Scenario 1: Use the Public Server**
+**场景一：使用公共服务器**
 
-No need to build your own infrastructure. Simply configure your Agent to connect to the public server and start invoking community-shared scientific services. Ideal for individual researchers to get started quickly.
+无需自建基础设施，直接配置你的 Agent 接入公共服务器，即可调用社区共享的科研服务。适合个人研究者快速接入。
 
-### Using the pi / Kimi Plugin
+### 用 pi / kimi 插件
 
-Just say in the conversation:
+在对话中直接说：
 
-> "Help me set the OpenAaaS server address to <https://api.open-aaas.com>, then submit a data analysis task"
+> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后提交一个数据分析任务"
 
-The client Agent will automatically complete registration, service discovery, task submission, and result retrieval.
+客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
 
 <video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
 
-### Using an MCP Client
+### 用 MCP 客户端
 
-`openaaas-mcp-adapter` is available on PyPI. If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.
+`openaaas-mcp-adapter` 已发布至 PyPI。如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。
 
 ```json
 {
@@ -192,47 +191,47 @@ The client Agent will automatically complete registration, service discovery, ta
 }
 ```
 
-After configuring, restart the client, and you can invoke OpenAaaS's 14 standard Tools (`set_server_url`, `register`, `list_services`, `submit_task`, etc.) directly in conversation without installing any plugins.
+配置后重启客户端，即可在对话中调用 OpenAaaS 的 14 个标准 Tool（`set_server_url`、`register`、`list_services`、`submit_task` 等），无需安装任何插件。
 
-Or better yet, you can have your Agent set it up for you directly.
+甚至，你可以直接让你的Agent帮你配置。
 
 <p align="center">
   <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
 </p>
 
-See [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md) for details.
+详见 [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md)。
 
-### Using the Desktop Client
+### 用桌面客户端
 
-If you prefer a graphical interface, use the **OpenAaaS Desktop Client** — a cross-platform desktop application based on Tauri, supporting macOS, Windows, and Linux.
+如果你偏好图形界面操作，可以使用 **OpenAaaS 桌面客户端**——一个基于 Tauri 的跨平台桌面应用，支持 macOS、Windows 和 Linux。
 
-The desktop client is ideal for:
-- Non-technical users who don't want to configure command-line tools or plugins
-- Managing multiple servers and browsing services visually
-- Drag-and-drop file uploads and real-time task progress tracking
+桌面客户端适合：
+- 不想配置命令行或插件的非技术用户
+- 需要管理多个服务器并直观浏览服务的场景
+- 希望拖拽上传文件、实时查看任务进度的用户
 
-📖 See [client-app/README.en.md](./client-app/README.en.md) for details.
+📖 详见 [client-app/README.md](./client-app/README.md)
 
 <p align="center">
   <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
 </p>
 
-> macOS users: The app is ad-hoc signed. On first launch, go to **System Settings → Privacy & Security → Security** and click **"Open Anyway"**.
+> macOS 用户请注意：应用使用 ad-hoc 自签名，首次打开时前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"即可。
 
-### Using a General Agent Framework
+### 用通用 Agent 框架
 
-If your Agent does not have an OpenAaaS plugin, simply have it access <https://api.open-aaas.com>:
+如果你的 Agent 没有 OpenAaaS 插件，让 Agent 直接访问 <https://api.open-aaas.com>
 
-- No authentication required; complete API documentation and usage instructions are returned
-- The Agent can then automatically complete registration, service discovery, and task submission after reading them
+- 无需认证，返回完整 API 文档和使用说明
+- Agent 读取后即可自动完成注册、服务发现、任务提交
 
-**Scenario 2: Deploy on a Lab Server and Connect Local Capabilities**
+**场景二：部署在实验室服务器，接入本地能力**
 
-Launch OpenAaaS on a local server in your machine room or lab, and register local analysis scripts and specialized computing workflows as network nodes. Any Agent in the research group — pi, Kimi, Claude, or a self-built system — can query node status, submit analysis tasks, and retrieve result data through a unified entry point.
+在机房或实验室的本地服务器上启动 OpenAaaS，将本地分析脚本、专用计算流程注册为网络节点。课题组内的任何 Agent——pi、Kimi、Claude 或自研系统——都能通过统一入口查询节点状态、提交分析任务、获取结果数据。
 
-### Local Deployment
+### 本地部署
 
-**Deploy Server (Scheduling Center)**:
+**部署 Server（调度中心）**：
 
 ```bash
 cd server
@@ -240,9 +239,9 @@ cargo build --release
 ./target/release/open-aaas-server run
 ```
 
-On first launch, `config.toml` and the SQLite database are auto-generated.
+首次启动自动生成 `config.toml`和 SQLite 数据库。
 
-**Deploy Agent Core (Execution Node)**:
+**部署 Agent Core（执行节点）**：
 
 ```bash
 cd agent-core
@@ -252,34 +251,34 @@ cargo build --release
 ./target/release/agent-core run
 ```
 
-The `registration_token` must be obtained by creating a Service on the Server first. Admins can use the API Key from the Server logs to call `POST /api/v1/services/` to create one.
+`registration_token` 需要先在 Server 上创建 Service 获取。Admin 可使用 Server 日志中的 API Key 调用 `POST /api/v1/services/` 创建。
 
-The Agent executor image needs to be built in advance (under the agent-core directory):
+Agent 执行器镜像需要提前构建（在 agent-core 目录下）：
 
 ```bash
 cd executor-example && docker build -t open-aaas-executor:latest .
 ```
 
-See [agent-core/README.md](./agent-core/README.md) for details.
+详见 [agent-core/README.md](./agent-core/README.md)
 
-## Project Structure
+## 项目结构
 
 ```
 OpenAaaS/
-├── server/           # Network Hub (Scheduling Center) (Rust) — Task scheduling, queuing, auth, file relay
-├── agent-core/       # Network Node (Execution Node) (Rust) — Registration, polling, Docker-isolated execution
-├── client-app/       # Desktop Client (Tauri + Vue 3) — Service marketplace, task submission, result viewing
-├── dash/             # Debug and admin tools (Python/Streamlit)
-└── client-extension/ # Client extensions — pi plugin, Kimi plugin, MCP adapter (Claude Desktop / Cursor / Cline)
+├── server/           # 网络枢纽（调度中心） (Rust) — 任务调度、队列、鉴权、文件中转
+├── agent-core/       # 网络节点（执行节点） (Rust) — 注册、轮询、Docker 隔离执行
+├── client-app/       # 桌面客户端 (Tauri + Vue 3) — 服务市场、任务提交、结果查看
+├── dash/             # 调试与管理员工具 (Python/Streamlit)
+└── client-extension/ # 客户端扩展 — pi 插件、kimi 插件、MCP 适配器（Claude Desktop / Cursor / Cline）
 ```
 
-## Research Vision
+## 科研愿景
 
-OpenAaaS's vision is to make every lab a composable node in the Agentic Science network. Data is no longer degraded by migration, and knowledge is no longer stalled by silos. Every research group's data morphology, analysis workflows, and domain methods — however unique their storage formats may be — can be discovered, invoked, and orchestrated by any Agent across the network.
+OpenAaaS 的愿景是让每个实验室都成为 Agentic Science 网络中的一个可组合节点。数据不再因迁移而损耗，知识不再因孤岛而停滞。每个课题组沉淀的数据形态、分析流程与领域方法——无论其存储格式多么独特——都可以通过网络被任意 Agent 发现、调用与编排。
 
-When analytical capabilities can flow to where data lives, the knowledge boundary of an Agent expands from the closed loop of a single lab to an open ecosystem of global collaboration. The marginal cost of moving data approaches zero, meaning datasets of any scale can be invoked on demand by Agents anywhere. The frontier of scientific innovation is no longer limited by a single team's data volume or domain depth.
+当分析能力能够流动到数据身边，Agent 的知识边界将从单个实验室的闭环，扩展到全球协作的开放生态。数据移动的边际成本趋近于零，意味着任意规模的 Dataset 都可以被任意位置的 Agent 即时调用。科研创新的边界，不再受限于单个团队的数据规模或领域深度。
 
-## Open Source License
+## 开源许可
 
 MIT License © IDM Explorer Lab
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-<p align="right">中文 | <a href="./README.md">English</a></p>
+<p align="right"><a href="./README.md">English</a> | 中文</p>
 
 <p align="center">
   <img src="./assets/logo.png" width="360" alt="OpenAaaS Logo">
@@ -7,13 +7,13 @@
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
 <p align="center">
-  <a href="https://www.open-aaas.com">官网</a> ·
-  <a href="https://arxiv.org/abs/2605.13618">论文</a> ·
-  <a href="./server/README.md">server 文档</a> ·
-  <a href="./agent-core/README.md">agent-core 文档</a> ·
-  <a href="#使用">使用指南</a> ·
-  <a href="./client-extension/README.md">客户端插件</a> ·
-  <a href="./client-app/README.md">桌面客户端</a>
+  <a href="https://www.open-aaas.com">Website</a> ·
+  <a href="https://arxiv.org/abs/2605.13618">Paper</a> ·
+  <a href="./server/README.zh.md">Server Docs</a> ·
+  <a href="./agent-core/README.zh.md">Agent Core Docs</a> ·
+  <a href="#Usage">Usage Guide</a> ·
+  <a href="./client-extension/README.zh.md">Client Extensions</a> ·
+  <a href="./client-app/README.zh.md">Desktop Client</a>
 </p>
 
 <p align="center">
@@ -32,153 +32,154 @@
 </p>
 
 <p align="center">
-  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>设计博客：不搬数据，蒸馏管理员.skill</b></a>
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.skill</b></a>
 </p>
 
 ---
 
-**智能流动，数据静止 —— 让 AI 走到数据身边，而不是把数据交给 AI。**
+**Intelligence flows, data stays still — bring AI to the data, instead of handing data over to AI.**
 
-**OpenAaaS 正在构建一种全新的科研基础设施：数据驻留在产生它的原地，分析能力通过网络流动到数据身边。**
+**OpenAaaS is building a new kind of scientific infrastructure: data stays where it was created, and analytical capabilities flow through the network to reach it.**
 
-AI 的瓶颈已从模型能力转向科研能力的可达性，而"数据被迫迁移"是比模型更硬的约束。每个实验室都沉淀了独特的数据、算法与流程，但它们分散在孤岛中，无法被发现与调用。OpenAaaS 将 Agent 能力分发到数据节点本地，让任意 Agent 都能发现、调用并组合全球科研节点的能力——数据原地处理，代码与指令在网络中流动。
+The bottleneck of AI has shifted from model capability to the accessibility of scientific capabilities, while "data being forced to migrate" is a harder constraint than models. Every lab has accumulated unique data, algorithms, and workflows, but they are scattered in silos and cannot be discovered or invoked. OpenAaaS distributes Agent capabilities to data nodes locally, enabling any Agent to discover, invoke, and compose capabilities from scientific nodes around the world — data is processed in place, while code and instructions flow through the network.
 
-任何 Agent——无论是 Claude Code、pi mono、Kimi Cli 还是自研系统——都可以通过网络发现并组合全球科研节点的能力。
+Any Agent — whether Claude Code, pi mono, Kimi Cli, or a self-built system — can discover and compose capabilities from scientific nodes across the network through the web.
 
-同时，我们致力于让网络的使用门槛降到最低，哪怕是手机上的通用大模型 App。
+At the same time, we strive to minimize the barrier to using the network, even for general-purpose LLM apps on mobile phones.
 
-| 操作视频 | 截图 |
+| Demo Video | Screenshots |
 |:---:|:---:|
-| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **接入服务**<br><img width="372" height="113" alt="截屏2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**查看服务列表**<br><img width="379" height="406" alt="截屏2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**服务结果返回**<br><img width="371" height="391" alt="截屏2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
+| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **Connect Service**<br><img width="372" height="113" alt="Screenshot 2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**View Service List**<br><img width="379" height="406" alt="Screenshot 2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**Service Result Returned**<br><img width="371" height="391" alt="Screenshot 2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
 ---
 
-### 📄 论文
+### 📄 Paper
 
-技术设计与实现细节详见：[arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
+Technical design and implementation details: [arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
 
 ---
 
-## 四大核心主张
+## Four Core Propositions
 
-### 数据原位驻留，能力跨节点流动
+### Data Stays In Situ, Capabilities Flow Across Nodes
 
-数据孤岛的真正解决方式，不是把数据搬在一起，而是让分析能力走到数据身边。每个实验室沉淀的数据集、算法流程与领域经验，通过网络化封装成为 Agent 可直接调用的能力单元。Agent 无需预先掌握特定领域的全部知识，只需发现、编排、调用全球节点的服务，即可在材料科学、生物医学、天文观测等垂直领域不断扩展知识边界。
+The real solution to data silos is not moving all the data into one place — it is bringing analytical capabilities to where the data lives. Every lab's accumulated datasets, algorithmic workflows, and domain expertise become composable capability units that any Agent can directly invoke. Agents need not master the full depth of a field in advance; they simply discover, orchestrate, and invoke services from nodes around the world, continuously expanding their knowledge boundaries across materials science, biomedicine, astronomy, and beyond.
 
-### 原生数据零迁移，规避迁移损耗
+### Zero Data Migration, Eliminating Migration Loss
 
-传统方案要求数据汇聚到中心化平台，这不可避免地带来格式转换失真、元数据丢失、版本分叉、合规审计链断裂等问题。OpenAaaS 不建立统一的数据仓库，数据始终保留在产生它的位置，维持最初的存储格式、目录结构与访问权限。分析任务以代码和指令的形式远程到达，结果回传，原始数据从未离开本地。
+Traditional solutions demand that data be aggregated into a centralized platform — inevitably introducing format conversion distortion, metadata loss, version divergence, and broken compliance audit chains. OpenAaaS builds no unified data warehouse. Data remains at its point of origin, preserved in its original storage format, directory structure, and access permissions. Analysis tasks arrive remotely as code and instructions; results are sent back. Raw data never leaves.
 
-### 免规范化接入，原生格式即服务能力
+### Schema-Free Onboarding, Raw Format as Service Capability
 
-我们不对数据提出任何前置的格式要求。JSON、CSV、Excel、MATLAB `.mat`、HDF5、仪器厂商的专有二进制格式——节点本地的解析与处理脚本本身就是网络能力的一部分。Agent 调用的是"解析+分析"的组合服务，而非要求数据预先被清洗、标准化、结构化。实验室现有的任意数据，接入即服务。
+We impose no upfront format requirements on data. JSON, CSV, Excel, MATLAB `.mat`, HDF5, vendor-specific binary formats from instruments — the local parsing and processing scripts on each node are themselves part of the network's capability. Agents invoke a combined "parse + analyze" service, rather than being required to pre-clean, standardize, or structure the data. Whatever format a lab already has, it is service-ready from day one.
 
-### 近数据端计算，调用开销趋近于零
+### Near-Data Computing, Data-Movement Cost Approaches Zero
 
-计算发生在数据旁边，而非数据被搬运到计算中心。网络仅传输任务描述与执行结果（KB~MB 级），原始数据就地处理。对于 TB 级数据集和受监管敏感样本，这意味着无需等待上传、无需突破带宽瓶颈、无需面临出域合规审查——数据移动的边际成本趋近于零。
+Computation happens next to the data, not the other way around. The network only transmits task descriptions and execution results (KB–MB scale); raw data is processed on-site. For TB-scale datasets and regulated sensitive samples, this means no upload wait, no bandwidth bottleneck, and no outbound compliance review — the marginal cost of moving data approaches zero.
 
-## 核心设计理念
+## Core Design Philosophy
 
-传统云端方案要求数据离开本地：TB 级数据集必须迁移上传，敏感样本交给第三方，实验室防火墙被迫开放入站端口。OpenAaaS 反其道而行——将 Agent 执行节点直接部署在数据本地，网络只传输任务描述、任务文件及结果，原始数据原地不动。
+Traditional cloud solutions require data to leave the premises: TB-scale datasets must be migrated and uploaded, sensitive samples are handed to third parties, and lab firewalls are forced to open inbound ports. OpenAaaS takes the opposite approach — deploying Agent execution nodes directly where the data resides. The network only transmits task descriptions, task files, and results; raw data stays in place.
 
-| | 传统云端方案 | OpenAaaS 近数据端方案 |
+| | Traditional Cloud Solution | OpenAaaS Near-Data Solution |
 |---|---|---|
-| 数据流向 | 本地 → 云端 → 本地 | **原始数据原地不动** |
-| 网络传输 | 原始数据（TB 级） | 任务描述、任务文件及结果（KB~MB 级） |
-| 防火墙要求 | 需开放入站端口 | **仅出站 HTTP 即可** |
-| 敏感数据 | 必须出域 | **不出实验室** |
-| 延迟 | 受带宽限制 | 本地计算，极低延迟 |
+| Data Flow | Local → Cloud → Local | **Raw data stays in place** |
+| Network Transfer | Raw data (TB scale) | Task descriptions, task files, and results (KB–MB scale) |
+| Firewall Requirements | Inbound ports required | **Outbound HTTP only** |
+| Sensitive Data | Must leave the domain | **Never leaves the lab** |
+| Latency | Bandwidth-limited | Local compute, extremely low latency |
 
-## 架构
+## Architecture
 
 ```
-客户端 Agent
-(pi mono / Claude Code / Kimi Cli / Cline / 自研 Agent)
+Client Agent
+(pi mono / Claude Code / Kimi Cli / Cline / Custom Agent)
         ▲
-        │ 控制流：任务描述、心跳、结果（KB 级）
+        │ Control flow: task description, heartbeat, results (KB scale)
         ▼
 ───────────────────────────────────────────────────────────────────
-OpenAaaS Server（网络枢纽）
-Rust + SQLite — 轻量索引层
-  • 服务注册  • 任务路由  • 节点心跳  • 文件中转
+OpenAaaS Server (Network Hub)
+Rust + SQLite — Lightweight indexing layer
+  • Service registration  • Task routing  • Node heartbeat  • File relay
         ▲
-        │ 短轮询（单向出站 HTTP）
+        │ Short polling (unidirectional outbound HTTP)
         ▼
 ───────────────────────────────────────────────────────────────────
-Agent Core（网络节点）
-Rust + Docker — 部署在数据本地
-  • 向网络注册能力  • 轮询认领任务  • 容器沙箱隔离执行  • 上报结果
+Agent Core (Network Node)
+Rust + Docker — Deployed locally where data resides
+  • Register capabilities to the network  • Poll for tasks
+  • Container sandbox isolation execution  • Report results
         │              │                   │
         ▼              ▼                   ▼
-   [本地数据集]    [分析脚本]         [专用硬件]
-    （TB 级）      （算法/模型）        （GPU/仪器）
+   [Local Dataset]  [Analysis Scripts]  [Specialized Hardware]
+    (TB scale)      (Algorithms/Models)  (GPU/Instruments)
 ```
 
-| 层级 | 组件 | 职责 |
+| Layer | Component | Responsibility |
 |------|------|------|
-| 客户端 Agent | pi mono / Kimi Cli / Codex / Open Code / 自研 Agent | 理解任务、发现网络节点、调度远端能力、整合结果 |
-| 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 服务注册、任务路由、节点心跳、文件中转 |
-| 网络节点 | agent-core — 能力执行节点 + Docker | 向网络注册自身能力、轮询认领任务、在沙箱中隔离执行、上报结果 |
+| Client Agent | pi mono / Kimi Cli / Codex / Open Code / Custom Agent | Understand tasks, discover network nodes, schedule remote capabilities, integrate results |
+| Network Hub | Server — Capability registration and scheduling center (Rust + SQLite) | Service registration, task routing, node heartbeat, file relay |
+| Network Node | agent-core — Capability execution node + Docker | Register capabilities to the network, poll for tasks, execute in sandbox isolation, report results |
 
-## 设计思路
+## Design Rationale
 
-| 原则 | 说明 | 效果 |
+| Principle | Description | Effect |
 |------|------|------|
-| Rust + 单二进制 | `cargo build --release` 得到一个可执行文件 | 零依赖部署，复制即用 |
-| SQLite 嵌入式 | 数据库随进程启动，无单独服务 | 零运维，单节点足够 |
-| Docker 隔离 | 每个任务独立容器，workspace 挂载 | 安全可控，环境可复现 |
-| 节点自组网 | 节点主动向网络注册并轮询任务，Server 仅维护索引。原始数据不出域，任务文件经 Server 流转 | 节点无需公网 IP，单向出站即可加入网络；数据原地处理，天然适应实验室防火墙环境 |
+| Rust + Single Binary | `cargo build --release` produces one executable | Zero-dependency deployment, copy and run |
+| Embedded SQLite | Database starts with the process, no separate service | Zero operations, single node is sufficient |
+| Docker Isolation | Each task runs in an independent container with workspace mounted | Secure and controllable, reproducible environment |
+| Self-Organizing Nodes | Nodes actively register with the network and poll for tasks; Server only maintains an index. Raw data never leaves the domain; task files flow through the Server | Nodes need no public IP; unidirectional outbound is enough to join the network; data is processed on-site, naturally adapting to lab firewall environments |
 
-## 特性
+## Features
 
-### 数据原位驻留与能力跨节点流动
+### Data In-Situ Retention & Cross-Node Capability Flow
 
-- **🔌 Agent 零学习成本接入，自描述 API 自动暴露服务文档** — 无需认证，返回完整 API 文档和使用说明。Agent 无需插件即可理解并调用全部科研服务。
-- **🧩 渐进式能力发现，避免上下文溢出** — 初次查询返回轻量摘要，再按需返回详细用法。类似 SKILL.md 的渐进式披露设计，保护 Agent 的上下文窗口。
+- **🔌 Zero-Learning-Cost Agent Integration, Self-Describing API Auto-Exposes Service Docs** — No authentication required; returns complete API documentation and usage instructions. Agents can understand and invoke all scientific services without any plugins.
+- **🧩 Progressive Capability Discovery, Avoiding Context Overflow** — Initial queries return lightweight summaries; detailed usage is returned on demand. A progressive disclosure design similar to SKILL.md protects the Agent's context window.
 
-### 原生数据零迁移
+### Zero Data Migration
 
-- **🔒 数据不出域** — Agent 执行节点直接部署在实验室服务器或仪器工作站上，原始大数据集通过本地挂载原地处理，敏感数据不离开防火墙。网络只传输任务描述、任务文件及结果，不触碰原始数据。
-- **💾 单二进制零运维** — SQLite 数据库 + 本地文件存储，无需 Redis/MySQL。单节点即可部署，适合实验室边缘节点。
-- **⚖️ 节点反向入网，不需要公网 IP** — 节点自行控制并发和任务认领，Server 只做轻量队列管理。实验室节点只需要单向出站即可接入，无需开放端口或 SSH。
+- **🔒 Data Never Leaves the Premises** — Agent execution nodes are deployed directly on lab servers or instrument workstations. Raw large datasets are processed in-place via local mounts; sensitive data never crosses the firewall. The network only transmits task descriptions, task files, and results; it never touches raw data.
+- **💾 Single Binary, Zero Operations** — SQLite database + local file storage; no Redis/MySQL required. A single node is enough for deployment, ideal for lab edge nodes.
+- **⚖️ Nodes Join via Reverse Connection, No Public IP Needed** — Nodes self-manage concurrency and task claiming; Server only does lightweight queue management. Lab nodes only need unidirectional outbound access to join; no open ports or SSH required.
 
-### 免规范化接入与近数据端计算
+### Schema-Free Onboarding & Near-Data Computing
 
-- **🐳 每个实验任务独立沙箱，结果可复现** — 每个任务在独立容器中运行，通过 workspace 挂载实现输入输出。环境隔离，结果可追溯、可复现。
-- **🔧 节点零配置入网** — `open-aaas-server run` 首次启动自动生成 `config.toml`、SQLite 数据库、密钥。无需手动配置，开箱即用。
-- **🤖 MCP 标准协议兼容** — 通过 `openaaas-mcp-adapter`，Claude Desktop、Cursor、Cline 等任意支持 MCP 的客户端均可一键接入，无需编写插件。
+- **🐳 Independent Sandbox per Experiment, Reproducible Results** — Each task runs in an isolated container with workspace mounts for input and output. Environment isolation makes results traceable and reproducible.
+- **🔧 Zero-Config Node Onboarding** — `open-aaas-server run` auto-generates `config.toml`, SQLite database, and keys on first launch. No manual configuration; ready to use out of the box.
+- **🤖 MCP Standard Protocol Compatible** — Through `openaaas-mcp-adapter`, any MCP-compatible client such as Claude Desktop, Cursor, or Cline can connect with one click, without writing any plugins.
 
-## 使用
+## Usage
 
-公共服务器：**<https://api.open-aaas.com>**
+Public Server: **<https://api.open-aaas.com>**
 
-我们在公共服务器中提供了三项试用的科研服务：
+We provide three trial scientific services on the public server:
 
-- 基于数十万真实文献的 IDM-Alpha 金属材料文献研究助手
-- 万亿规模六元高熵合金描述符数据库
-- 扶摇智能体圆桌会议系统
+- IDM-Alpha Metal Materials Literature Research Assistant Based on Hundreds of Thousands of Real Papers
+- Trillion-Scale Hexa-High-Entropy Alloy Descriptor Database
+- Fuyao Multi-Agent Roundtable System
 
-可以让 Agent 接入公共服务器使用
+You can have your Agent connect to the public server to use them.
 
-### 快速开始
+### Quick Start
 
-**场景一：使用公共服务器**
+**Scenario 1: Use the Public Server**
 
-无需自建基础设施，直接配置你的 Agent 接入公共服务器，即可调用社区共享的科研服务。适合个人研究者快速接入。
+No need to build your own infrastructure. Simply configure your Agent to connect to the public server and start invoking community-shared scientific services. Ideal for individual researchers to get started quickly.
 
-### 用 pi / kimi 插件
+### Using the pi / Kimi Plugin
 
-在对话中直接说：
+Just say in the conversation:
 
-> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后提交一个数据分析任务"
+> "Help me set the OpenAaaS server address to <https://api.open-aaas.com>, then submit a data analysis task"
 
-客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
+The client Agent will automatically complete registration, service discovery, task submission, and result retrieval.
 
 <video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
 
-### 用 MCP 客户端
+### Using an MCP Client
 
-`openaaas-mcp-adapter` 已发布至 PyPI。如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。
+`openaaas-mcp-adapter` is available on PyPI. If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.
 
 ```json
 {
@@ -191,47 +192,47 @@ Rust + Docker — 部署在数据本地
 }
 ```
 
-配置后重启客户端，即可在对话中调用 OpenAaaS 的 14 个标准 Tool（`set_server_url`、`register`、`list_services`、`submit_task` 等），无需安装任何插件。
+After configuring, restart the client, and you can invoke OpenAaaS's 14 standard Tools (`set_server_url`, `register`, `list_services`, `submit_task`, etc.) directly in conversation without installing any plugins.
 
-甚至，你可以直接让你的Agent帮你配置。
+Or better yet, you can have your Agent set it up for you directly.
 
 <p align="center">
   <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
 </p>
 
-详见 [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md)。
+See [client-extension/openaaas-mcp-adapter/README.zh.md](./client-extension/openaaas-mcp-adapter/README.zh.md) for details.
 
-### 用桌面客户端
+### Using the Desktop Client
 
-如果你偏好图形界面操作，可以使用 **OpenAaaS 桌面客户端**——一个基于 Tauri 的跨平台桌面应用，支持 macOS、Windows 和 Linux。
+If you prefer a graphical interface, use the **OpenAaaS Desktop Client** — a cross-platform desktop application based on Tauri, supporting macOS, Windows, and Linux.
 
-桌面客户端适合：
-- 不想配置命令行或插件的非技术用户
-- 需要管理多个服务器并直观浏览服务的场景
-- 希望拖拽上传文件、实时查看任务进度的用户
+The desktop client is ideal for:
+- Non-technical users who don't want to configure command-line tools or plugins
+- Managing multiple servers and browsing services visually
+- Drag-and-drop file uploads and real-time task progress tracking
 
-📖 详见 [client-app/README.md](./client-app/README.md)
+📖 See [client-app/README.zh.md](./client-app/README.zh.md) for details.
 
 <p align="center">
   <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
 </p>
 
-> macOS 用户请注意：应用使用 ad-hoc 自签名，首次打开时前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"即可。
+> macOS users: The app is ad-hoc signed. On first launch, go to **System Settings → Privacy & Security → Security** and click **"Open Anyway"**.
 
-### 用通用 Agent 框架
+### Using a General Agent Framework
 
-如果你的 Agent 没有 OpenAaaS 插件，让 Agent 直接访问 <https://api.open-aaas.com>
+If your Agent does not have an OpenAaaS plugin, simply have it access <https://api.open-aaas.com>:
 
-- 无需认证，返回完整 API 文档和使用说明
-- Agent 读取后即可自动完成注册、服务发现、任务提交
+- No authentication required; complete API documentation and usage instructions are returned
+- The Agent can then automatically complete registration, service discovery, and task submission after reading them
 
-**场景二：部署在实验室服务器，接入本地能力**
+**Scenario 2: Deploy on a Lab Server and Connect Local Capabilities**
 
-在机房或实验室的本地服务器上启动 OpenAaaS，将本地分析脚本、专用计算流程注册为网络节点。课题组内的任何 Agent——pi、Kimi、Claude 或自研系统——都能通过统一入口查询节点状态、提交分析任务、获取结果数据。
+Launch OpenAaaS on a local server in your machine room or lab, and register local analysis scripts and specialized computing workflows as network nodes. Any Agent in the research group — pi, Kimi, Claude, or a self-built system — can query node status, submit analysis tasks, and retrieve result data through a unified entry point.
 
-### 本地部署
+### Local Deployment
 
-**部署 Server（调度中心）**：
+**Deploy Server (Scheduling Center)**:
 
 ```bash
 cd server
@@ -239,9 +240,9 @@ cargo build --release
 ./target/release/open-aaas-server run
 ```
 
-首次启动自动生成 `config.toml`和 SQLite 数据库。
+On first launch, `config.toml` and the SQLite database are auto-generated.
 
-**部署 Agent Core（执行节点）**：
+**Deploy Agent Core (Execution Node)**:
 
 ```bash
 cd agent-core
@@ -251,34 +252,34 @@ cargo build --release
 ./target/release/agent-core run
 ```
 
-`registration_token` 需要先在 Server 上创建 Service 获取。Admin 可使用 Server 日志中的 API Key 调用 `POST /api/v1/services/` 创建。
+The `registration_token` must be obtained by creating a Service on the Server first. Admins can use the API Key from the Server logs to call `POST /api/v1/services/` to create one.
 
-Agent 执行器镜像需要提前构建（在 agent-core 目录下）：
+The Agent executor image needs to be built in advance (under the agent-core directory):
 
 ```bash
 cd executor-example && docker build -t open-aaas-executor:latest .
 ```
 
-详见 [agent-core/README.md](./agent-core/README.md)
+See [agent-core/README.zh.md](./agent-core/README.zh.md) for details.
 
-## 项目结构
+## Project Structure
 
 ```
 OpenAaaS/
-├── server/           # 网络枢纽（调度中心） (Rust) — 任务调度、队列、鉴权、文件中转
-├── agent-core/       # 网络节点（执行节点） (Rust) — 注册、轮询、Docker 隔离执行
-├── client-app/       # 桌面客户端 (Tauri + Vue 3) — 服务市场、任务提交、结果查看
-├── dash/             # 调试与管理员工具 (Python/Streamlit)
-└── client-extension/ # 客户端扩展 — pi 插件、kimi 插件、MCP 适配器（Claude Desktop / Cursor / Cline）
+├── server/           # Network Hub (Scheduling Center) (Rust) — Task scheduling, queuing, auth, file relay
+├── agent-core/       # Network Node (Execution Node) (Rust) — Registration, polling, Docker-isolated execution
+├── client-app/       # Desktop Client (Tauri + Vue 3) — Service marketplace, task submission, result viewing
+├── dash/             # Debug and admin tools (Python/Streamlit)
+└── client-extension/ # Client extensions — pi plugin, Kimi plugin, MCP adapter (Claude Desktop / Cursor / Cline)
 ```
 
-## 科研愿景
+## Research Vision
 
-OpenAaaS 的愿景是让每个实验室都成为 Agentic Science 网络中的一个可组合节点。数据不再因迁移而损耗，知识不再因孤岛而停滞。每个课题组沉淀的数据形态、分析流程与领域方法——无论其存储格式多么独特——都可以通过网络被任意 Agent 发现、调用与编排。
+OpenAaaS's vision is to make every lab a composable node in the Agentic Science network. Data is no longer degraded by migration, and knowledge is no longer stalled by silos. Every research group's data morphology, analysis workflows, and domain methods — however unique their storage formats may be — can be discovered, invoked, and orchestrated by any Agent across the network.
 
-当分析能力能够流动到数据身边，Agent 的知识边界将从单个实验室的闭环，扩展到全球协作的开放生态。数据移动的边际成本趋近于零，意味着任意规模的 Dataset 都可以被任意位置的 Agent 即时调用。科研创新的边界，不再受限于单个团队的数据规模或领域深度。
+When analytical capabilities can flow to where data lives, the knowledge boundary of an Agent expands from the closed loop of a single lab to an open ecosystem of global collaboration. The marginal cost of moving data approaches zero, meaning datasets of any scale can be invoked on demand by Agents anywhere. The frontier of scientific innovation is no longer limited by a single team's data volume or domain depth.
 
-## 开源许可
+## Open Source License
 
 MIT License © IDM Explorer Lab
 

--- a/agent-core/README.md
+++ b/agent-core/README.md
@@ -2,208 +2,208 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-The Agent scheduler for OpenAaaS, responsible for registering with the Server, polling for tasks, and executing tasks in isolated Docker containers.
+OpenAaaS 的 Agent 调度器，负责向 Server 注册、轮询获取任务，并通过 Docker 容器隔离执行任务。
 
-## Build & Install
+## 编译安装
 
-Requires Rust toolchain (1.85+) and Docker:
+需要安装 Rust 工具链（1.85+）和 Docker：
 
 ```bash
 cd agent-core
 cargo build --release
 ```
 
-The compiled binary is located at `target/release/agent-core`.
+编译产物为 `target/release/agent-core`。
 
-## Executor Image
+## 执行器镜像
 
-Agent Core executes tasks in isolated Docker containers, so a Docker image must be prepared in advance as the executor.
+Agent Core 通过 Docker 容器隔离执行任务，因此需要提前准备一个 Docker 镜像作为执行器。
 
-The interaction contract is simple: **Agent Core mounts `task.json` and input files into the container, and the container writes result files to the workspace after execution**. Agent Core does not care how the container is implemented internally, as long as this protocol is satisfied.
+交互契约很简单：**Agent Core 把 `task.json` 和输入文件挂进容器，容器执行完把结果文件写到 workspace**。Agent Core 不关心容器内部怎么实现，只要满足这个协议即可。
 
-The `executor-example/` directory provides a **sample image** (based on node + python3, using pi-coding-agent as the execution logic) to demonstrate this interaction process. You can modify it directly or build your own image from scratch. See `executor-example/README.md` for details.
+`executor-example/` 目录提供了一个**示例镜像**（基于 node + python3，恰好用 pi-coding-agent 作为执行逻辑），用来演示这个交互过程。你可以直接基于它修改，也可以完全从零构建自己的镜像。详见 `executor-example/README.md`。
 
-Build the sample image:
+构建示例镜像：
 
 ```bash
 cd executor-example
 docker build -t open-aaas-executor:latest .
 ```
 
-> The image name must match `executor.image` in `config.toml` (default value is `open-aaas-executor:latest`).
+> 镜像名需要与 `config.toml` 中的 `executor.image` 保持一致（默认值为 `open-aaas-executor:latest`）。
 
-### How It Works
+### 工作原理
 
-1. Agent Core polls the Server for tasks.
-2. Creates a local workspace directory for the task, writes `task.json`, and downloads input files to `input/`.
-3. Starts a container via `docker run`, mounting the workspace to `/workspace` in the container.
-4. The container reads `/workspace/task.json`, executes the task, and writes result files to the workspace.
-5. After the container exits, Agent Core scans files in the workspace (excluding `task.json` and `input/`) and reports them as outputs to the Server.
+1. Agent Core 从 Server 轮询获取任务。
+2. 在本地为任务创建 workspace 目录，写入 `task.json`，下载输入文件到 `input/`。
+3. 通过 `docker run` 启动容器，挂载 workspace 到容器的 `/workspace`。
+4. 容器读取 `/workspace/task.json`，执行任务，将结果文件写入 workspace。
+5. 容器退出后，Agent Core 扫描 workspace 下文件（排除 `task.json` 和 `input/`），作为输出上报 Server。
 
-## Command Usage
+## 命令用法
 
 ```bash
 agent-core [OPTIONS] <COMMAND>
 ```
 
-### Global Options
+### 全局选项
 
-| Option | Description |
-|--------|-------------|
-| `--config <FILE>` | Specify the configuration file path; defaults to `config.toml` in the current directory |
+| 选项 | 说明 |
+|------|------|
+| `--config <FILE>` | 指定配置文件路径，默认读取当前目录的 `config.toml` |
 
-### Subcommands
+### 子命令
 
-| Command | Description |
-|---------|-------------|
-| `init` | Generate a default `config.toml` in the current directory |
-| `register --token <TOKEN> [--name <NAME>]` | Register with the Server to obtain `service_id` and `api_key` |
-| `run [--interactive]` | Run the scheduler in the foreground. `--interactive` enters interactive registration if not yet registered |
-| `run-detached` | Run the scheduler in the background |
-| `stop` | Stop the background scheduler |
-| `status` | Check the scheduler status |
+| 命令 | 说明 |
+|------|------|
+| `init` | 在当前目录生成默认 `config.toml` |
+| `register --token <TOKEN> [--name <NAME>]` | 向 Server 注册，获取 service_id 和 api_key |
+| `run [--interactive]` | 前台运行调度器。`--interactive` 表示未注册时进入交互式注册 |
+| `run-detached` | 后台运行调度器 |
+| `stop` | 停止后台调度器 |
+| `status` | 查看调度器状态 |
 
-## First-Time Setup
+## 首次使用
 
-### 1. Initialize Configuration
+### 1. 初始化配置
 
 ```bash
 ./agent-core init
 ```
 
-Generates a default `config.toml` in the current directory.
+在当前目录生成默认 `config.toml`。
 
-### 2. Edit Configuration
+### 2. 编辑配置
 
-Open `config.toml` and modify the Server address:
+打开 `config.toml`，修改 Server 地址：
 
 ```toml
 [server]
-base_url = "http://127.0.0.1:8080"  # Change to your Server address
+base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ```
 
-### 3. Register
+### 3. 注册
 
-Obtain a registration token from the Server, then run:
+从 Server 获取注册 token 后执行：
 
 ```bash
 ./agent-core register --token rt_xxx --name my-agent
 ```
 
-After successful registration, `service_id` and `api_key` will be automatically written to `config.toml`.
+注册成功后，`service_id` 和 `api_key` 会自动写入 `config.toml`。
 
-### 4. Run
+### 4. 运行
 
-Run in the foreground:
-
-```bash
-./agent-core run
-```
-
-On the first startup, it will interactively confirm the Server URL and data directory (default `./data`), then start polling for tasks.
-
-If the current directory already has a complete configuration and is registered, it will start directly without prompting.
-
-## Foreground Run
+前台运行：
 
 ```bash
 ./agent-core run
 ```
 
-After starting, it polls the Server for tasks, sends heartbeats, and runs tasks through the Docker executor. Press `Ctrl+C` or send `SIGTERM` for graceful shutdown.
+首次启动会交互式确认 Server URL 和数据目录（默认 `./data`），随后开始轮询任务。
 
-If not yet registered and with `--interactive`, it will interactively ask for the token and complete registration:
+如果当前目录已有完整配置且已注册，会直接启动，不再询问。
+
+## 前台运行
+
+```bash
+./agent-core run
+```
+
+启动后向 Server 轮询获取任务、发送心跳，并通过 Docker 执行器运行任务。按 `Ctrl+C` 或发送 `SIGTERM` 可优雅关闭。
+
+未注册且带有 `--interactive` 时，会交互式询问 token 并完成注册：
 
 ```bash
 ./agent-core run --interactive
 ```
 
-## Background Run
+## 后台运行
 
 ```bash
 ./agent-core run-detached
 ```
 
-- Linux/macOS: Runs in the background via `nohup`, logs output to `{data_dir}/agent.log`
-- Windows: Runs in the background via `cmd /C start /B`
+- Linux/macOS：通过 `nohup` 后台运行，日志输出到 `{data_dir}/agent.log`
+- Windows：通过 `cmd /C start /B` 后台运行
 
-After background startup, a pidfile is written for subsequent management and status queries.
+后台启动后会写入 pidfile，用于后续管理和状态查询。
 
-## Check Status
+## 查看状态
 
 ```bash
 ./agent-core status
 ```
 
-Example output:
+输出示例：
 
 ```
-OpenAaaS Agent Status
+OpenAaaS Agent 状态
 ====================
-Config file: /path/to/config.toml
-Data directory: /path/to/data
+配置文件: /path/to/config.toml
+数据目录: /path/to/data
 
 Server URL: http://127.0.0.1:8080
-Poll interval: 5 seconds
+轮询间隔: 5 秒
 
-Registration status: Registered
+注册状态: 已注册
 Service ID: svc_xxx
-Agent name: my-agent
+Agent 名称: my-agent
 
-Executor configuration:
-  Image: open-aaas-executor:latest
-  Capacity: 2
-  Timeout: 0 minutes
+执行器配置:
+  镜像: open-aaas-executor:latest
+  容量: 2
+  超时: 0 分钟
 ```
 
-## Stop Service
+## 停止服务
 
 ```bash
 ./agent-core stop
 ```
 
-Sends `SIGTERM` to the background process, waiting up to 5 seconds for graceful exit; if timed out, sends `SIGKILL` to force termination and cleans up the pidfile.
+向后台进程发送 `SIGTERM`，等待最多 5 秒优雅退出；超时则发送 `SIGKILL` 强制终止，并清理 pidfile。
 
-## Configuration File Reference
+## 配置文件说明
 
-Complete `config.toml` example:
+`config.toml` 完整示例：
 
 ```toml
 [server]
-base_url = "http://127.0.0.1:8080"  # Server address
-poll_interval_secs = 5               # Polling interval (seconds)
-use_system_proxy = false             # Whether to use system proxy
+base_url = "http://127.0.0.1:8080"  # Server 地址
+poll_interval_secs = 5               # 轮询间隔（秒）
+use_system_proxy = false             # 是否使用系统代理
 
 [agent]
-service_id = "svc-xxx"               # Auto-filled after registration
-api_key = "ak_xxx"                   # Auto-filled after registration
-name = "agent-core"                  # Agent name
+service_id = "svc-xxx"               # 注册后自动填充
+api_key = "ak_xxx"                   # 注册后自动填充
+name = "agent-core"                  # Agent 名称
 
 [executor]
-executor_type = "standard"           # Executor type: standard / bash / python / custom
-image = "open-aaas-executor:latest"  # Docker image
-capacity = 2                         # Concurrent task count
-timeout_minutes = 0                  # Task timeout (minutes), 0 means unlimited
-# memory_limit = "4g"                # Memory limit (optional)
-working_dir = "/workspace"           # Working directory inside the container
-# script_path = "/workspace/run.sh"  # Script path (for bash/python type)
-custom_entrypoint = ["/bin/sh"]      # Custom ENTRYPOINT (custom type)
-custom_args = ["-c", "echo hi"]      # Custom arguments (custom type)
+executor_type = "standard"           # 执行器类型：standard / bash / python / custom
+image = "open-aaas-executor:latest"  # Docker 镜像
+capacity = 2                         # 并发任务数
+timeout_minutes = 0                  # 任务超时（分钟），0 表示不限制
+# memory_limit = "4g"                # 内存限制（可选）
+working_dir = "/workspace"           # 容器内工作目录
+# script_path = "/workspace/run.sh"  # 脚本路径（bash/python 类型用）
+custom_entrypoint = ["/bin/sh"]      # 自定义 ENTRYPOINT（custom 类型）
+custom_args = ["-c", "echo hi"]      # 自定义参数（custom 类型）
 
 [paths]
-data_dir = "./data"                  # Data directory
+data_dir = "./data"                  # 数据目录
 
 [[paths.mounts]]
-host = "./share/kimi-config"         # Host path (relative or absolute)
-container = "/shared/kimi-config"    # Container path
-readonly = true                      # Read-only
+host = "./share/kimi-config"         # 宿主机路径（相对或绝对）
+container = "/shared/kimi-config"    # 容器内路径
+readonly = true                      # 是否只读
 ```
 
-### Configuration Items
+### 配置项说明
 
-- **server**: Configuration related to connecting to the Server; `base_url` is required.
-- **agent**: `service_id` and `api_key` are auto-filled by the `register` command; no need to fill manually.
-- **executor**: Task executor configuration. `executor_type` supports `standard` (container default ENTRYPOINT), `bash`, `python`, `custom`; `capacity` controls the number of concurrent tasks.
-- **paths**: `data_dir` stores logs and runtime data. `[[paths.mounts]]` defines additional directories mounted into the executor container, commonly used for mounting configuration files or shared data.
+- **server**: 连接 Server 的相关配置，`base_url` 必填。
+- **agent**: `service_id` 和 `api_key` 由 `register` 命令自动填充，无需手动填写。
+- **executor**: 任务执行器配置。`executor_type` 支持 `standard`（容器默认 ENTRYPOINT）、`bash`、`python`、`custom`；`capacity` 控制并发任务数。
+- **paths**: `data_dir` 存放日志和运行时数据。`[[paths.mounts]]` 定义额外挂载到执行器容器的目录，常用于挂载配置文件或共享数据。
 
-After the first run, most configurations do not need to be modified manually. If adjustments are needed, simply edit `config.toml` and restart.
+首次运行后无需手动修改大部分配置。若需调整，直接编辑 `config.toml` 后重启即可。

--- a/agent-core/README.zh.md
+++ b/agent-core/README.zh.md
@@ -1,209 +1,209 @@
 # OpenAaaS Agent Core
 
-<p align="right">中文 | <a href="./README.md">English</a></p>
+<p align="right"><a href="./README.md">English</a> | 中文</p>
 
-OpenAaaS 的 Agent 调度器，负责向 Server 注册、轮询获取任务，并通过 Docker 容器隔离执行任务。
+The Agent scheduler for OpenAaaS, responsible for registering with the Server, polling for tasks, and executing tasks in isolated Docker containers.
 
-## 编译安装
+## Build & Install
 
-需要安装 Rust 工具链（1.85+）和 Docker：
+Requires Rust toolchain (1.85+) and Docker:
 
 ```bash
 cd agent-core
 cargo build --release
 ```
 
-编译产物为 `target/release/agent-core`。
+The compiled binary is located at `target/release/agent-core`.
 
-## 执行器镜像
+## Executor Image
 
-Agent Core 通过 Docker 容器隔离执行任务，因此需要提前准备一个 Docker 镜像作为执行器。
+Agent Core executes tasks in isolated Docker containers, so a Docker image must be prepared in advance as the executor.
 
-交互契约很简单：**Agent Core 把 `task.json` 和输入文件挂进容器，容器执行完把结果文件写到 workspace**。Agent Core 不关心容器内部怎么实现，只要满足这个协议即可。
+The interaction contract is simple: **Agent Core mounts `task.json` and input files into the container, and the container writes result files to the workspace after execution**. Agent Core does not care how the container is implemented internally, as long as this protocol is satisfied.
 
-`executor-example/` 目录提供了一个**示例镜像**（基于 node + python3，恰好用 pi-coding-agent 作为执行逻辑），用来演示这个交互过程。你可以直接基于它修改，也可以完全从零构建自己的镜像。详见 `executor-example/README.md`。
+The `executor-example/` directory provides a **sample image** (based on node + python3, using pi-coding-agent as the execution logic) to demonstrate this interaction process. You can modify it directly or build your own image from scratch. See `executor-example/README.zh.md` for details.
 
-构建示例镜像：
+Build the sample image:
 
 ```bash
 cd executor-example
 docker build -t open-aaas-executor:latest .
 ```
 
-> 镜像名需要与 `config.toml` 中的 `executor.image` 保持一致（默认值为 `open-aaas-executor:latest`）。
+> The image name must match `executor.image` in `config.toml` (default value is `open-aaas-executor:latest`).
 
-### 工作原理
+### How It Works
 
-1. Agent Core 从 Server 轮询获取任务。
-2. 在本地为任务创建 workspace 目录，写入 `task.json`，下载输入文件到 `input/`。
-3. 通过 `docker run` 启动容器，挂载 workspace 到容器的 `/workspace`。
-4. 容器读取 `/workspace/task.json`，执行任务，将结果文件写入 workspace。
-5. 容器退出后，Agent Core 扫描 workspace 下文件（排除 `task.json` 和 `input/`），作为输出上报 Server。
+1. Agent Core polls the Server for tasks.
+2. Creates a local workspace directory for the task, writes `task.json`, and downloads input files to `input/`.
+3. Starts a container via `docker run`, mounting the workspace to `/workspace` in the container.
+4. The container reads `/workspace/task.json`, executes the task, and writes result files to the workspace.
+5. After the container exits, Agent Core scans files in the workspace (excluding `task.json` and `input/`) and reports them as outputs to the Server.
 
-## 命令用法
+## Command Usage
 
 ```bash
 agent-core [OPTIONS] <COMMAND>
 ```
 
-### 全局选项
+### Global Options
 
-| 选项 | 说明 |
-|------|------|
-| `--config <FILE>` | 指定配置文件路径，默认读取当前目录的 `config.toml` |
+| Option | Description |
+|--------|-------------|
+| `--config <FILE>` | Specify the configuration file path; defaults to `config.toml` in the current directory |
 
-### 子命令
+### Subcommands
 
-| 命令 | 说明 |
-|------|------|
-| `init` | 在当前目录生成默认 `config.toml` |
-| `register --token <TOKEN> [--name <NAME>]` | 向 Server 注册，获取 service_id 和 api_key |
-| `run [--interactive]` | 前台运行调度器。`--interactive` 表示未注册时进入交互式注册 |
-| `run-detached` | 后台运行调度器 |
-| `stop` | 停止后台调度器 |
-| `status` | 查看调度器状态 |
+| Command | Description |
+|---------|-------------|
+| `init` | Generate a default `config.toml` in the current directory |
+| `register --token <TOKEN> [--name <NAME>]` | Register with the Server to obtain `service_id` and `api_key` |
+| `run [--interactive]` | Run the scheduler in the foreground. `--interactive` enters interactive registration if not yet registered |
+| `run-detached` | Run the scheduler in the background |
+| `stop` | Stop the background scheduler |
+| `status` | Check the scheduler status |
 
-## 首次使用
+## First-Time Setup
 
-### 1. 初始化配置
+### 1. Initialize Configuration
 
 ```bash
 ./agent-core init
 ```
 
-在当前目录生成默认 `config.toml`。
+Generates a default `config.toml` in the current directory.
 
-### 2. 编辑配置
+### 2. Edit Configuration
 
-打开 `config.toml`，修改 Server 地址：
+Open `config.toml` and modify the Server address:
 
 ```toml
 [server]
-base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
+base_url = "http://127.0.0.1:8080"  # Change to your Server address
 ```
 
-### 3. 注册
+### 3. Register
 
-从 Server 获取注册 token 后执行：
+Obtain a registration token from the Server, then run:
 
 ```bash
 ./agent-core register --token rt_xxx --name my-agent
 ```
 
-注册成功后，`service_id` 和 `api_key` 会自动写入 `config.toml`。
+After successful registration, `service_id` and `api_key` will be automatically written to `config.toml`.
 
-### 4. 运行
+### 4. Run
 
-前台运行：
-
-```bash
-./agent-core run
-```
-
-首次启动会交互式确认 Server URL 和数据目录（默认 `./data`），随后开始轮询任务。
-
-如果当前目录已有完整配置且已注册，会直接启动，不再询问。
-
-## 前台运行
+Run in the foreground:
 
 ```bash
 ./agent-core run
 ```
 
-启动后向 Server 轮询获取任务、发送心跳，并通过 Docker 执行器运行任务。按 `Ctrl+C` 或发送 `SIGTERM` 可优雅关闭。
+On the first startup, it will interactively confirm the Server URL and data directory (default `./data`), then start polling for tasks.
 
-未注册且带有 `--interactive` 时，会交互式询问 token 并完成注册：
+If the current directory already has a complete configuration and is registered, it will start directly without prompting.
+
+## Foreground Run
+
+```bash
+./agent-core run
+```
+
+After starting, it polls the Server for tasks, sends heartbeats, and runs tasks through the Docker executor. Press `Ctrl+C` or send `SIGTERM` for graceful shutdown.
+
+If not yet registered and with `--interactive`, it will interactively ask for the token and complete registration:
 
 ```bash
 ./agent-core run --interactive
 ```
 
-## 后台运行
+## Background Run
 
 ```bash
 ./agent-core run-detached
 ```
 
-- Linux/macOS：通过 `nohup` 后台运行，日志输出到 `{data_dir}/agent.log`
-- Windows：通过 `cmd /C start /B` 后台运行
+- Linux/macOS: Runs in the background via `nohup`, logs output to `{data_dir}/agent.log`
+- Windows: Runs in the background via `cmd /C start /B`
 
-后台启动后会写入 pidfile，用于后续管理和状态查询。
+After background startup, a pidfile is written for subsequent management and status queries.
 
-## 查看状态
+## Check Status
 
 ```bash
 ./agent-core status
 ```
 
-输出示例：
+Example output:
 
 ```
-OpenAaaS Agent 状态
+OpenAaaS Agent Status
 ====================
-配置文件: /path/to/config.toml
-数据目录: /path/to/data
+Config file: /path/to/config.toml
+Data directory: /path/to/data
 
 Server URL: http://127.0.0.1:8080
-轮询间隔: 5 秒
+Poll interval: 5 seconds
 
-注册状态: 已注册
+Registration status: Registered
 Service ID: svc_xxx
-Agent 名称: my-agent
+Agent name: my-agent
 
-执行器配置:
-  镜像: open-aaas-executor:latest
-  容量: 2
-  超时: 0 分钟
+Executor configuration:
+  Image: open-aaas-executor:latest
+  Capacity: 2
+  Timeout: 0 minutes
 ```
 
-## 停止服务
+## Stop Service
 
 ```bash
 ./agent-core stop
 ```
 
-向后台进程发送 `SIGTERM`，等待最多 5 秒优雅退出；超时则发送 `SIGKILL` 强制终止，并清理 pidfile。
+Sends `SIGTERM` to the background process, waiting up to 5 seconds for graceful exit; if timed out, sends `SIGKILL` to force termination and cleans up the pidfile.
 
-## 配置文件说明
+## Configuration File Reference
 
-`config.toml` 完整示例：
+Complete `config.toml` example:
 
 ```toml
 [server]
-base_url = "http://127.0.0.1:8080"  # Server 地址
-poll_interval_secs = 5               # 轮询间隔（秒）
-use_system_proxy = false             # 是否使用系统代理
+base_url = "http://127.0.0.1:8080"  # Server address
+poll_interval_secs = 5               # Polling interval (seconds)
+use_system_proxy = false             # Whether to use system proxy
 
 [agent]
-service_id = "svc-xxx"               # 注册后自动填充
-api_key = "ak_xxx"                   # 注册后自动填充
-name = "agent-core"                  # Agent 名称
+service_id = "svc-xxx"               # Auto-filled after registration
+api_key = "ak_xxx"                   # Auto-filled after registration
+name = "agent-core"                  # Agent name
 
 [executor]
-executor_type = "standard"           # 执行器类型：standard / bash / python / custom
-image = "open-aaas-executor:latest"  # Docker 镜像
-capacity = 2                         # 并发任务数
-timeout_minutes = 0                  # 任务超时（分钟），0 表示不限制
-# memory_limit = "4g"                # 内存限制（可选）
-working_dir = "/workspace"           # 容器内工作目录
-# script_path = "/workspace/run.sh"  # 脚本路径（bash/python 类型用）
-custom_entrypoint = ["/bin/sh"]      # 自定义 ENTRYPOINT（custom 类型）
-custom_args = ["-c", "echo hi"]      # 自定义参数（custom 类型）
+executor_type = "standard"           # Executor type: standard / bash / python / custom
+image = "open-aaas-executor:latest"  # Docker image
+capacity = 2                         # Concurrent task count
+timeout_minutes = 0                  # Task timeout (minutes), 0 means unlimited
+# memory_limit = "4g"                # Memory limit (optional)
+working_dir = "/workspace"           # Working directory inside the container
+# script_path = "/workspace/run.sh"  # Script path (for bash/python type)
+custom_entrypoint = ["/bin/sh"]      # Custom ENTRYPOINT (custom type)
+custom_args = ["-c", "echo hi"]      # Custom arguments (custom type)
 
 [paths]
-data_dir = "./data"                  # 数据目录
+data_dir = "./data"                  # Data directory
 
 [[paths.mounts]]
-host = "./share/kimi-config"         # 宿主机路径（相对或绝对）
-container = "/shared/kimi-config"    # 容器内路径
-readonly = true                      # 是否只读
+host = "./share/kimi-config"         # Host path (relative or absolute)
+container = "/shared/kimi-config"    # Container path
+readonly = true                      # Read-only
 ```
 
-### 配置项说明
+### Configuration Items
 
-- **server**: 连接 Server 的相关配置，`base_url` 必填。
-- **agent**: `service_id` 和 `api_key` 由 `register` 命令自动填充，无需手动填写。
-- **executor**: 任务执行器配置。`executor_type` 支持 `standard`（容器默认 ENTRYPOINT）、`bash`、`python`、`custom`；`capacity` 控制并发任务数。
-- **paths**: `data_dir` 存放日志和运行时数据。`[[paths.mounts]]` 定义额外挂载到执行器容器的目录，常用于挂载配置文件或共享数据。
+- **server**: Configuration related to connecting to the Server; `base_url` is required.
+- **agent**: `service_id` and `api_key` are auto-filled by the `register` command; no need to fill manually.
+- **executor**: Task executor configuration. `executor_type` supports `standard` (container default ENTRYPOINT), `bash`, `python`, `custom`; `capacity` controls the number of concurrent tasks.
+- **paths**: `data_dir` stores logs and runtime data. `[[paths.mounts]]` defines additional directories mounted into the executor container, commonly used for mounting configuration files or shared data.
 
-首次运行后无需手动修改大部分配置。若需调整，直接编辑 `config.toml` 后重启即可。
+After the first run, most configurations do not need to be modified manually. If adjustments are needed, simply edit `config.toml` and restart.

--- a/agent-core/executor-example/README.md
+++ b/agent-core/executor-example/README.md
@@ -2,105 +2,105 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-This is **a sample Docker executor image for OpenAaaS**.
+这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
 
-Agent Core executes tasks in isolated Docker containers. This example demonstrates the **minimal interaction contract**: the container reads `task.json`, executes the task, and writes result files to the workspace. You can directly modify based on it, or write your own image entirely — as long as it satisfies the same input/output protocol.
-
----
-
-## Interaction Contract
-
-This is the only agreement between Agent Core and the container. Whether or not you modify based on this example, as long as you follow this contract, Agent Core can correctly schedule your image.
-
-### Input
-
-When Agent Core starts the container, it completes the following preparations:
-
-- Places `task.json` at the container's `/workspace/task.json`
-- Places input files in `/workspace/input/`
-- Passes two environment variables: `TASK_ID` (task ID) and `TIMEOUT` (timeout in seconds)
-
-`task.json` contains the following fields:
-
-| Field | Description |
-|-------|-------------|
-| `task_id` | Unique task identifier |
-| `task_prompt` | User's original task description |
-| `prompt` | Same as `task_prompt`, for backward compatibility |
-| `output_prompt` | Requirements for output format/content |
-| `session_id` | Session identifier |
-| `input_files` | List of input file names |
-
-### Output
-
-After execution is complete, simply place result files under the workspace (recommended under `/workspace/output/`). Agent Core will scan all files under the workspace (excluding `task.json` and `input/`), and report them as output files to the Server.
+Agent Core 通过 Docker 容器隔离执行任务。这个示例展示了**最小的交互契约**：容器读取 `task.json`，执行任务，将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
 
 ---
 
-## Architecture Overview
+## 交互契约
+
+这是 Agent Core 与容器之间的唯一约定。无论你是否基于本示例修改，只要遵守这个契约，Agent Core 就能正确调度你的镜像。
+
+### 输入
+
+Agent Core 启动容器时，会完成以下准备：
+
+- 将 `task.json` 放在容器的 `/workspace/task.json`
+- 将输入文件放在 `/workspace/input/`
+- 传入两个环境变量：`TASK_ID`（任务 ID）和 `TIMEOUT`（超时秒数）
+
+`task.json` 包含以下字段：
+
+| 字段 | 说明 |
+|------|------|
+| `task_id` | 任务唯一标识 |
+| `task_prompt` | 用户原始任务描述 |
+| `prompt` | 同 `task_prompt`，向后兼容 |
+| `output_prompt` | 对输出格式/内容的要求 |
+| `session_id` | 会话标识 |
+| `input_files` | 输入文件名列表 |
+
+### 输出
+
+执行完成后，把结果文件放在 workspace 下即可（推荐放在 `/workspace/output/` 下）。Agent Core 会扫描 workspace 下所有文件（排除 `task.json` 和 `input/`），作为输出文件上报 Server。
+
+---
+
+## 架构概述
 
 ```
-Agent Core  →  Create workspace + task.json + input/  →  docker run
+Agent Core  →  创建 workspace + task.json + input/  →  docker run
                                                        │
                                                        ▼
-                                                  Container Execution
+                                                  容器执行
                                                        │
                                                        ▼
-Agent Core  ←  Scan output files to report to Server  ←  Results written to workspace
+Agent Core  ←  扫描输出文件上报 Server  ←  结果写入 workspace
 ```
 
 ---
 
-## Build Example Image
+## 构建示例镜像
 
 ```bash
 cd OpenAaaS/agent-core/executor-example
 docker build -t open-aaas-executor:latest .
 ```
 
-> The image name (e.g. `open-aaas-executor:latest`) must match the `executor.image` configuration in `agent-core`'s `config.toml`; otherwise Agent Core cannot correctly schedule it.
+> 镜像名（如 `open-aaas-executor:latest`）需要与 `agent-core` 的 `config.toml` 中 `executor.image` 配置保持一致，否则 Agent Core 无法正确调度。
 
 ---
 
-## What's Included in This Example
+## 本示例包含什么
 
-| File | Description |
-|------|-------------|
-| `Dockerfile` | Example image definition. Based on `node:22-slim`, installs `jq`/`git`/`python3` and other common tools |
-| `entrypoint.sh` | Container entry script, checks for `task.json` existence then calls the execution script |
-| `run.sh` | **Example execution logic**. In this example, it calls the pi-coding-agent agent framework to process tasks; you can directly replace it with other agent frameworks |
-| `main-agent.md` | System prompt appended to pi in `run.sh`. If you don't use pi, this file can be ignored |
-| `pi/` | Configuration directory for pi-coding-agent. If you don't use pi, you can delete it |
-
----
-
-## Customization
-
-### Method 1: Modify Based on This Example
-
-This is the fastest way to get started:
-
-- **Modify `run.sh`**: Replace execution logic, such as using other Agent frameworks (e.g. Kimi Cli, Open Code, Codex, etc.)
-- **Modify `Dockerfile`**: Add or remove dependencies, change base image
-- **Delete unnecessary files**: If not using pi, delete the `pi/` directory and `main-agent.md`
-
-### Method 2: Build Your Own Image from Scratch
-
-You can also write your own image entirely; just satisfy the interaction contract:
-
-1. Write a Dockerfile, install the runtime environment and Agent framework you need
-2. Write an entry script (or directly write ENTRYPOINT), have the agent read `/workspace/task.json` and execute the task
-3. Core requirement: after the agent finishes executing, write result files to the workspace
-
-Agent Core doesn't care about the internal implementation of the container; it only cares whether output files appear in the workspace as required.
+| 文件 | 说明 |
+|------|------|
+| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装了 `jq`/`git`/`python3` 等常用工具 |
+| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用执行脚本 |
+| `run.sh` | **示例的执行逻辑**。本示例中用它调用 pi-coding-agent 这个 agent 框架处理任务，你可以直接替换为其他 agent 框架 |
+| `main-agent.md` | `run.sh` 中给 pi 追加的系统提示词。如果你不用 pi，这个文件可以忽略 |
+| `pi/` | pi-coding-agent 的配置目录。如果你不用 pi，可以删除 |
 
 ---
 
-## Security Reminder
+## 自定义
 
-`pi/agent/models.json` contains sensitive API keys, **do not commit to Git**.
+### 方式一：基于本示例修改
 
-Recommended to inject at runtime via `agent-core`'s `config.toml`:
+这是最快的上手方式：
+
+- **修改 `run.sh`**：替换执行逻辑，比如使用其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
+- **修改 `Dockerfile`**：增减依赖、换基础镜像
+- **删除不需要的文件**：如果不用 pi，删掉 `pi/` 目录和 `main-agent.md`
+
+### 方式二：从零构建自己的镜像
+
+你也可以完全自己写一个镜像，只需要满足交互契约即可：
+
+1. 写一个 Dockerfile，安装你需要的运行环境和 Agent 框架
+2. 写一个入口脚本（或直接写 ENTRYPOINT），让 agent 读取 `/workspace/task.json` 并执行任务
+3. 核心要求：agent 执行完成后，将结果文件写入 workspace
+
+Agent Core 不关心容器内部怎么实现，只关心输出文件是否按要求出现在 workspace 中。
+
+---
+
+## 安全提醒
+
+`pi/agent/models.json` 包含敏感 API key，**不要提交到 Git**。
+
+推荐通过 `agent-core` 的 `config.toml` 在运行时注入：
 
 ```toml
 [[paths.mounts]]
@@ -109,4 +109,4 @@ container = "/home/executor/.pi/agent/models.json"
 readonly = true
 ```
 
-This avoids packaging API keys into the image, ensuring keys are separate from the image.
+这样可以避免将 API key 打包进镜像，确保密钥与镜像分离。

--- a/agent-core/executor-example/README.zh.md
+++ b/agent-core/executor-example/README.zh.md
@@ -2,105 +2,105 @@
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
+This is **a sample Docker executor image for OpenAaaS**.
 
-Agent Core 通过 Docker 容器隔离执行任务。这个示例展示了**最小的交互契约**：容器读取 `task.json`，执行任务，将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
-
----
-
-## 交互契约
-
-这是 Agent Core 与容器之间的唯一约定。无论你是否基于本示例修改，只要遵守这个契约，Agent Core 就能正确调度你的镜像。
-
-### 输入
-
-Agent Core 启动容器时，会完成以下准备：
-
-- 将 `task.json` 放在容器的 `/workspace/task.json`
-- 将输入文件放在 `/workspace/input/`
-- 传入两个环境变量：`TASK_ID`（任务 ID）和 `TIMEOUT`（超时秒数）
-
-`task.json` 包含以下字段：
-
-| 字段 | 说明 |
-|------|------|
-| `task_id` | 任务唯一标识 |
-| `task_prompt` | 用户原始任务描述 |
-| `prompt` | 同 `task_prompt`，向后兼容 |
-| `output_prompt` | 对输出格式/内容的要求 |
-| `session_id` | 会话标识 |
-| `input_files` | 输入文件名列表 |
-
-### 输出
-
-执行完成后，把结果文件放在 workspace 下即可（推荐放在 `/workspace/output/` 下）。Agent Core 会扫描 workspace 下所有文件（排除 `task.json` 和 `input/`），作为输出文件上报 Server。
+Agent Core executes tasks in isolated Docker containers. This example demonstrates the **minimal interaction contract**: the container reads `task.json`, executes the task, and writes result files to the workspace. You can directly modify based on it, or write your own image entirely — as long as it satisfies the same input/output protocol.
 
 ---
 
-## 架构概述
+## Interaction Contract
+
+This is the only agreement between Agent Core and the container. Whether or not you modify based on this example, as long as you follow this contract, Agent Core can correctly schedule your image.
+
+### Input
+
+When Agent Core starts the container, it completes the following preparations:
+
+- Places `task.json` at the container's `/workspace/task.json`
+- Places input files in `/workspace/input/`
+- Passes two environment variables: `TASK_ID` (task ID) and `TIMEOUT` (timeout in seconds)
+
+`task.json` contains the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `task_id` | Unique task identifier |
+| `task_prompt` | User's original task description |
+| `prompt` | Same as `task_prompt`, for backward compatibility |
+| `output_prompt` | Requirements for output format/content |
+| `session_id` | Session identifier |
+| `input_files` | List of input file names |
+
+### Output
+
+After execution is complete, simply place result files under the workspace (recommended under `/workspace/output/`). Agent Core will scan all files under the workspace (excluding `task.json` and `input/`), and report them as output files to the Server.
+
+---
+
+## Architecture Overview
 
 ```
-Agent Core  →  创建 workspace + task.json + input/  →  docker run
+Agent Core  →  Create workspace + task.json + input/  →  docker run
                                                        │
                                                        ▼
-                                                  容器执行
+                                                  Container Execution
                                                        │
                                                        ▼
-Agent Core  ←  扫描输出文件上报 Server  ←  结果写入 workspace
+Agent Core  ←  Scan output files to report to Server  ←  Results written to workspace
 ```
 
 ---
 
-## 构建示例镜像
+## Build Example Image
 
 ```bash
 cd OpenAaaS/agent-core/executor-example
 docker build -t open-aaas-executor:latest .
 ```
 
-> 镜像名（如 `open-aaas-executor:latest`）需要与 `agent-core` 的 `config.toml` 中 `executor.image` 配置保持一致，否则 Agent Core 无法正确调度。
+> The image name (e.g. `open-aaas-executor:latest`) must match the `executor.image` configuration in `agent-core`'s `config.toml`; otherwise Agent Core cannot correctly schedule it.
 
 ---
 
-## 本示例包含什么
+## What's Included in This Example
 
-| 文件 | 说明 |
-|------|------|
-| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装了 `jq`/`git`/`python3` 等常用工具 |
-| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用执行脚本 |
-| `run.sh` | **示例的执行逻辑**。本示例中用它调用 pi-coding-agent 这个 agent 框架处理任务，你可以直接替换为其他 agent 框架 |
-| `main-agent.md` | `run.sh` 中给 pi 追加的系统提示词。如果你不用 pi，这个文件可以忽略 |
-| `pi/` | pi-coding-agent 的配置目录。如果你不用 pi，可以删除 |
-
----
-
-## 自定义
-
-### 方式一：基于本示例修改
-
-这是最快的上手方式：
-
-- **修改 `run.sh`**：替换执行逻辑，比如使用其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
-- **修改 `Dockerfile`**：增减依赖、换基础镜像
-- **删除不需要的文件**：如果不用 pi，删掉 `pi/` 目录和 `main-agent.md`
-
-### 方式二：从零构建自己的镜像
-
-你也可以完全自己写一个镜像，只需要满足交互契约即可：
-
-1. 写一个 Dockerfile，安装你需要的运行环境和 Agent 框架
-2. 写一个入口脚本（或直接写 ENTRYPOINT），让 agent 读取 `/workspace/task.json` 并执行任务
-3. 核心要求：agent 执行完成后，将结果文件写入 workspace
-
-Agent Core 不关心容器内部怎么实现，只关心输出文件是否按要求出现在 workspace 中。
+| File | Description |
+|------|-------------|
+| `Dockerfile` | Example image definition. Based on `node:22-slim`, installs `jq`/`git`/`python3` and other common tools |
+| `entrypoint.sh` | Container entry script, checks for `task.json` existence then calls the execution script |
+| `run.sh` | **Example execution logic**. In this example, it calls the pi-coding-agent agent framework to process tasks; you can directly replace it with other agent frameworks |
+| `main-agent.md` | System prompt appended to pi in `run.sh`. If you don't use pi, this file can be ignored |
+| `pi/` | Configuration directory for pi-coding-agent. If you don't use pi, you can delete it |
 
 ---
 
-## 安全提醒
+## Customization
 
-`pi/agent/models.json` 包含敏感 API key，**不要提交到 Git**。
+### Method 1: Modify Based on This Example
 
-推荐通过 `agent-core` 的 `config.toml` 在运行时注入：
+This is the fastest way to get started:
+
+- **Modify `run.sh`**: Replace execution logic, such as using other Agent frameworks (e.g. Kimi Cli, Open Code, Codex, etc.)
+- **Modify `Dockerfile`**: Add or remove dependencies, change base image
+- **Delete unnecessary files**: If not using pi, delete the `pi/` directory and `main-agent.md`
+
+### Method 2: Build Your Own Image from Scratch
+
+You can also write your own image entirely; just satisfy the interaction contract:
+
+1. Write a Dockerfile, install the runtime environment and Agent framework you need
+2. Write an entry script (or directly write ENTRYPOINT), have the agent read `/workspace/task.json` and execute the task
+3. Core requirement: after the agent finishes executing, write result files to the workspace
+
+Agent Core doesn't care about the internal implementation of the container; it only cares whether output files appear in the workspace as required.
+
+---
+
+## Security Reminder
+
+`pi/agent/models.json` contains sensitive API keys, **do not commit to Git**.
+
+Recommended to inject at runtime via `agent-core`'s `config.toml`:
 
 ```toml
 [[paths.mounts]]
@@ -109,4 +109,4 @@ container = "/home/executor/.pi/agent/models.json"
 readonly = true
 ```
 
-这样可以避免将 API key 打包进镜像，确保密钥与镜像分离。
+This avoids packaging API keys into the image, ensuring keys are separate from the image.

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
@@ -2,54 +2,54 @@
 
 # subagent-isolation
 
-> A `pi` extension that delegates tasks to specialized subagents in isolated `pi` processes, giving each subagent its own clean context window.
+> 一个 `pi` 扩展，将任务委托给专门的 subagent，在隔离的 `pi` 进程中运行，让每个 subagent 拥有独立的干净上下文窗口。
 
-## Features
+## 功能特性
 
-- **Three invocation modes**
-  - `single` - call one agent with a task
-  - `parallel` - run up to 8 tasks concurrently (max 4 at a time)
-  - `chain` - run agents sequentially, injecting the previous step's output via `{previous}`
-- **Agent discovery & scoping**
-  - `user` agents from `~/.pi/agent/agents/`
-  - `project` agents from `.pi/agents/` (searched upward from the working directory)
-  - `both` — merges both scopes (project overrides user on name collisions)
-  - Optional `confirmProjectAgents` prompt before running repo-local agents
-  - `agentScope` defaults to `"both"` at runtime
-- **Process isolation & depth control**
-  - Every subagent spawns a fresh `pi --mode json` process
-  - Each subagent’s system prompt is written to a temporary file and passed via `--append-system-prompt`
-  - Max recursion depth: `2`
-  - Per-agent `canDelegate: false` in frontmatter blocks further delegation
-- **Skill isolation**
-  - Global skills can be cleared with `--no-skills`
-  - Per-agent `skills` list injects only the specified skills via `--skill <path>`
-- **Timeout & graceful termination**
-  - Silence timeout: 15 minutes (kills if stdout is idle)
-  - Hard timeout: 1 hour
-  - `AbortSignal` triggers `SIGTERM` → `SIGKILL` after 5 seconds
-- **TUI rendering**
-  - Real-time status with collapsible output (`Ctrl+O`)
-  - Token usage stats: input / output / cacheRead / cacheWrite / cost / model / turns
+- **三种调用模式**
+  - `single` - 调用一个 agent 执行单个任务
+  - `parallel` - 最多并发运行 8 个任务（每次最多 4 个）
+  - `chain` - 按顺序运行多个 agent，通过 `{previous}` 注入上一步的输出
+- **Agent 发现与作用域**
+  - `user` agents 来自 `~/.pi/agent/agents/`
+  - `project` agents 来自 `.pi/agents/`（从工作目录向上搜索）
+  - `both` — 合并两个作用域（项目名称冲突时 project 覆盖 user）
+  - 运行仓库本地 agent 前可选 `confirmProjectAgents` 确认提示
+  - 运行时 `agentScope` 默认为 `"both"`
+- **进程隔离与深度控制**
+  - 每个 subagent 都会启动一个全新的 `pi --mode json` 进程
+  - 每个 subagent 的 system prompt 被写入临时文件，并通过 `--append-system-prompt` 传入
+  - 最大递归深度：`2`
+  - 在 frontmatter 中设置 per-agent `canDelegate: false` 可阻止进一步委托
+- **Skill 隔离**
+  - 可使用 `--no-skills` 清除全局 skills
+  - per-agent `skills` 列表仅注入指定的 skill，通过 `--skill <path>` 传入
+- **超时与优雅终止**
+  - 静默超时：15 分钟（stdout 空闲时终止）
+  - 硬超时：1 小时
+  - `AbortSignal` 触发 `SIGTERM` → 5 秒后 `SIGKILL`
+- **TUI 渲染**
+  - 实时状态，支持可折叠输出（`Ctrl+O`）
+  - Token 用量统计：input / output / cacheRead / cacheWrite / cost / model / turns
 
-## Installation
+## 安装
 
-Requires `pi` to be installed and available on your `$PATH`.
+需要已安装 `pi` 并使其在 `$PATH` 中可用。
 
-Clone (or copy) the extension into your `pi` extensions directory:
+将扩展克隆（或复制）到 `pi` 的扩展目录：
 
 ```bash
 git clone https://github.com/your-username/subagent-isolation.git \
   ~/.pi/agent/extensions/subagent-isolation
 ```
 
-Or manually place the files so that `~/.pi/agent/extensions/subagent-isolation/index.ts` exists.
+或手动放置文件，确保 `~/.pi/agent/extensions/subagent-isolation/index.ts` 存在。
 
-## Usage Examples
+## 使用示例
 
-Agents are invoked via the `subagent` tool. Provide exactly one of `agent`/`task`, `tasks`, or `chain`.
+通过 `subagent` 工具调用 agent。必须且只能提供 `agent`/`task`、`tasks` 或 `chain` 中的一种。
 
-### Single mode
+### Single 模式
 
 ```json
 {
@@ -59,7 +59,7 @@ Agents are invoked via the `subagent` tool. Provide exactly one of `agent`/`task
 }
 ```
 
-### Parallel mode
+### Parallel 模式
 
 ```json
 {
@@ -72,7 +72,7 @@ Agents are invoked via the `subagent` tool. Provide exactly one of `agent`/`task
 }
 ```
 
-### Chain mode
+### Chain 模式
 
 ```json
 {
@@ -84,11 +84,11 @@ Agents are invoked via the `subagent` tool. Provide exactly one of `agent`/`task
 }
 ```
 
-If any step in the chain fails, execution stops immediately and the remaining steps are not run.
+如果 chain 中的任何一步失败，执行会立即停止，剩余的步骤不会运行。
 
-## Agent Definition Format
+## Agent 定义格式
 
-Agents are defined as Markdown files (`.md`) in the agents directory. Frontmatter describes the agent; the body becomes the system prompt.
+Agent 以 Markdown 文件（`.md`）形式定义在 agents 目录中。Frontmatter 描述 agent 属性；正文内容作为 system prompt。
 
 ```markdown
 ---
@@ -102,37 +102,37 @@ skills: /path/to/skill1, /path/to/skill2
 You are a senior TypeScript engineer. Prefer async/await, avoid callbacks.
 ```
 
-### Frontmatter fields
+### Frontmatter 字段
 
-| Field | Type | Description |
+| 字段 | 类型 | 说明 |
 |-------|------|-------------|
-| `name` | `string` | **Required.** Unique identifier used in tool calls. |
-| `description` | `string` | **Required.** Short summary shown in discovery / error messages. |
-| `tools` | `string[]` (comma-separated) | Optional tool whitelist for the subagent. |
-| `model` | `string` | Optional model override (e.g. `claude-3-7-sonnet`). |
-| `skills` | `string[]` (comma-separated) | Optional list of skill paths. If present, global skills are disabled and only these are loaded. Paths can be absolute or relative to the working directory. |
-| `canDelegate` | `boolean` | Defaults to `true`. Set to `false` to prevent this agent from spawning further subagents. |
+| `name` | `string` | **必填。** 在工具调用中使用的唯一标识符。 |
+| `description` | `string` | **必填。** 在发现 / 错误消息中显示的简短摘要。 |
+| `tools` | `string[]`（逗号分隔） | 可选的 subagent 工具白名单。 |
+| `model` | `string` | 可选的模型覆盖（例如 `claude-3-7-sonnet`）。 |
+| `skills` | `string[]`（逗号分隔） | 可选的 skill 路径列表。如果存在，全局 skills 会被禁用，仅加载指定的 skills。路径可以是绝对路径或相对于工作目录的路径。 |
+| `canDelegate` | `boolean` | 默认为 `true`。设置为 `false` 可阻止该 agent 启动进一步的 subagent。 |
 
-## Environment Variables
+## 环境变量
 
-These variables control runtime behavior. They are propagated into every subagent process automatically.
+这些变量控制运行时行为。它们会自动传播到每个 subagent 进程中。
 
-| Variable | Default | Description |
+| 变量 | 默认值 | 说明 |
 |----------|---------|-------------|
-| `PI_SUBAGENT_DEPTH` | `0` | Current recursion depth. Automatically incremented per nested invocation. Hard cap is `2`. |
-| `PI_CAN_DELEGATE` | `true` | Whether the current agent is allowed to delegate. Derived from the agent's `canDelegate` frontmatter. |
-| `PI_CURRENT_AGENT_NAME` | — | Name of the current agent, injected into every subagent process. |
-| `PI_SUBAGENT_SILENCE_TIMEOUT_MS` | `900000` (15 min) | Max allowed idle time on stdout before the subagent is killed. |
-| `PI_SUBAGENT_HARD_TIMEOUT_MS` | `3600000` (1 hour) | Absolute maximum runtime for a single subagent call. |
+| `PI_SUBAGENT_DEPTH` | `0` | 当前递归深度。每次嵌套调用自动递增。硬上限为 `2`。 |
+| `PI_CAN_DELEGATE` | `true` | 当前 agent 是否允许委托。派生自 agent 的 `canDelegate` frontmatter。 |
+| `PI_CURRENT_AGENT_NAME` | — | 当前 agent 的名称，注入到每个 subagent 进程中。 |
+| `PI_SUBAGENT_SILENCE_TIMEOUT_MS` | `900000`（15 分钟） | stdout 空闲时允许的最大时间，超过则终止 subagent。 |
+| `PI_SUBAGENT_HARD_TIMEOUT_MS` | `3600000`（1 小时） | 单次 subagent 调用的绝对最大运行时间。 |
 
-## Project Structure
+## 项目结构
 
 ```
 ~/.pi/agent/extensions/subagent-isolation/
-├── index.ts      # Main extension source (~1,280 lines)
-└── README.md     # This file
+├── index.ts      # 主扩展源码（约 1,280 行）
+└── README.md     # 本文件
 ```
 
-## License
+## 许可证
 
 MIT

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.zh.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.zh.md
@@ -2,54 +2,54 @@
 
 # subagent-isolation
 
-> 一个 `pi` 扩展，将任务委托给专门的 subagent，在隔离的 `pi` 进程中运行，让每个 subagent 拥有独立的干净上下文窗口。
+> A `pi` extension that delegates tasks to specialized subagents in isolated `pi` processes, giving each subagent its own clean context window.
 
-## 功能特性
+## Features
 
-- **三种调用模式**
-  - `single` - 调用一个 agent 执行单个任务
-  - `parallel` - 最多并发运行 8 个任务（每次最多 4 个）
-  - `chain` - 按顺序运行多个 agent，通过 `{previous}` 注入上一步的输出
-- **Agent 发现与作用域**
-  - `user` agents 来自 `~/.pi/agent/agents/`
-  - `project` agents 来自 `.pi/agents/`（从工作目录向上搜索）
-  - `both` — 合并两个作用域（项目名称冲突时 project 覆盖 user）
-  - 运行仓库本地 agent 前可选 `confirmProjectAgents` 确认提示
-  - 运行时 `agentScope` 默认为 `"both"`
-- **进程隔离与深度控制**
-  - 每个 subagent 都会启动一个全新的 `pi --mode json` 进程
-  - 每个 subagent 的 system prompt 被写入临时文件，并通过 `--append-system-prompt` 传入
-  - 最大递归深度：`2`
-  - 在 frontmatter 中设置 per-agent `canDelegate: false` 可阻止进一步委托
-- **Skill 隔离**
-  - 可使用 `--no-skills` 清除全局 skills
-  - per-agent `skills` 列表仅注入指定的 skill，通过 `--skill <path>` 传入
-- **超时与优雅终止**
-  - 静默超时：15 分钟（stdout 空闲时终止）
-  - 硬超时：1 小时
-  - `AbortSignal` 触发 `SIGTERM` → 5 秒后 `SIGKILL`
-- **TUI 渲染**
-  - 实时状态，支持可折叠输出（`Ctrl+O`）
-  - Token 用量统计：input / output / cacheRead / cacheWrite / cost / model / turns
+- **Three invocation modes**
+  - `single` - call one agent with a task
+  - `parallel` - run up to 8 tasks concurrently (max 4 at a time)
+  - `chain` - run agents sequentially, injecting the previous step's output via `{previous}`
+- **Agent discovery & scoping**
+  - `user` agents from `~/.pi/agent/agents/`
+  - `project` agents from `.pi/agents/` (searched upward from the working directory)
+  - `both` — merges both scopes (project overrides user on name collisions)
+  - Optional `confirmProjectAgents` prompt before running repo-local agents
+  - `agentScope` defaults to `"both"` at runtime
+- **Process isolation & depth control**
+  - Every subagent spawns a fresh `pi --mode json` process
+  - Each subagent’s system prompt is written to a temporary file and passed via `--append-system-prompt`
+  - Max recursion depth: `2`
+  - Per-agent `canDelegate: false` in frontmatter blocks further delegation
+- **Skill isolation**
+  - Global skills can be cleared with `--no-skills`
+  - Per-agent `skills` list injects only the specified skills via `--skill <path>`
+- **Timeout & graceful termination**
+  - Silence timeout: 15 minutes (kills if stdout is idle)
+  - Hard timeout: 1 hour
+  - `AbortSignal` triggers `SIGTERM` → `SIGKILL` after 5 seconds
+- **TUI rendering**
+  - Real-time status with collapsible output (`Ctrl+O`)
+  - Token usage stats: input / output / cacheRead / cacheWrite / cost / model / turns
 
-## 安装
+## Installation
 
-需要已安装 `pi` 并使其在 `$PATH` 中可用。
+Requires `pi` to be installed and available on your `$PATH`.
 
-将扩展克隆（或复制）到 `pi` 的扩展目录：
+Clone (or copy) the extension into your `pi` extensions directory:
 
 ```bash
 git clone https://github.com/your-username/subagent-isolation.git \
   ~/.pi/agent/extensions/subagent-isolation
 ```
 
-或手动放置文件，确保 `~/.pi/agent/extensions/subagent-isolation/index.ts` 存在。
+Or manually place the files so that `~/.pi/agent/extensions/subagent-isolation/index.ts` exists.
 
-## 使用示例
+## Usage Examples
 
-通过 `subagent` 工具调用 agent。必须且只能提供 `agent`/`task`、`tasks` 或 `chain` 中的一种。
+Agents are invoked via the `subagent` tool. Provide exactly one of `agent`/`task`, `tasks`, or `chain`.
 
-### Single 模式
+### Single mode
 
 ```json
 {
@@ -59,7 +59,7 @@ git clone https://github.com/your-username/subagent-isolation.git \
 }
 ```
 
-### Parallel 模式
+### Parallel mode
 
 ```json
 {
@@ -72,7 +72,7 @@ git clone https://github.com/your-username/subagent-isolation.git \
 }
 ```
 
-### Chain 模式
+### Chain mode
 
 ```json
 {
@@ -84,11 +84,11 @@ git clone https://github.com/your-username/subagent-isolation.git \
 }
 ```
 
-如果 chain 中的任何一步失败，执行会立即停止，剩余的步骤不会运行。
+If any step in the chain fails, execution stops immediately and the remaining steps are not run.
 
-## Agent 定义格式
+## Agent Definition Format
 
-Agent 以 Markdown 文件（`.md`）形式定义在 agents 目录中。Frontmatter 描述 agent 属性；正文内容作为 system prompt。
+Agents are defined as Markdown files (`.md`) in the agents directory. Frontmatter describes the agent; the body becomes the system prompt.
 
 ```markdown
 ---
@@ -102,37 +102,37 @@ skills: /path/to/skill1, /path/to/skill2
 You are a senior TypeScript engineer. Prefer async/await, avoid callbacks.
 ```
 
-### Frontmatter 字段
+### Frontmatter fields
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 |-------|------|-------------|
-| `name` | `string` | **必填。** 在工具调用中使用的唯一标识符。 |
-| `description` | `string` | **必填。** 在发现 / 错误消息中显示的简短摘要。 |
-| `tools` | `string[]`（逗号分隔） | 可选的 subagent 工具白名单。 |
-| `model` | `string` | 可选的模型覆盖（例如 `claude-3-7-sonnet`）。 |
-| `skills` | `string[]`（逗号分隔） | 可选的 skill 路径列表。如果存在，全局 skills 会被禁用，仅加载指定的 skills。路径可以是绝对路径或相对于工作目录的路径。 |
-| `canDelegate` | `boolean` | 默认为 `true`。设置为 `false` 可阻止该 agent 启动进一步的 subagent。 |
+| `name` | `string` | **Required.** Unique identifier used in tool calls. |
+| `description` | `string` | **Required.** Short summary shown in discovery / error messages. |
+| `tools` | `string[]` (comma-separated) | Optional tool whitelist for the subagent. |
+| `model` | `string` | Optional model override (e.g. `claude-3-7-sonnet`). |
+| `skills` | `string[]` (comma-separated) | Optional list of skill paths. If present, global skills are disabled and only these are loaded. Paths can be absolute or relative to the working directory. |
+| `canDelegate` | `boolean` | Defaults to `true`. Set to `false` to prevent this agent from spawning further subagents. |
 
-## 环境变量
+## Environment Variables
 
-这些变量控制运行时行为。它们会自动传播到每个 subagent 进程中。
+These variables control runtime behavior. They are propagated into every subagent process automatically.
 
-| 变量 | 默认值 | 说明 |
+| Variable | Default | Description |
 |----------|---------|-------------|
-| `PI_SUBAGENT_DEPTH` | `0` | 当前递归深度。每次嵌套调用自动递增。硬上限为 `2`。 |
-| `PI_CAN_DELEGATE` | `true` | 当前 agent 是否允许委托。派生自 agent 的 `canDelegate` frontmatter。 |
-| `PI_CURRENT_AGENT_NAME` | — | 当前 agent 的名称，注入到每个 subagent 进程中。 |
-| `PI_SUBAGENT_SILENCE_TIMEOUT_MS` | `900000`（15 分钟） | stdout 空闲时允许的最大时间，超过则终止 subagent。 |
-| `PI_SUBAGENT_HARD_TIMEOUT_MS` | `3600000`（1 小时） | 单次 subagent 调用的绝对最大运行时间。 |
+| `PI_SUBAGENT_DEPTH` | `0` | Current recursion depth. Automatically incremented per nested invocation. Hard cap is `2`. |
+| `PI_CAN_DELEGATE` | `true` | Whether the current agent is allowed to delegate. Derived from the agent's `canDelegate` frontmatter. |
+| `PI_CURRENT_AGENT_NAME` | — | Name of the current agent, injected into every subagent process. |
+| `PI_SUBAGENT_SILENCE_TIMEOUT_MS` | `900000` (15 min) | Max allowed idle time on stdout before the subagent is killed. |
+| `PI_SUBAGENT_HARD_TIMEOUT_MS` | `3600000` (1 hour) | Absolute maximum runtime for a single subagent call. |
 
-## 项目结构
+## Project Structure
 
 ```
 ~/.pi/agent/extensions/subagent-isolation/
-├── index.ts      # 主扩展源码（约 1,280 行）
-└── README.md     # 本文件
+├── index.ts      # Main extension source (~1,280 lines)
+└── README.md     # This file
 ```
 
-## 许可证
+## License
 
 MIT

--- a/client-app/README.md
+++ b/client-app/README.md
@@ -2,57 +2,57 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-The desktop client for OpenAaaS, providing visual server management, service marketplace browsing, and task submission.
+OpenAaaS 的桌面客户端，提供可视化的服务器管理、服务市场浏览和任务提交能力。
 
-## Tech Stack
+## 技术栈
 
-| Technology | Purpose |
-|------------|---------|
-| Tauri 2.0 | Cross-platform desktop framework |
-| Vue 3 + TypeScript | Frontend UI and type safety |
-| Tailwind CSS | Styling system |
-| Pinia | State management |
-| `@tauri-apps/plugin-http` | Direct server connection bypassing CORS |
+| 技术 | 用途 |
+|------|------|
+| Tauri 2.0 | 跨平台桌面框架 |
+| Vue 3 + TypeScript | 前端界面与类型安全 |
+| Tailwind CSS | 样式系统 |
+| Pinia | 状态管理 |
+| `@tauri-apps/plugin-http` | 绕过 CORS 直连 Server |
 
-## Features
+## 功能特性
 
-- **Multi-server management** — Add, remove, register, and switch default servers
-- **Service marketplace** — Browse available services across all servers, view real-time load and status
-- **Service details** — View usage instructions and real-time load
-- **Guided task submission** — Fill in task_prompt and output_prompt, with file upload support (drag-and-drop or click)
-- **Auto task polling** — 5-second polling after submission, then 30-second intervals
-- **Task details** — View task status, results (Markdown rendering), and download output files
-- **Task list** — Filter by status, with server origin indicators
-- **Data persistence** — Server configuration and local data stored in localStorage
-- **Skeleton screens** — Loading placeholders on all async-loaded areas to prevent blank screens
+- **多服务器管理** — 添加、删除、注册和切换默认服务器
+- **服务市场** — 浏览所有服务器上的可用服务，查看实时负载与状态
+- **服务详情** — 查看 Usage 说明和实时负载
+- **向导式任务提交** — 填写 task_prompt、output_prompt，支持文件上传（拖拽或点击）
+- **任务自动轮询** — 提交后首次 5 秒轮询，之后 30 秒间隔
+- **任务详情** — 查看任务状态、结果（Markdown 渲染）和输出文件下载
+- **任务列表** — 按状态筛选，显示服务器来源标识
+- **数据持久化** — 服务器配置和本地数据存储在 localStorage
+- **骨架屏** — 所有异步加载区域均有 loading 占位，避免白屏
 
-## Build & Run
+## 构建运行
 
-Requires Rust 1.85+, Node.js 18+, and [Tauri system dependencies](https://v2.tauri.app/start/prerequisites/).
+需要安装 Rust 1.85+ 和 Node.js 18+，以及 [Tauri 对应的系统依赖](https://v2.tauri.app/start/prerequisites/)。
 
 ```bash
 cd client-app
 npm install
-cargo tauri dev      # Development mode
-cargo tauri build    # Release build
+cargo tauri dev      # 开发模式
+cargo tauri build    # 发行构建
 ```
 
-In development mode, Tauri automatically opens a desktop window; frontend code supports hot reload, Rust code changes require a restart.
+开发模式下，Tauri 会自动打开桌面窗口；前端代码支持热更新，Rust 代码修改后需重启。
 
-## Build Artifacts
+## 构建产物
 
-Release build artifacts are located at `src-tauri/target/release/bundle/`:
+发行构建产物位于 `src-tauri/target/release/bundle/`：
 
-| Platform | Artifacts |
-|----------|-----------|
-| macOS | `.dmg` installer + `.app` bundle |
-| Windows | `.msi` installer + `.exe` executable |
-| Linux | `.deb` package |
+| 平台 | 产物 |
+|------|------|
+| macOS | `.dmg` 安装包 + `.app` 应用 |
+| Windows | `.msi` 安装包 + `.exe` 可执行文件 |
+| Linux | `.deb` 安装包 |
 
-## macOS Installation Note
+## macOS 安装说明
 
-The app is ad-hoc signed (without an Apple Developer ID). On first launch, macOS may warn **"cannot be opened because the developer cannot be verified."**
+由于应用使用 ad-hoc 自签名（未购买 Apple Developer ID），macOS 首次打开时可能提示**"无法验证开发者"**。
 
-To open: Go to **System Settings → Privacy & Security → Security**, then click **"Open Anyway"**.
+解决方式：前往 **系统设置 → 隐私与安全性 → 安全性**，点击**"仍要打开"**即可。
 
-> 💡 This is preferable to no signing at all, which would show "damaged" and require a terminal command to remove quarantine attributes.
+> 💡 我们推荐此方法而非不签名（不签名会提示"已损坏"，需要用终端命令解除隔离属性）。

--- a/client-app/README.zh.md
+++ b/client-app/README.zh.md
@@ -1,58 +1,58 @@
 # OpenAaaS Desktop Client
 
-<p align="right">中文 | <a href="./README.md">English</a></p>
+<p align="right"><a href="./README.md">English</a> | 中文</p>
 
-OpenAaaS 的桌面客户端，提供可视化的服务器管理、服务市场浏览和任务提交能力。
+The desktop client for OpenAaaS, providing visual server management, service marketplace browsing, and task submission.
 
-## 技术栈
+## Tech Stack
 
-| 技术 | 用途 |
-|------|------|
-| Tauri 2.0 | 跨平台桌面框架 |
-| Vue 3 + TypeScript | 前端界面与类型安全 |
-| Tailwind CSS | 样式系统 |
-| Pinia | 状态管理 |
-| `@tauri-apps/plugin-http` | 绕过 CORS 直连 Server |
+| Technology | Purpose |
+|------------|---------|
+| Tauri 2.0 | Cross-platform desktop framework |
+| Vue 3 + TypeScript | Frontend UI and type safety |
+| Tailwind CSS | Styling system |
+| Pinia | State management |
+| `@tauri-apps/plugin-http` | Direct server connection bypassing CORS |
 
-## 功能特性
+## Features
 
-- **多服务器管理** — 添加、删除、注册和切换默认服务器
-- **服务市场** — 浏览所有服务器上的可用服务，查看实时负载与状态
-- **服务详情** — 查看 Usage 说明和实时负载
-- **向导式任务提交** — 填写 task_prompt、output_prompt，支持文件上传（拖拽或点击）
-- **任务自动轮询** — 提交后首次 5 秒轮询，之后 30 秒间隔
-- **任务详情** — 查看任务状态、结果（Markdown 渲染）和输出文件下载
-- **任务列表** — 按状态筛选，显示服务器来源标识
-- **数据持久化** — 服务器配置和本地数据存储在 localStorage
-- **骨架屏** — 所有异步加载区域均有 loading 占位，避免白屏
+- **Multi-server management** — Add, remove, register, and switch default servers
+- **Service marketplace** — Browse available services across all servers, view real-time load and status
+- **Service details** — View usage instructions and real-time load
+- **Guided task submission** — Fill in task_prompt and output_prompt, with file upload support (drag-and-drop or click)
+- **Auto task polling** — 5-second polling after submission, then 30-second intervals
+- **Task details** — View task status, results (Markdown rendering), and download output files
+- **Task list** — Filter by status, with server origin indicators
+- **Data persistence** — Server configuration and local data stored in localStorage
+- **Skeleton screens** — Loading placeholders on all async-loaded areas to prevent blank screens
 
-## 构建运行
+## Build & Run
 
-需要安装 Rust 1.85+ 和 Node.js 18+，以及 [Tauri 对应的系统依赖](https://v2.tauri.app/start/prerequisites/)。
+Requires Rust 1.85+, Node.js 18+, and [Tauri system dependencies](https://v2.tauri.app/start/prerequisites/).
 
 ```bash
 cd client-app
 npm install
-cargo tauri dev      # 开发模式
-cargo tauri build    # 发行构建
+cargo tauri dev      # Development mode
+cargo tauri build    # Release build
 ```
 
-开发模式下，Tauri 会自动打开桌面窗口；前端代码支持热更新，Rust 代码修改后需重启。
+In development mode, Tauri automatically opens a desktop window; frontend code supports hot reload, Rust code changes require a restart.
 
-## 构建产物
+## Build Artifacts
 
-发行构建产物位于 `src-tauri/target/release/bundle/`：
+Release build artifacts are located at `src-tauri/target/release/bundle/`:
 
-| 平台 | 产物 |
-|------|------|
-| macOS | `.dmg` 安装包 + `.app` 应用 |
-| Windows | `.msi` 安装包 + `.exe` 可执行文件 |
-| Linux | `.deb` 安装包 |
+| Platform | Artifacts |
+|----------|-----------|
+| macOS | `.dmg` installer + `.app` bundle |
+| Windows | `.msi` installer + `.exe` executable |
+| Linux | `.deb` package |
 
-## macOS 安装说明
+## macOS Installation Note
 
-由于应用使用 ad-hoc 自签名（未购买 Apple Developer ID），macOS 首次打开时可能提示**"无法验证开发者"**。
+The app is ad-hoc signed (without an Apple Developer ID). On first launch, macOS may warn **"cannot be opened because the developer cannot be verified."**
 
-解决方式：前往 **系统设置 → 隐私与安全性 → 安全性**，点击**"仍要打开"**即可。
+To open: Go to **System Settings → Privacy & Security → Security**, then click **"Open Anyway"**.
 
-> 💡 我们推荐此方法而非不签名（不签名会提示"已损坏"，需要用终端命令解除隔离属性）。
+> 💡 This is preferable to no signing at all, which would show "damaged" and require a terminal command to remove quarantine attributes.

--- a/client-extension/README.md
+++ b/client-extension/README.md
@@ -2,21 +2,21 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-`client-extension/` is the collection of client extensions for OpenAaaS, enabling different Agent clients (pi, Kimi, etc.) to connect to the OpenAaaS network, discover remote services, submit tasks, and retrieve results.
+`client-extension/` 是 OpenAaaS 的客户端扩展集合，让不同的 Agent 客户端（pi、Kimi 等）能够连接到 OpenAaaS 网络，发现远程服务、提交任务并获取结果。
 
-Currently includes three extensions:
+目前包含三个扩展：
 
 ### pi-extension
 
-A TypeScript extension for [pi](https://github.com/badlogic/pi-mono). Provides a unified `OpenAaaS` entry tool with different functionalities invoked via the `action` parameter. Supports multi-server configuration, automatic task monitoring (widget + toast notifications), Session persistence, and reconstruction reminders.
+面向 [pi](https://github.com/badlogic/pi-mono) 的 TypeScript 扩展。提供统一的 `OpenAaaS` 入口工具，通过 `action` 参数调用不同功能。支持多服务器配置、自动任务监控（widget + toast 通知）、Session 持久化与重建提醒。
 
 ### kimi-plugin
 
-A Python plugin for Kimi. Defines multiple independent tools via `plugin.json`, supports multi-server management, and progressive information retrieval. Includes a complete test suite.
+面向 Kimi 的 Python 插件。通过 `plugin.json` 定义多个独立工具，支持多服务器管理、渐进式信息获取。包含完整的测试套件。
 
 ### openaaas-mcp-adapter
 
-A Python adapter for MCP clients such as Claude Desktop, Cursor, and Cline. Built on the MCP SDK, with `stdio` Transport, providing 14 core Tools, supporting file upload/download, multi-server configuration, path traversal, and zip bomb protection.
+面向 Claude Desktop、Cursor、Cline 等 MCP 客户端的 Python 适配器。基于 MCP SDK 构建，Transport 为 `stdio`，提供 14 个核心 Tool，支持文件上传下载、多服务器配置、路径遍历与 zip 炸弹防护。
 
 ---
 
@@ -31,7 +31,7 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-Execute `/reload` in pi to load the extension. A default configuration file will be created automatically on first use. Then you can invoke via conversation:
+在 pi 中执行 `/reload` 加载扩展。首次使用时会自动创建默认配置文件，然后即可通过对话调用：
 
 ```
 OpenAaaS(action: "set_server_url", server_url: "https://api.open-aaas.com")
@@ -41,13 +41,13 @@ OpenAaaS(action: "list_services")
 
 ### openaaas-mcp-adapter
 
-Run with zero installation using uvx (requires [uv](https://docs.astral.sh/uv/)):
+使用 uvx 零安装运行（需已安装 [uv](https://docs.astral.sh/uv/)）：
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-Or add to Claude Desktop's `claude_desktop_config.json`:
+或在 Claude Desktop 的 `claude_desktop_config.json` 中添加：
 
 ```json
 {
@@ -60,7 +60,7 @@ Or add to Claude Desktop's `claude_desktop_config.json`:
 }
 ```
 
-After configuration, restart Claude Desktop, then invoke tools in conversation:
+配置完成后重启 Claude Desktop，即可在对话中调用工具：
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com")
@@ -70,22 +70,22 @@ list_services()
 
 ### kimi-plugin
 
-Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create `config.json` in its root directory (refer to `config.json.example`), then load the plugin in Kimi to use it.
+将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在其根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
 
 ---
 
 ## Standard Workflow
 
-Regardless of which client extension you use, the standard interaction flow with OpenAaaS is consistent:
+无论你使用哪个客户端扩展，与 OpenAaaS 交互的标准流程一致：
 
-1. **Set up server** — Configure the target OpenAaaS server address
-2. **Register** — Register the client with the server, obtain and save the `api_key` (only once per server)
-3. **Browse services** — Use `list_services` to get lightweight summaries of available services and filter candidates
-4. **Get usage** — Use `get_service_usage` to view the detailed capabilities, calling conventions, and return format of the target service
-5. **Submit task** — Use `submit_task` to construct `task_prompt` and `output_prompt`, save the returned `task_id`
-6. **Query result** — Only call `get_task` to query task status and results when the user explicitly requests it (do not poll actively)
-7. **Download result** — Use `download_result` to retrieve task output files
+1. **设置服务器** — 配置目标 OpenAaaS 服务器地址
+2. **注册** — 向服务器注册客户端，获取并保存 `api_key`（每个服务器仅需一次）
+3. **浏览服务** — `list_services` 获取可用服务的轻量摘要，筛选候选服务
+4. **获取用法** — `get_service_usage` 查看目标服务的详细能力范围、调用规范和返回格式
+5. **提交任务** — `submit_task` 构造 `task_prompt` 和 `output_prompt`，保存返回的 `task_id`
+6. **查询结果** — 仅在用户明确要求时调用 `get_task` 查询任务状态和结果（不要主动轮询）
+7. **下载结果** — `download_result` 获取任务输出的文件
 
-> **Note**: The pi-extension additionally supports `list_history` for querying the current Session's task history, enabling context reconstruction after session interruption.
+> **注意**：pi-extension 额外支持 `list_history` 用于查询当前 Session 的任务历史，实现会话中断后的上下文重建。
 
-Follow the principle of progressive disclosure: first browse the lightweight service list to filter candidates, then get detailed usage on demand, to avoid loading complete documentation for all services at once, which could cause context overflow.
+遵循渐进式披露原则：先浏览轻量服务列表筛选候选，再按需获取详细用法，避免一次性加载所有服务的完整文档导致上下文溢出。

--- a/client-extension/README.zh.md
+++ b/client-extension/README.zh.md
@@ -2,21 +2,21 @@
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-`client-extension/` 是 OpenAaaS 的客户端扩展集合，让不同的 Agent 客户端（pi、Kimi 等）能够连接到 OpenAaaS 网络，发现远程服务、提交任务并获取结果。
+`client-extension/` is the collection of client extensions for OpenAaaS, enabling different Agent clients (pi, Kimi, etc.) to connect to the OpenAaaS network, discover remote services, submit tasks, and retrieve results.
 
-目前包含三个扩展：
+Currently includes three extensions:
 
 ### pi-extension
 
-面向 [pi](https://github.com/badlogic/pi-mono) 的 TypeScript 扩展。提供统一的 `OpenAaaS` 入口工具，通过 `action` 参数调用不同功能。支持多服务器配置、自动任务监控（widget + toast 通知）、Session 持久化与重建提醒。
+A TypeScript extension for [pi](https://github.com/badlogic/pi-mono). Provides a unified `OpenAaaS` entry tool with different functionalities invoked via the `action` parameter. Supports multi-server configuration, automatic task monitoring (widget + toast notifications), Session persistence, and reconstruction reminders.
 
 ### kimi-plugin
 
-面向 Kimi 的 Python 插件。通过 `plugin.json` 定义多个独立工具，支持多服务器管理、渐进式信息获取。包含完整的测试套件。
+A Python plugin for Kimi. Defines multiple independent tools via `plugin.json`, supports multi-server management, and progressive information retrieval. Includes a complete test suite.
 
 ### openaaas-mcp-adapter
 
-面向 Claude Desktop、Cursor、Cline 等 MCP 客户端的 Python 适配器。基于 MCP SDK 构建，Transport 为 `stdio`，提供 14 个核心 Tool，支持文件上传下载、多服务器配置、路径遍历与 zip 炸弹防护。
+A Python adapter for MCP clients such as Claude Desktop, Cursor, and Cline. Built on the MCP SDK, with `stdio` Transport, providing 14 core Tools, supporting file upload/download, multi-server configuration, path traversal, and zip bomb protection.
 
 ---
 
@@ -31,7 +31,7 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-在 pi 中执行 `/reload` 加载扩展。首次使用时会自动创建默认配置文件，然后即可通过对话调用：
+Execute `/reload` in pi to load the extension. A default configuration file will be created automatically on first use. Then you can invoke via conversation:
 
 ```
 OpenAaaS(action: "set_server_url", server_url: "https://api.open-aaas.com")
@@ -41,13 +41,13 @@ OpenAaaS(action: "list_services")
 
 ### openaaas-mcp-adapter
 
-使用 uvx 零安装运行（需已安装 [uv](https://docs.astral.sh/uv/)）：
+Run with zero installation using uvx (requires [uv](https://docs.astral.sh/uv/)):
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-或在 Claude Desktop 的 `claude_desktop_config.json` 中添加：
+Or add to Claude Desktop's `claude_desktop_config.json`:
 
 ```json
 {
@@ -60,7 +60,7 @@ uvx openaaas-mcp-adapter
 }
 ```
 
-配置完成后重启 Claude Desktop，即可在对话中调用工具：
+After configuration, restart Claude Desktop, then invoke tools in conversation:
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com")
@@ -70,22 +70,22 @@ list_services()
 
 ### kimi-plugin
 
-将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在其根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
+Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create `config.json` in its root directory (refer to `config.json.example`), then load the plugin in Kimi to use it.
 
 ---
 
 ## Standard Workflow
 
-无论你使用哪个客户端扩展，与 OpenAaaS 交互的标准流程一致：
+Regardless of which client extension you use, the standard interaction flow with OpenAaaS is consistent:
 
-1. **设置服务器** — 配置目标 OpenAaaS 服务器地址
-2. **注册** — 向服务器注册客户端，获取并保存 `api_key`（每个服务器仅需一次）
-3. **浏览服务** — `list_services` 获取可用服务的轻量摘要，筛选候选服务
-4. **获取用法** — `get_service_usage` 查看目标服务的详细能力范围、调用规范和返回格式
-5. **提交任务** — `submit_task` 构造 `task_prompt` 和 `output_prompt`，保存返回的 `task_id`
-6. **查询结果** — 仅在用户明确要求时调用 `get_task` 查询任务状态和结果（不要主动轮询）
-7. **下载结果** — `download_result` 获取任务输出的文件
+1. **Set up server** — Configure the target OpenAaaS server address
+2. **Register** — Register the client with the server, obtain and save the `api_key` (only once per server)
+3. **Browse services** — Use `list_services` to get lightweight summaries of available services and filter candidates
+4. **Get usage** — Use `get_service_usage` to view the detailed capabilities, calling conventions, and return format of the target service
+5. **Submit task** — Use `submit_task` to construct `task_prompt` and `output_prompt`, save the returned `task_id`
+6. **Query result** — Only call `get_task` to query task status and results when the user explicitly requests it (do not poll actively)
+7. **Download result** — Use `download_result` to retrieve task output files
 
-> **注意**：pi-extension 额外支持 `list_history` 用于查询当前 Session 的任务历史，实现会话中断后的上下文重建。
+> **Note**: The pi-extension additionally supports `list_history` for querying the current Session's task history, enabling context reconstruction after session interruption.
 
-遵循渐进式披露原则：先浏览轻量服务列表筛选候选，再按需获取详细用法，避免一次性加载所有服务的完整文档导致上下文溢出。
+Follow the principle of progressive disclosure: first browse the lightweight service list to filter candidates, then get detailed usage on demand, to avoid loading complete documentation for all services at once, which could cause context overflow.

--- a/client-extension/kimi-plugin/README.md
+++ b/client-extension/kimi-plugin/README.md
@@ -1,47 +1,47 @@
-# OpenAaaS Kimi Plugin
+# OpenAaaS Kimi 插件
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-A Kimi Code plugin for OpenAaaS, enabling Kimi to connect to the OpenAaaS network, discover remote Agent services, submit tasks, and retrieve results.
+OpenAaaS 的 Kimi Code 插件，让 Kimi 能够连接 OpenAaaS 网络，发现远程 Agent 服务、提交任务并获取结果。
 
-## Features
+## 功能
 
-- **Service Discovery** — `discover` to get server API info, available services, and authentication methods
-- **Multi-Server Management** — `set_server_url`, `list_servers`, and `remove_server` for managing multiple server configurations
-- **Client Registration** — `register` to obtain and persist `api_key` automatically
-- **Service Browsing** — `list_services` for lightweight summaries, `get_service_usage` for detailed capabilities
-- **Task Lifecycle** — `submit_task`, `get_task`, `cancel_task`, `list_files`, and `download_result` for full task management
-- **Progressive Disclosure** — Follows the principle of browsing lightweight summaries first, then retrieving detailed usage on demand
+- **服务发现** — `discover` 获取服务端 API 信息、可用服务列表和认证方式
+- **多服务器管理** — `set_server_url`、`list_servers`、`remove_server` 管理多服务器配置
+- **客户端注册** — `register` 自动获取并持久化 `api_key`
+- **服务浏览** — `list_services` 获取轻量摘要，`get_service_usage` 获取详细能力说明
+- **任务全生命周期** — `submit_task`、`get_task`、`cancel_task`、`list_files`、`download_result` 完整任务管理
+- **渐进式披露** — 遵循先浏览轻量摘要，再按需获取详细用法的原则
 
-## Tools
+## 工具列表
 
-| Tool | Description |
-|------|-------------|
-| `discover` | Discover server API information |
-| `set_server_url` | Configure server URL |
-| `list_servers` | List all configured servers |
-| `remove_server` | Remove a server configuration |
-| `register` | Register client and save API key |
-| `update_profile` | Update client profile name |
-| `list_services` | List available Agent services |
-| `get_service_usage` | Get detailed usage for a service |
-| `submit_task` | Submit a task to a remote Agent |
-| `get_task` | Query task status and results |
-| `cancel_task` | Cancel a running task |
-| `list_files` | List result files for a task |
-| `download_result` | Download task result files |
+| 工具 | 说明 |
+|------|------|
+| `discover` | 发现服务端 API 信息 |
+| `set_server_url` | 配置服务器地址 |
+| `list_servers` | 列出所有已配置的服务器 |
+| `remove_server` | 移除服务器配置 |
+| `register` | 注册客户端并保存 API key |
+| `update_profile` | 更新客户端名称 |
+| `list_services` | 列出可用 Agent 服务 |
+| `get_service_usage` | 获取指定服务的详细用法 |
+| `submit_task` | 向远程 Agent 提交任务 |
+| `get_task` | 查询任务状态和结果 |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务结果文件 |
+| `download_result` | 下载任务结果文件 |
 
-## Installation
+## 安装
 
-Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create a `config.json` in the root (refer to `config.json.example`), then load the plugin in Kimi.
+将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
 
-## Standard Workflow
+## 标准流程
 
-1. `set_server_url` — Configure the target OpenAaaS server
-2. `register` — Register the client to obtain `api_key` (once per server)
-3. `list_services` — Browse available services and filter candidates
-4. `get_service_usage` — Get detailed usage for selected services
-5. `submit_task` — Submit a task with `task_prompt` and `output_prompt`
-6. `get_task` / `download_result` — Query status and download results
+1. `set_server_url` — 配置目标 OpenAaaS 服务器
+2. `register` — 注册客户端获取 `api_key`（每个服务器仅需一次）
+3. `list_services` — 浏览可用服务并筛选候选
+4. `get_service_usage` — 获取候选服务的详细用法
+5. `submit_task` — 使用 `task_prompt` 和 `output_prompt` 提交任务
+6. `get_task` / `download_result` — 查询状态并下载结果
 
-> **Note**: Do not poll `get_task` actively. Wait for the user to request status updates.
+> **注意**：不要主动轮询 `get_task`，等待用户要求查询状态时再调用。

--- a/client-extension/kimi-plugin/README.zh.md
+++ b/client-extension/kimi-plugin/README.zh.md
@@ -1,47 +1,47 @@
-# OpenAaaS Kimi 插件
+# OpenAaaS Kimi Plugin
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-OpenAaaS 的 Kimi Code 插件，让 Kimi 能够连接 OpenAaaS 网络，发现远程 Agent 服务、提交任务并获取结果。
+A Kimi Code plugin for OpenAaaS, enabling Kimi to connect to the OpenAaaS network, discover remote Agent services, submit tasks, and retrieve results.
 
-## 功能
+## Features
 
-- **服务发现** — `discover` 获取服务端 API 信息、可用服务列表和认证方式
-- **多服务器管理** — `set_server_url`、`list_servers`、`remove_server` 管理多服务器配置
-- **客户端注册** — `register` 自动获取并持久化 `api_key`
-- **服务浏览** — `list_services` 获取轻量摘要，`get_service_usage` 获取详细能力说明
-- **任务全生命周期** — `submit_task`、`get_task`、`cancel_task`、`list_files`、`download_result` 完整任务管理
-- **渐进式披露** — 遵循先浏览轻量摘要，再按需获取详细用法的原则
+- **Service Discovery** — `discover` to get server API info, available services, and authentication methods
+- **Multi-Server Management** — `set_server_url`, `list_servers`, and `remove_server` for managing multiple server configurations
+- **Client Registration** — `register` to obtain and persist `api_key` automatically
+- **Service Browsing** — `list_services` for lightweight summaries, `get_service_usage` for detailed capabilities
+- **Task Lifecycle** — `submit_task`, `get_task`, `cancel_task`, `list_files`, and `download_result` for full task management
+- **Progressive Disclosure** — Follows the principle of browsing lightweight summaries first, then retrieving detailed usage on demand
 
-## 工具列表
+## Tools
 
-| 工具 | 说明 |
-|------|------|
-| `discover` | 发现服务端 API 信息 |
-| `set_server_url` | 配置服务器地址 |
-| `list_servers` | 列出所有已配置的服务器 |
-| `remove_server` | 移除服务器配置 |
-| `register` | 注册客户端并保存 API key |
-| `update_profile` | 更新客户端名称 |
-| `list_services` | 列出可用 Agent 服务 |
-| `get_service_usage` | 获取指定服务的详细用法 |
-| `submit_task` | 向远程 Agent 提交任务 |
-| `get_task` | 查询任务状态和结果 |
-| `cancel_task` | 取消执行中的任务 |
-| `list_files` | 列出任务结果文件 |
-| `download_result` | 下载任务结果文件 |
+| Tool | Description |
+|------|-------------|
+| `discover` | Discover server API information |
+| `set_server_url` | Configure server URL |
+| `list_servers` | List all configured servers |
+| `remove_server` | Remove a server configuration |
+| `register` | Register client and save API key |
+| `update_profile` | Update client profile name |
+| `list_services` | List available Agent services |
+| `get_service_usage` | Get detailed usage for a service |
+| `submit_task` | Submit a task to a remote Agent |
+| `get_task` | Query task status and results |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for a task |
+| `download_result` | Download task result files |
 
-## 安装
+## Installation
 
-将 `kimi-plugin/` 目录复制到 Kimi 插件目录（如 `~/.kimi/plugins/kimi-plugin`），在根目录下创建 `config.json`（可参考 `config.json.example`），然后在 Kimi 中加载插件即可使用。
+Copy the `kimi-plugin/` directory to the Kimi plugin directory (e.g. `~/.kimi/plugins/kimi-plugin`), create a `config.json` in the root (refer to `config.json.example`), then load the plugin in Kimi.
 
-## 标准流程
+## Standard Workflow
 
-1. `set_server_url` — 配置目标 OpenAaaS 服务器
-2. `register` — 注册客户端获取 `api_key`（每个服务器仅需一次）
-3. `list_services` — 浏览可用服务并筛选候选
-4. `get_service_usage` — 获取候选服务的详细用法
-5. `submit_task` — 使用 `task_prompt` 和 `output_prompt` 提交任务
-6. `get_task` / `download_result` — 查询状态并下载结果
+1. `set_server_url` — Configure the target OpenAaaS server
+2. `register` — Register the client to obtain `api_key` (once per server)
+3. `list_services` — Browse available services and filter candidates
+4. `get_service_usage` — Get detailed usage for selected services
+5. `submit_task` — Submit a task with `task_prompt` and `output_prompt`
+6. `get_task` / `download_result` — Query status and download results
 
-> **注意**：不要主动轮询 `get_task`，等待用户要求查询状态时再调用。
+> **Note**: Do not poll `get_task` actively. Wait for the user to request status updates.

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -2,31 +2,31 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-The MCP (Model Context Protocol) adapter for OpenAaaS, enabling MCP-enabled AI clients such as Claude Desktop, Cursor, and Cline to connect to the OpenAaaS Server, discover remote services, submit tasks, and retrieve results.
+OpenAaaS 的 MCP（Model Context Protocol）适配器，让 Claude Desktop、Cursor、Cline 等支持 MCP 的 AI 客户端能够连接 OpenAaaS Server，发现远程服务、提交任务并获取结果。
 
-Built on the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), providing 14 core Tools covering the complete client capabilities: service discovery, registration and authentication, task submission, result download, and multi-server management.
+基于 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) 构建，提供 14 个核心 Tool，覆盖完整的客户端能力：服务发现、注册认证、任务提交、结果下载及多服务器管理。
 
 ---
 
-## Quick Start
+## 快速开始
 
-### Recommended: uvx (Zero Install, No Local Download)
+### 推荐：uvx（零安装，无需下载到本地）
 
-After installing [uv](https://docs.astral.sh/uv/), run directly without downloading the package locally:
+安装 [uv](https://docs.astral.sh/uv/) 后，直接运行，无需把包下载到本地：
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-`uv` will automatically pull from PyPI and create a temporary virtual environment to run, cleaning up afterward without leaving any files on the system.
+`uv` 会自动从 PyPI 拉取并创建临时虚拟环境运行，用完即走，不会在系统中留下任何文件。
 
-This is the **most recommended method**, suitable for all users.
+这是**最推荐的方式**，适合所有用户。
 
 ---
 
-### Client Configuration
+### 客户端配置
 
-Configure Claude Desktop, Cursor, or Cline:
+配置 Claude Desktop、Cursor 或 Cline：
 
 ```json
 {
@@ -39,22 +39,22 @@ Configure Claude Desktop, Cursor, or Cline:
 }
 ```
 
-After modifying the configuration, restart the client for it to take effect.
+配置修改后，重启客户端即可生效。
 
 ---
 
-### Other Installation Methods (Optional)
+### 其他安装方式（可选）
 
 <details>
-<summary>Click to view other installation methods</summary>
+<summary>点击查看其他安装方式</summary>
 
-#### pipx (Global Install)
+#### pipx（全局安装）
 
 ```bash
 pipx install openaaas-mcp-adapter
 ```
 
-MCP configuration changes to:
+MCP 配置改为：
 ```json
 {
   "mcpServers": {
@@ -65,13 +65,13 @@ MCP configuration changes to:
 }
 ```
 
-#### pip Install
+#### pip 安装
 
 ```bash
 pip install openaaas-mcp-adapter
 ```
 
-#### Local Source Run (Development)
+#### 本地源码运行（开发）
 
 ```bash
 cd openaaas-mcp-adapter
@@ -83,15 +83,15 @@ uv run openaaas-mcp-adapter
 
 ---
 
-## Configuration File
+## 配置文件
 
-The configuration file is saved in the user's home directory:
+配置文件保存在用户主目录下：
 
 ```
 ~/.openaaas-mcp-adapter/config.json
 ```
 
-If it does not exist on first run, a default configuration will be created automatically:
+首次运行时若不存在，会自动创建默认配置：
 
 ```json
 {
@@ -107,7 +107,7 @@ If it does not exist on first run, a default configuration will be created autom
 }
 ```
 
-Example configuration after successful registration:
+注册成功后的配置示例：
 
 ```json
 {
@@ -123,39 +123,39 @@ Example configuration after successful registration:
 }
 ```
 
-After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
+运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
 
 ---
 
-## Multi-Server Configuration
+## 多服务器配置
 
-Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
+支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
 
-### Register for Multiple Servers Separately
+### 为多个服务器分别注册
 
-Each server alias has independent registration information:
+每个服务器别名有独立的注册信息：
 
 ```
 register(name: "my-prod-client", server: "prod")
 register(name: "my-local-client", server: "local")
 ```
 
-The two servers will save their respective api_keys independently without interference.
+两个服务器会分别保存各自的 api_key，互不干扰。
 
-### Set Server URL
+### 设置服务器地址
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com", server: "prod")
 set_server_url(server_url: "http://127.0.0.1:8080", server: "local")
 ```
 
-### Switch Default Server
+### 切换默认服务器
 
 ```
 set_default_server(server: "prod")
 ```
 
-### List All Configured Servers
+### 列出所有配置的服务器
 
 ```
 list_servers()
@@ -163,176 +163,176 @@ list_servers()
 
 ---
 
-## Available Tools
+## 可用工具
 
-| Tool Name | Function Description |
-|-----------|----------------------|
-| `discover` | Discover server API information (returns server version, supported API endpoints, available service list, authentication method, etc. Recommended to call when connecting to a new server for the first time) |
-| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
-| `register` | Register client, automatically save api_key (only once) |
-| `update_profile` | Modify user name |
-| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
-| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
-| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
-| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
-| `cancel_task` | Cancel a running task |
-| `list_files` | List result files for the task |
-| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
-| `list_servers` | List all configured servers |
-| `set_default_server` | Switch default server |
-| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
+| 工具名 | 功能描述 |
+|--------|----------|
+| `discover` | 发现服务端 API 信息（返回服务端版本、支持的 API 端点、可用服务列表、认证方式等。建议在首次连接新服务器时调用） |
+| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
+| `register` | 注册客户端，自动保存 api_key（仅需一次） |
+| `update_profile` | 修改用户名 |
+| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
+| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
+| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
+| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务的结果文件列表 |
+| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
+| `list_servers` | 列出所有已配置的服务器 |
+| `set_default_server` | 切换默认服务器 |
+| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
 
-### Parameter Description
+### 参数说明
 
-| Tool Name | Parameter | Required | Description |
-|-----------|-----------|----------|-------------|
-| `discover` | `server_url` | ✅ | Target server URL |
-| `set_server_url` | `server_url` | ✅ | Server URL (must start with http:// or https://) |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `register` | `name` | ✅ | Client name (length ≤64, no ASCII control characters, Unicode control characters, or `\/<>|&;$`) |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `update_profile` | `name` | ✅ | New user name (same constraints) |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `list_services` | `server` | ❌ | Server alias, default `"default"` |
-| `get_service_usage` | `service_id` | ✅ | Target service ID |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `submit_task` | `service_id` | ✅ | Target service ID |
-| | `task_prompt` | ✅ | Task description prompt |
-| | `output_prompt` | ❌ | Output format requirement, default `""` |
-| | `input_files` | ❌ | Local file path list (up to 10 files, single file ≤100MB, current working directory only) |
-| | `session_id` | ❌ | Session ID, for maintaining conversation context |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `get_task` | `task_id` | ✅ | Task ID |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `cancel_task` | `task_id` | ✅ | Task ID |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `list_files` | `task_id` | ✅ | Task ID |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `download_result` | `task_id` | ✅ | Task ID |
-| | `file_id` | ❌ | Specify file ID, default `""` |
-| | `download_all` | ❌ | Whether to download all files, default `false` |
-| | `server` | ❌ | Server alias, default `"default"` |
-| `list_servers` | — | — | No parameters |
-| `set_default_server` | `server` | ✅ | Server alias to set as default |
-| `remove_server` | `server` | ✅ | Server alias to delete |
-
----
-
-## Progressive Information Retrieval
-
-This adapter follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
-
-### Standard Usage Flow
-
-1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
-2. `register` — Register to get api_key (only once)
-3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
-4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
-5. Based on usage content, construct correct `task_prompt` and `output_prompt`
-6. `submit_task` — Submit task (with optional files), save returned `task_id`
-7. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
-8. `download_result` — Download result files after task completion
-
-### Why This Design
-
-- `list_services` returns a lightweight summary, not occupying LLM context
-- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
-- Avoid loading complete documentation for all services at once, which could cause context overflow
+| 工具名 | 参数 | 必填 | 说明 |
+|--------|------|------|------|
+| `discover` | `server_url` | ✅ | 目标服务器地址 |
+| `set_server_url` | `server_url` | ✅ | 服务器地址（以 http:// 或 https:// 开头） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `register` | `name` | ✅ | 客户端名称（长度 ≤64，不含 ASCII 控制字符、Unicode 控制字符及 `\/<>|&;$`） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `update_profile` | `name` | ✅ | 新用户名（同上约束） |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_services` | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `get_service_usage` | `service_id` | ✅ | 目标服务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `submit_task` | `service_id` | ✅ | 目标服务 ID |
+| | `task_prompt` | ✅ | 任务描述 prompt |
+| | `output_prompt` | ❌ | 输出格式要求，默认 `""` |
+| | `input_files` | ❌ | 本地文件路径列表（最多 10 个，单文件 ≤100MB，仅限当前工作目录） |
+| | `session_id` | ❌ | 会话 ID，用于保持对话上下文 |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `get_task` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `cancel_task` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_files` | `task_id` | ✅ | 任务 ID |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `download_result` | `task_id` | ✅ | 任务 ID |
+| | `file_id` | ❌ | 指定文件 ID，默认 `""` |
+| | `download_all` | ❌ | 是否下载所有文件，默认 `false` |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `list_servers` | — | — | 无参数 |
+| `set_default_server` | `server` | ✅ | 要设为默认的服务器别名 |
+| `remove_server` | `server` | ✅ | 要删除的服务器别名 |
 
 ---
 
-## MCP Transport Description
+## 渐进式信息获取
 
-- **MCP Transport**: `stdio` (standard input/output). The adapter is launched as a child process by the MCP client; all tool calls communicate via JSON-RPC over stdio
-- **File Transfer**: File upload and download do not go through the MCP protocol, but instead use independent **HTTP (multipart/form-data)** direct connection to the OpenAaaS Server:
-  - `input_files` in `submit_task` are uploaded via HTTP multipart
-  - `download_result` downloads files via HTTP GET
-- This design avoids transferring large binary data through MCP stdio, ensuring performance and stability
+本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
+
+### 标准使用流程
+
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
+2. `register` — 注册获取 api_key（仅需一次）
+3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
+4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
+5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
+6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
+7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
+8. `download_result` — 任务完成后下载结果文件
+
+### 为什么这样设计
+
+- `list_services` 返回轻量摘要，不占用 LLM 上下文
+- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
+- 避免一次性加载所有服务的完整文档导致上下文溢出
 
 ---
 
-## Registration Constraints
+## MCP 传输说明
 
-- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
-- To modify the user name, use `update_profile` (example: `update_profile(name: "new-name")`)
-- **`name` parameter constraint**: Length does not exceed 64 characters, no ASCII control characters, Unicode control characters, or `\ / < > | & ; $`
-- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
-- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
-- **Cross-alias duplicate registration check**: If a `server_url` has already been registered under another `server` alias (i.e. the URL already has an api_key), the new alias cannot register or set that address again, preventing the same server from being recorded multiple times under different aliases
-- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
+- **MCP Transport**：`stdio`（标准输入输出），适配器作为子进程由 MCP 客户端启动，所有 tool 调用通过 JSON-RPC 在 stdio 上通信
+- **文件传输**：文件上传和下载不走 MCP 协议，而是通过独立的 **HTTP（multipart/form-data）** 直连 OpenAaaS Server：
+  - `submit_task` 中的 `input_files` 通过 HTTP multipart 上传
+  - `download_result` 通过 HTTP GET 下载文件
+- 这样设计避免了通过 MCP stdio 传输大体积二进制数据，保证性能和稳定性
 
 ---
 
-## Usage Examples
+## 注册约束
 
-### Basic Flow
+- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
+- 如需修改用户名，请使用 `update_profile`（示例：`update_profile(name: "new-name")`）
+- **`name` 参数约束**：长度不超过 64 个字符，不含 ASCII 控制字符、Unicode 控制字符及 `\ / < > | & ; $`
+- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
+- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
+- **跨别名重复注册检查**：如果某个 `server_url` 已被其他 `server` 别名注册过（即该 URL 已有 api_key），则新别名无法再次注册或设置该地址，防止同一服务器被多个别名重复记录
+- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
 
-1. **Set server URL** (optional, default https://api.open-aaas.com):
+---
+
+## 使用示例
+
+### 基础流程
+
+1. **设置服务器地址**（可选，默认 https://api.open-aaas.com）：
    ```
    set_server_url(server_url: "https://api.open-aaas.com")
    ```
 
-   Optional: Discover server information:
+   可选：发现服务端信息：
    ```
    discover(server_url: "https://api.open-aaas.com")
    ```
 
-2. **Register client**:
+2. **注册客户端**：
    ```
    register(name: "my-client")
    ```
 
-3. **List services and filter candidates**:
+3. **列出服务并筛选候选**：
    ```
    list_services()
    ```
 
-4. **Get detailed usage for the target service**:
+4. **对目标服务获取详细 usage**：
    ```
    get_service_usage(service_id: "my-service")
    ```
 
-5. **Submit task**:
+5. **提交任务**：
    ```
    submit_task(
      service_id: "my-service",
-     task_prompt: "Analyze data and generate report",
-     output_prompt: "Return analysis report in Markdown format"
+     task_prompt: "分析数据并生成报告",
+     output_prompt: "返回 Markdown 格式的分析报告"
    )
    ```
 
-6. **Query task** (only call when the user requests it):
+6. **查询任务**（仅在用户要求时调用）：
    ```
    get_task(task_id: "xxx")
    ```
 
-7. **Download result**:
+7. **下载结果**：
    ```
    download_result(task_id: "xxx")
    ```
 
-### Task with File Upload
+### 带文件上传的任务
 
 ```
 submit_task(
   service_id: "data-analysis-agent",
-  task_prompt: "Analyze sales data in the attachment and identify growth trends",
-  output_prompt: "Return analysis results in JSON format, containing trend and insights fields",
+  task_prompt: "分析附件中的销售数据，找出增长趋势",
+  output_prompt: "返回 JSON 格式的分析结果，包含 trend 和 insights 字段",
   input_files: ["./sales_data.csv", "./notes.txt"],
-  session_id: "Optional, for maintaining conversation context"
+  session_id: "可选，用于保持对话上下文"
 )
 ```
 
-File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
+文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
 
-### Multi-Server Switching
+### 多服务器切换
 
 ```
 list_services(server: "prod")
 submit_task(server: "local", service_id: "my-service", task_prompt: "...")
 ```
 
-### Delete Server Configuration
+### 删除服务器配置
 
 ```
 remove_server(server: "old-server")
@@ -340,19 +340,19 @@ remove_server(server: "old-server")
 
 ---
 
-## Security Features
+## 安全特性
 
-- **Path traversal protection**: File uploads are limited to the current working directory; zip extraction validates paths file by file, preventing `../` path traversal
-- **Zip bomb protection**: Maximum compression ratio 500, total size after extraction 100MB, maximum file count 1000, single file maximum 50MB
-- **Symbolic link rejection**: Symbolic links in uploaded files and zip archives are directly rejected
-- **Atomic write**: Configuration files use temporary file + `replace` to ensure the write process does not corrupt data
-- **Download limit**: Single file download does not exceed 100MB
+- **路径遍历防护**：文件上传仅限当前工作目录下；zip 解压逐文件验证路径，防止 `../` 路径穿越
+- **zip 炸弹防护**：最大压缩比 500、解压后总大小 100MB、最大文件数 1000、单文件最大 50MB
+- **符号链接拒绝**：上传文件和 zip 中的符号链接均被直接拒绝
+- **原子写入**：配置文件使用临时文件 + `replace` 保证写入过程不损坏
+- **下载限制**：单文件下载不超过 100MB
 
 ---
 
-## Development
+## 开发
 
-Local development run method:
+本地开发运行方式：
 
 ```bash
 cd openaaas-mcp-adapter
@@ -360,7 +360,7 @@ uv sync
 uv run openaaas-mcp-adapter
 ```
 
-Or using Python module mode:
+或使用 Python 模块方式：
 
 ```bash
 uv run python -m openaaas_mcp_adapter
@@ -368,13 +368,13 @@ uv run python -m openaaas_mcp_adapter
 
 ---
 
-## Links
+## 链接
 
 - GitHub: [https://github.com/Wolido/OpenAaaS](https://github.com/Wolido/OpenAaaS)
-- Website: [https://www.open-aaas.com](https://www.open-aaas.com)
+- 官网: [https://www.open-aaas.com](https://www.open-aaas.com)
 
 ---
 
-## License
+## 许可证
 
 MIT License

--- a/client-extension/openaaas-mcp-adapter/README.zh.md
+++ b/client-extension/openaaas-mcp-adapter/README.zh.md
@@ -2,31 +2,31 @@
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-OpenAaaS 的 MCP（Model Context Protocol）适配器，让 Claude Desktop、Cursor、Cline 等支持 MCP 的 AI 客户端能够连接 OpenAaaS Server，发现远程服务、提交任务并获取结果。
+The MCP (Model Context Protocol) adapter for OpenAaaS, enabling MCP-enabled AI clients such as Claude Desktop, Cursor, and Cline to connect to the OpenAaaS Server, discover remote services, submit tasks, and retrieve results.
 
-基于 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) 构建，提供 14 个核心 Tool，覆盖完整的客户端能力：服务发现、注册认证、任务提交、结果下载及多服务器管理。
+Built on the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), providing 14 core Tools covering the complete client capabilities: service discovery, registration and authentication, task submission, result download, and multi-server management.
 
 ---
 
-## 快速开始
+## Quick Start
 
-### 推荐：uvx（零安装，无需下载到本地）
+### Recommended: uvx (Zero Install, No Local Download)
 
-安装 [uv](https://docs.astral.sh/uv/) 后，直接运行，无需把包下载到本地：
+After installing [uv](https://docs.astral.sh/uv/), run directly without downloading the package locally:
 
 ```bash
 uvx openaaas-mcp-adapter
 ```
 
-`uv` 会自动从 PyPI 拉取并创建临时虚拟环境运行，用完即走，不会在系统中留下任何文件。
+`uv` will automatically pull from PyPI and create a temporary virtual environment to run, cleaning up afterward without leaving any files on the system.
 
-这是**最推荐的方式**，适合所有用户。
+This is the **most recommended method**, suitable for all users.
 
 ---
 
-### 客户端配置
+### Client Configuration
 
-配置 Claude Desktop、Cursor 或 Cline：
+Configure Claude Desktop, Cursor, or Cline:
 
 ```json
 {
@@ -39,22 +39,22 @@ uvx openaaas-mcp-adapter
 }
 ```
 
-配置修改后，重启客户端即可生效。
+After modifying the configuration, restart the client for it to take effect.
 
 ---
 
-### 其他安装方式（可选）
+### Other Installation Methods (Optional)
 
 <details>
-<summary>点击查看其他安装方式</summary>
+<summary>Click to view other installation methods</summary>
 
-#### pipx（全局安装）
+#### pipx (Global Install)
 
 ```bash
 pipx install openaaas-mcp-adapter
 ```
 
-MCP 配置改为：
+MCP configuration changes to:
 ```json
 {
   "mcpServers": {
@@ -65,13 +65,13 @@ MCP 配置改为：
 }
 ```
 
-#### pip 安装
+#### pip Install
 
 ```bash
 pip install openaaas-mcp-adapter
 ```
 
-#### 本地源码运行（开发）
+#### Local Source Run (Development)
 
 ```bash
 cd openaaas-mcp-adapter
@@ -83,15 +83,15 @@ uv run openaaas-mcp-adapter
 
 ---
 
-## 配置文件
+## Configuration File
 
-配置文件保存在用户主目录下：
+The configuration file is saved in the user's home directory:
 
 ```
 ~/.openaaas-mcp-adapter/config.json
 ```
 
-首次运行时若不存在，会自动创建默认配置：
+If it does not exist on first run, a default configuration will be created automatically:
 
 ```json
 {
@@ -107,7 +107,7 @@ uv run openaaas-mcp-adapter
 }
 ```
 
-注册成功后的配置示例：
+Example configuration after successful registration:
 
 ```json
 {
@@ -123,39 +123,39 @@ uv run openaaas-mcp-adapter
 }
 ```
 
-运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
 
 ---
 
-## 多服务器配置
+## Multi-Server Configuration
 
-支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
 
-### 为多个服务器分别注册
+### Register for Multiple Servers Separately
 
-每个服务器别名有独立的注册信息：
+Each server alias has independent registration information:
 
 ```
 register(name: "my-prod-client", server: "prod")
 register(name: "my-local-client", server: "local")
 ```
 
-两个服务器会分别保存各自的 api_key，互不干扰。
+The two servers will save their respective api_keys independently without interference.
 
-### 设置服务器地址
+### Set Server URL
 
 ```
 set_server_url(server_url: "https://api.open-aaas.com", server: "prod")
 set_server_url(server_url: "http://127.0.0.1:8080", server: "local")
 ```
 
-### 切换默认服务器
+### Switch Default Server
 
 ```
 set_default_server(server: "prod")
 ```
 
-### 列出所有配置的服务器
+### List All Configured Servers
 
 ```
 list_servers()
@@ -163,176 +163,176 @@ list_servers()
 
 ---
 
-## 可用工具
+## Available Tools
 
-| 工具名 | 功能描述 |
-|--------|----------|
-| `discover` | 发现服务端 API 信息（返回服务端版本、支持的 API 端点、可用服务列表、认证方式等。建议在首次连接新服务器时调用） |
-| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
-| `register` | 注册客户端，自动保存 api_key（仅需一次） |
-| `update_profile` | 修改用户名 |
-| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
-| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
-| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
-| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
-| `cancel_task` | 取消执行中的任务 |
-| `list_files` | 列出任务的结果文件列表 |
-| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
-| `list_servers` | 列出所有已配置的服务器 |
-| `set_default_server` | 切换默认服务器 |
-| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+| Tool Name | Function Description |
+|-----------|----------------------|
+| `discover` | Discover server API information (returns server version, supported API endpoints, available service list, authentication method, etc. Recommended to call when connecting to a new server for the first time) |
+| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
+| `register` | Register client, automatically save api_key (only once) |
+| `update_profile` | Modify user name |
+| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
+| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
+| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
+| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for the task |
+| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
+| `list_servers` | List all configured servers |
+| `set_default_server` | Switch default server |
+| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
 
-### 参数说明
+### Parameter Description
 
-| 工具名 | 参数 | 必填 | 说明 |
-|--------|------|------|------|
-| `discover` | `server_url` | ✅ | 目标服务器地址 |
-| `set_server_url` | `server_url` | ✅ | 服务器地址（以 http:// 或 https:// 开头） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `register` | `name` | ✅ | 客户端名称（长度 ≤64，不含 ASCII 控制字符、Unicode 控制字符及 `\/<>|&;$`） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `update_profile` | `name` | ✅ | 新用户名（同上约束） |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_services` | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `get_service_usage` | `service_id` | ✅ | 目标服务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `submit_task` | `service_id` | ✅ | 目标服务 ID |
-| | `task_prompt` | ✅ | 任务描述 prompt |
-| | `output_prompt` | ❌ | 输出格式要求，默认 `""` |
-| | `input_files` | ❌ | 本地文件路径列表（最多 10 个，单文件 ≤100MB，仅限当前工作目录） |
-| | `session_id` | ❌ | 会话 ID，用于保持对话上下文 |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `get_task` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `cancel_task` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_files` | `task_id` | ✅ | 任务 ID |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `download_result` | `task_id` | ✅ | 任务 ID |
-| | `file_id` | ❌ | 指定文件 ID，默认 `""` |
-| | `download_all` | ❌ | 是否下载所有文件，默认 `false` |
-| | `server` | ❌ | 服务器别名，默认 `"default"` |
-| `list_servers` | — | — | 无参数 |
-| `set_default_server` | `server` | ✅ | 要设为默认的服务器别名 |
-| `remove_server` | `server` | ✅ | 要删除的服务器别名 |
-
----
-
-## 渐进式信息获取
-
-本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
-
-### 标准使用流程
-
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
-2. `register` — 注册获取 api_key（仅需一次）
-3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
-4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
-5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
-6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
-7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-8. `download_result` — 任务完成后下载结果文件
-
-### 为什么这样设计
-
-- `list_services` 返回轻量摘要，不占用 LLM 上下文
-- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
-- 避免一次性加载所有服务的完整文档导致上下文溢出
+| Tool Name | Parameter | Required | Description |
+|-----------|-----------|----------|-------------|
+| `discover` | `server_url` | ✅ | Target server URL |
+| `set_server_url` | `server_url` | ✅ | Server URL (must start with http:// or https://) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `register` | `name` | ✅ | Client name (length ≤64, no ASCII control characters, Unicode control characters, or `\/<>|&;$`) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `update_profile` | `name` | ✅ | New user name (same constraints) |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_services` | `server` | ❌ | Server alias, default `"default"` |
+| `get_service_usage` | `service_id` | ✅ | Target service ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `submit_task` | `service_id` | ✅ | Target service ID |
+| | `task_prompt` | ✅ | Task description prompt |
+| | `output_prompt` | ❌ | Output format requirement, default `""` |
+| | `input_files` | ❌ | Local file path list (up to 10 files, single file ≤100MB, current working directory only) |
+| | `session_id` | ❌ | Session ID, for maintaining conversation context |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `get_task` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `cancel_task` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_files` | `task_id` | ✅ | Task ID |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `download_result` | `task_id` | ✅ | Task ID |
+| | `file_id` | ❌ | Specify file ID, default `""` |
+| | `download_all` | ❌ | Whether to download all files, default `false` |
+| | `server` | ❌ | Server alias, default `"default"` |
+| `list_servers` | — | — | No parameters |
+| `set_default_server` | `server` | ✅ | Server alias to set as default |
+| `remove_server` | `server` | ✅ | Server alias to delete |
 
 ---
 
-## MCP 传输说明
+## Progressive Information Retrieval
 
-- **MCP Transport**：`stdio`（标准输入输出），适配器作为子进程由 MCP 客户端启动，所有 tool 调用通过 JSON-RPC 在 stdio 上通信
-- **文件传输**：文件上传和下载不走 MCP 协议，而是通过独立的 **HTTP（multipart/form-data）** 直连 OpenAaaS Server：
-  - `submit_task` 中的 `input_files` 通过 HTTP multipart 上传
-  - `download_result` 通过 HTTP GET 下载文件
-- 这样设计避免了通过 MCP stdio 传输大体积二进制数据，保证性能和稳定性
+This adapter follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
+
+### Standard Usage Flow
+
+1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
+2. `register` — Register to get api_key (only once)
+3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
+4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
+5. Based on usage content, construct correct `task_prompt` and `output_prompt`
+6. `submit_task` — Submit task (with optional files), save returned `task_id`
+7. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
+8. `download_result` — Download result files after task completion
+
+### Why This Design
+
+- `list_services` returns a lightweight summary, not occupying LLM context
+- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
+- Avoid loading complete documentation for all services at once, which could cause context overflow
 
 ---
 
-## 注册约束
+## MCP Transport Description
 
-- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
-- 如需修改用户名，请使用 `update_profile`（示例：`update_profile(name: "new-name")`）
-- **`name` 参数约束**：长度不超过 64 个字符，不含 ASCII 控制字符、Unicode 控制字符及 `\ / < > | & ; $`
-- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
-- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
-- **跨别名重复注册检查**：如果某个 `server_url` 已被其他 `server` 别名注册过（即该 URL 已有 api_key），则新别名无法再次注册或设置该地址，防止同一服务器被多个别名重复记录
-- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+- **MCP Transport**: `stdio` (standard input/output). The adapter is launched as a child process by the MCP client; all tool calls communicate via JSON-RPC over stdio
+- **File Transfer**: File upload and download do not go through the MCP protocol, but instead use independent **HTTP (multipart/form-data)** direct connection to the OpenAaaS Server:
+  - `input_files` in `submit_task` are uploaded via HTTP multipart
+  - `download_result` downloads files via HTTP GET
+- This design avoids transferring large binary data through MCP stdio, ensuring performance and stability
 
 ---
 
-## 使用示例
+## Registration Constraints
 
-### 基础流程
+- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
+- To modify the user name, use `update_profile` (example: `update_profile(name: "new-name")`)
+- **`name` parameter constraint**: Length does not exceed 64 characters, no ASCII control characters, Unicode control characters, or `\ / < > | & ; $`
+- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
+- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
+- **Cross-alias duplicate registration check**: If a `server_url` has already been registered under another `server` alias (i.e. the URL already has an api_key), the new alias cannot register or set that address again, preventing the same server from being recorded multiple times under different aliases
+- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
 
-1. **设置服务器地址**（可选，默认 https://api.open-aaas.com）：
+---
+
+## Usage Examples
+
+### Basic Flow
+
+1. **Set server URL** (optional, default https://api.open-aaas.com):
    ```
    set_server_url(server_url: "https://api.open-aaas.com")
    ```
 
-   可选：发现服务端信息：
+   Optional: Discover server information:
    ```
    discover(server_url: "https://api.open-aaas.com")
    ```
 
-2. **注册客户端**：
+2. **Register client**:
    ```
    register(name: "my-client")
    ```
 
-3. **列出服务并筛选候选**：
+3. **List services and filter candidates**:
    ```
    list_services()
    ```
 
-4. **对目标服务获取详细 usage**：
+4. **Get detailed usage for the target service**:
    ```
    get_service_usage(service_id: "my-service")
    ```
 
-5. **提交任务**：
+5. **Submit task**:
    ```
    submit_task(
      service_id: "my-service",
-     task_prompt: "分析数据并生成报告",
-     output_prompt: "返回 Markdown 格式的分析报告"
+     task_prompt: "Analyze data and generate report",
+     output_prompt: "Return analysis report in Markdown format"
    )
    ```
 
-6. **查询任务**（仅在用户要求时调用）：
+6. **Query task** (only call when the user requests it):
    ```
    get_task(task_id: "xxx")
    ```
 
-7. **下载结果**：
+7. **Download result**:
    ```
    download_result(task_id: "xxx")
    ```
 
-### 带文件上传的任务
+### Task with File Upload
 
 ```
 submit_task(
   service_id: "data-analysis-agent",
-  task_prompt: "分析附件中的销售数据，找出增长趋势",
-  output_prompt: "返回 JSON 格式的分析结果，包含 trend 和 insights 字段",
+  task_prompt: "Analyze sales data in the attachment and identify growth trends",
+  output_prompt: "Return analysis results in JSON format, containing trend and insights fields",
   input_files: ["./sales_data.csv", "./notes.txt"],
-  session_id: "可选，用于保持对话上下文"
+  session_id: "Optional, for maintaining conversation context"
 )
 ```
 
-文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
 
-### 多服务器切换
+### Multi-Server Switching
 
 ```
 list_services(server: "prod")
 submit_task(server: "local", service_id: "my-service", task_prompt: "...")
 ```
 
-### 删除服务器配置
+### Delete Server Configuration
 
 ```
 remove_server(server: "old-server")
@@ -340,19 +340,19 @@ remove_server(server: "old-server")
 
 ---
 
-## 安全特性
+## Security Features
 
-- **路径遍历防护**：文件上传仅限当前工作目录下；zip 解压逐文件验证路径，防止 `../` 路径穿越
-- **zip 炸弹防护**：最大压缩比 500、解压后总大小 100MB、最大文件数 1000、单文件最大 50MB
-- **符号链接拒绝**：上传文件和 zip 中的符号链接均被直接拒绝
-- **原子写入**：配置文件使用临时文件 + `replace` 保证写入过程不损坏
-- **下载限制**：单文件下载不超过 100MB
+- **Path traversal protection**: File uploads are limited to the current working directory; zip extraction validates paths file by file, preventing `../` path traversal
+- **Zip bomb protection**: Maximum compression ratio 500, total size after extraction 100MB, maximum file count 1000, single file maximum 50MB
+- **Symbolic link rejection**: Symbolic links in uploaded files and zip archives are directly rejected
+- **Atomic write**: Configuration files use temporary file + `replace` to ensure the write process does not corrupt data
+- **Download limit**: Single file download does not exceed 100MB
 
 ---
 
-## 开发
+## Development
 
-本地开发运行方式：
+Local development run method:
 
 ```bash
 cd openaaas-mcp-adapter
@@ -360,7 +360,7 @@ uv sync
 uv run openaaas-mcp-adapter
 ```
 
-或使用 Python 模块方式：
+Or using Python module mode:
 
 ```bash
 uv run python -m openaaas_mcp_adapter
@@ -368,13 +368,13 @@ uv run python -m openaaas_mcp_adapter
 
 ---
 
-## 链接
+## Links
 
 - GitHub: [https://github.com/Wolido/OpenAaaS](https://github.com/Wolido/OpenAaaS)
-- 官网: [https://www.open-aaas.com](https://www.open-aaas.com)
+- Website: [https://www.open-aaas.com](https://www.open-aaas.com)
 
 ---
 
-## 许可证
+## License
 
 MIT License

--- a/client-extension/pi-extension/README.md
+++ b/client-extension/pi-extension/README.md
@@ -2,11 +2,11 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-An OpenAaaS extension for [pi](https://github.com/badlogic/pi-mono), providing a unified `OpenAaaS` tool for service discovery, client registration, task submission, and result download.
+为 [pi](https://github.com/badlogic/pi-mono) 开发的 OpenAaaS 扩展，提供统一的 `OpenAaaS` 工具，用于服务发现、客户端注册、任务提交及结果下载。
 
-## Installation
+## 安装
 
-Copy the extension directory to pi's global extension directory. The directory name becomes the extension name:
+将扩展目录复制到 pi 全局扩展目录，目录名即为扩展名：
 
 ```bash
 mkdir -p ~/.pi/agent/extensions/OpenAaaS
@@ -15,17 +15,17 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-After installation, execute `/reload` in pi to load the extension automatically.
+安装后，在 pi 中执行 `/reload` 即可自动加载扩展。
 
-## Configuration
+## 配置文件
 
-The configuration file is saved in the extension directory, at a dynamic path:
+配置文件保存在扩展目录下，路径为动态路径：
 
 ```
-~/.pi/agent/extensions/<extension-directory-name>/config.json
+~/.pi/agent/extensions/<扩展目录名>/config.json
 ```
 
-If it does not exist on first load, a default configuration will be created automatically:
+首次加载时若不存在，会自动创建默认配置：
 
 ```json
 {
@@ -38,7 +38,7 @@ If it does not exist on first load, a default configuration will be created auto
 }
 ```
 
-Example configuration after successful registration:
+注册成功后的配置示例：
 
 ```json
 {
@@ -54,178 +54,178 @@ Example configuration after successful registration:
 }
 ```
 
-After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
+运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
 
-## Multi-Server Configuration
+## 多服务器配置
 
-Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
+支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
 
-### Register for Multiple Servers Separately
+### 为多个服务器分别注册
 
-Each server alias has independent registration information:
+每个服务器别名有独立的注册信息：
 
 ```bash
-# Register on the prod server
+# 在 prod 服务器注册
 OpenAaaS(action: "register", server: "prod", name: "my-prod-client")
 
-# Register on the local server
+# 在 local 服务器注册
 OpenAaaS(action: "register", server: "local", name: "my-local-client")
 ```
 
-The two servers will save their respective api_keys independently without interference.
+两个服务器会分别保存各自的 api_key，互不干扰。
 
-### Set Server URL
+### 设置服务器地址
 
 ```
 OpenAaaS(action: "set_server_url", server: "prod", server_url: "https://api.open-aaas.com")
 OpenAaaS(action: "set_server_url", server: "local", server_url: "http://127.0.0.1:8080")
 ```
 
-Switch default server:
+切换默认服务器：
 ```
 OpenAaaS(action: "set_default_server", server: "prod")
 ```
 
-List all configured servers:
+列出所有配置的服务器：
 ```
 OpenAaaS(action: "list_servers")
 ```
 
-## Available Tools
+## 可用工具
 
-| Tool Name | Function |
-|-----------|----------|
-| `OpenAaaS` | Unified entry tool, invoking different functionalities via the `action` parameter |
+| 工具名 | 功能 |
+|--------|------|
+| `OpenAaaS` | 统一入口工具，通过 `action` 参数调用不同功能 |
 
-### Supported Actions
+### 支持的 action
 
-| Action | Function |
-|--------|----------|
-| `discover` | Discover server API information (returns server version, Base URL, authentication method, available endpoint list, registered service list) |
-| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
-| `register` | Register client, automatically save api_key (only once) |
-| `update_profile` | Modify user name |
-| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
-| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
-| `list_history` | List all OpenAaaS task history in the current Session |
-| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
-| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
-| `cancel_task` | Cancel a running task |
-| `list_files` | List result files for the task |
-| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files. Single file download does not exceed 100MB, total size after extraction does not exceed 300MB (zip bomb protection) |
-| `list_servers` | List all configured servers |
-| `set_default_server` | Switch default server |
-| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
+| action | 功能 |
+|--------|------|
+| `discover` | 发现服务端 API 信息（返回服务端版本、Base URL、认证方式、可用端点列表、已注册服务列表） |
+| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
+| `register` | 注册客户端，自动保存 api_key（仅需一次） |
+| `update_profile` | 修改用户名 |
+| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
+| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
+| `list_history` | 列出当前 Session 中所有 OpenAaaS 任务历史 |
+| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
+| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
+| `cancel_task` | 取消执行中的任务 |
+| `list_files` | 列出任务的结果文件列表 |
+| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件，单文件下载不超过 100MB，解压后总大小不超过 300MB（Zip 炸弹防护） |
+| `list_servers` | 列出所有已配置的服务器 |
+| `set_default_server` | 切换默认服务器 |
+| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
 
-## Progressive Information Retrieval
+## 渐进式信息获取
 
-This extension follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
+本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
 
-**Standard Usage Flow**:
-1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
-2. `register` — Register to get api_key (only once)
-3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
-4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
-5. Based on usage content, construct correct task_prompt and output_prompt
-6. `submit_task` — Submit task (with optional files), save returned task_id
-7. `list_history` — View all task history in the current Session (can be used to restore memory after context compression)
-8. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
-9. `download_result` — Download result files after task completion
+**标准使用流程**：
+1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
+2. `register` — 注册获取 api_key（仅需一次）
+3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
+4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
+5. 根据 usage 内容，构造正确的 task_prompt 和 output_prompt
+6. `submit_task` — 提交任务（可附带文件），保存返回的 task_id
+7. `list_history` — 查看当前 Session 中所有任务历史（上下文压缩后可用来恢复记忆）
+8. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
+9. `download_result` — 任务完成后下载结果文件
 
-**Why this design**:
-- `list_services` returns a lightweight summary, not occupying LLM context
-- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
-- Avoid loading complete documentation for all services at once, which could cause context overflow
+**为什么这样设计**：
+- `list_services` 返回轻量摘要，不占用 LLM 上下文
+- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
+- 避免一次性加载所有服务的完整文档导致上下文溢出
 
-## Automatic Monitoring
+## 自动监控
 
-After calling `submit_task` to submit a task, the extension will automatically monitor task status in the background:
+调用 `submit_task` 提交任务后，扩展会自动在后台监控任务状态：
 
-- **Widget real-time display**: Shows active task (pending / accepted / running / cancelling) statistics and task list below the editor, automatically refreshing on status changes
-- **UI notifications**: Automatically push notifications when tasks complete, fail, or are cancelled
-- **No polling needed**: The LLM does not need to actively call `get_task` to poll status; wait for the user to inform that the task is complete before retrieving results
-- **Widget visibility constraint**: The widget's real-time task status is only visible to the user; you cannot see it directly. If you need to answer the user about any task's current status (e.g. "What is the task status now?" "Is it complete?"), you must call `get_task` to re-query the latest status, do not reference the old status returned by previous calls
-- **Polling interval**: First 10 seconds, then 30 seconds
-- **Session persistence**: Task status is saved to the current session, and monitoring is automatically reconstructed after switching the session tree
-- **Session reconstruction reminder**: After the session is compressed and reconstructed, the extension will automatically send a message to the conversation, informing which tasks are still being monitored, to prevent LLM amnesia
+- **Widget 实时显示**：在编辑器下方显示活跃任务（pending / accepted / running / cancelling）的统计信息和任务列表，状态变更时自动刷新
+- **UI 通知**：任务完成、失败或取消时自动推送通知
+- **无需轮询**：LLM 不需要主动调用 `get_task` 轮询状态，等待用户告知任务完成后再获取结果即可
+- **Widget 可见性约束**：widget 实时显示的任务状态仅对用户可见，你无法直接看到。如果你需要回答用户关于某个任务当前状态的任何问题（例如"任务现在是什么状态""完成了吗"），必须先调用 `get_task` 重新查询最新状态，不要引用之前调用返回的旧状态
+- **轮询间隔**：首次 10 秒，后续 30 秒
+- **Session 持久化**：任务状态会保存到当前会话中，切换会话树后自动重建监控
+- **Session 重建自动提醒**：当 session 被压缩重建后，扩展会自动发送消息到对话中，告知当前有哪些任务仍在监控，防止 LLM 失忆
 
-## Commands
+## 命令
 
 ### `/OpenAaaS-tasks`
 
-Pops up a panel showing tasks in the current session (including terminal tasks, up to 20), press `Escape` or `Ctrl+C` to close, automatically closes after 30 seconds of inactivity.
+弹出面板显示当前会话中的任务（包括终态任务，最多 20 个），按 `Escape` 或 `Ctrl+C` 关闭，30 秒无操作自动关闭。
 
-## Registration Constraints
+## 注册约束
 
-- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
-- To modify the user name, use `update_profile` (example: `OpenAaaS(action: "update_profile", name: "new-name")`)
-- **`name` parameter constraint**: Length does not exceed 64 characters, cannot contain control characters and the following illegal characters: `/ \ < > | & ; $`
-- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
-- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
-- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
+- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
+- 如需修改用户名，请使用 `update_profile`（示例：`OpenAaaS(action: "update_profile", name: "new-name")`）
+- **`name` 参数约束**：长度不超过 64 个字符，不能包含控制字符及以下非法字符：`/ \ < > | & ; $`
+- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
+- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
+- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
 
-## Usage Examples
+## 使用示例
 
-1. Set server URL (optional, default https://api.open-aaas.com):
+1. 设置服务器地址（可选，默认 https://api.open-aaas.com）：
    ```
    OpenAaaS(action: "set_server_url", server_url: "https://www.open-aaas.com")
    ```
 
-   Optional: Discover server information:
+   可选：发现服务端信息：
    ```
    OpenAaaS(action: "discover")
    ```
 
-1.5. Switch to another server for operations:
+1.5. 切换到其他服务器操作：
    ```
    OpenAaaS(action: "list_services", server: "prod")
    OpenAaaS(action: "submit_task", server: "local", service_id: "my-service", task_prompt: "...")
    ```
 
-2. Register client:
+2. 注册客户端：
    ```
    OpenAaaS(action: "register", name: "my-client")
    ```
 
-3. List services and filter candidates:
+3. 列出服务并筛选候选：
    ```
    OpenAaaS(action: "list_services")
    ```
 
-4. Get detailed usage for the target service:
+4. 对目标服务获取详细 usage：
    ```
    OpenAaaS(action: "get_service_usage", service_id: "my-service")
    ```
 
-5. Submit task (with file upload):
+5. 提交任务（带文件上传）：
    ```
    OpenAaaS(
      action: "submit_task",
      service_id: "my-service",
-     task_prompt: "Analyze data",
-     output_prompt: "Return JSON",
+     task_prompt: "分析数据",
+     output_prompt: "返回 JSON",
      input_files: ["./data.csv"],
-     session_id: "Optional, for maintaining conversation context"
+     session_id: "可选，用于保持对话上下文"
    )
    ```
-   File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
+   文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
 
-6. List current Session task history:
+6. 列出当前 Session 任务历史：
    ```
    OpenAaaS(action: "list_history")
    ```
 
-7. Query task (only call when the user requests it):
+7. 查询任务（仅在用户要求时调用）：
    ```
    OpenAaaS(action: "get_task", task_id: "xxx")
    ```
 
-8. Download result:
+8. 下载结果：
    ```
    OpenAaaS(action: "download_result", task_id: "xxx")
    ```
 
-9. Delete server configuration:
+9. 删除服务器配置：
    ```
    OpenAaaS(action: "remove_server", server: "old-server")
    ```

--- a/client-extension/pi-extension/README.zh.md
+++ b/client-extension/pi-extension/README.zh.md
@@ -2,11 +2,11 @@
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-为 [pi](https://github.com/badlogic/pi-mono) 开发的 OpenAaaS 扩展，提供统一的 `OpenAaaS` 工具，用于服务发现、客户端注册、任务提交及结果下载。
+An OpenAaaS extension for [pi](https://github.com/badlogic/pi-mono), providing a unified `OpenAaaS` tool for service discovery, client registration, task submission, and result download.
 
-## 安装
+## Installation
 
-将扩展目录复制到 pi 全局扩展目录，目录名即为扩展名：
+Copy the extension directory to pi's global extension directory. The directory name becomes the extension name:
 
 ```bash
 mkdir -p ~/.pi/agent/extensions/OpenAaaS
@@ -15,17 +15,17 @@ cd ~/.pi/agent/extensions/OpenAaaS
 npm install
 ```
 
-安装后，在 pi 中执行 `/reload` 即可自动加载扩展。
+After installation, execute `/reload` in pi to load the extension automatically.
 
-## 配置文件
+## Configuration
 
-配置文件保存在扩展目录下，路径为动态路径：
+The configuration file is saved in the extension directory, at a dynamic path:
 
 ```
-~/.pi/agent/extensions/<扩展目录名>/config.json
+~/.pi/agent/extensions/<extension-directory-name>/config.json
 ```
 
-首次加载时若不存在，会自动创建默认配置：
+If it does not exist on first load, a default configuration will be created automatically:
 
 ```json
 {
@@ -38,7 +38,7 @@ npm install
 }
 ```
 
-注册成功后的配置示例：
+Example configuration after successful registration:
 
 ```json
 {
@@ -54,178 +54,178 @@ npm install
 }
 ```
 
-运行 `register` 成功后会自动写入 `api_key`、`client_id` 和 `name`。
+After running `register`, `api_key`, `client_id`, and `name` will be written automatically.
 
-## 多服务器配置
+## Multi-Server Configuration
 
-支持同时配置多个服务器，通过 `server` 参数指定目标服务器。
+Supports configuring multiple servers simultaneously. Use the `server` parameter to specify the target server.
 
-### 为多个服务器分别注册
+### Register for Multiple Servers Separately
 
-每个服务器别名有独立的注册信息：
+Each server alias has independent registration information:
 
 ```bash
-# 在 prod 服务器注册
+# Register on the prod server
 OpenAaaS(action: "register", server: "prod", name: "my-prod-client")
 
-# 在 local 服务器注册
+# Register on the local server
 OpenAaaS(action: "register", server: "local", name: "my-local-client")
 ```
 
-两个服务器会分别保存各自的 api_key，互不干扰。
+The two servers will save their respective api_keys independently without interference.
 
-### 设置服务器地址
+### Set Server URL
 
 ```
 OpenAaaS(action: "set_server_url", server: "prod", server_url: "https://api.open-aaas.com")
 OpenAaaS(action: "set_server_url", server: "local", server_url: "http://127.0.0.1:8080")
 ```
 
-切换默认服务器：
+Switch default server:
 ```
 OpenAaaS(action: "set_default_server", server: "prod")
 ```
 
-列出所有配置的服务器：
+List all configured servers:
 ```
 OpenAaaS(action: "list_servers")
 ```
 
-## 可用工具
+## Available Tools
 
-| 工具名 | 功能 |
-|--------|------|
-| `OpenAaaS` | 统一入口工具，通过 `action` 参数调用不同功能 |
+| Tool Name | Function |
+|-----------|----------|
+| `OpenAaaS` | Unified entry tool, invoking different functionalities via the `action` parameter |
 
-### 支持的 action
+### Supported Actions
 
-| action | 功能 |
-|--------|------|
-| `discover` | 发现服务端 API 信息（返回服务端版本、Base URL、认证方式、可用端点列表、已注册服务列表） |
-| `set_server_url` | 设置服务器地址并保存到 config.json。已有注册信息（api_key）的服务器不会被覆盖 |
-| `register` | 注册客户端，自动保存 api_key（仅需一次） |
-| `update_profile` | 修改用户名 |
-| `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
-| `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
-| `list_history` | 列出当前 Session 中所有 OpenAaaS 任务历史 |
-| `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
-| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
-| `cancel_task` | 取消执行中的任务 |
-| `list_files` | 列出任务的结果文件列表 |
-| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件，单文件下载不超过 100MB，解压后总大小不超过 300MB（Zip 炸弹防护） |
-| `list_servers` | 列出所有已配置的服务器 |
-| `set_default_server` | 切换默认服务器 |
-| `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |
+| Action | Function |
+|--------|----------|
+| `discover` | Discover server API information (returns server version, Base URL, authentication method, available endpoint list, registered service list) |
+| `set_server_url` | Set server URL and save to config.json. Servers with existing registration information (api_key) will not be overwritten |
+| `register` | Register client, automatically save api_key (only once) |
+| `update_profile` | Modify user name |
+| `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
+| `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
+| `list_history` | List all OpenAaaS task history in the current Session |
+| `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
+| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
+| `cancel_task` | Cancel a running task |
+| `list_files` | List result files for the task |
+| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files. Single file download does not exceed 100MB, total size after extraction does not exceed 300MB (zip bomb protection) |
+| `list_servers` | List all configured servers |
+| `set_default_server` | Switch default server |
+| `remove_server` | Delete configuration for the specified server (cannot delete the default server) |
 
-## 渐进式信息获取
+## Progressive Information Retrieval
 
-本插件遵循"信息渐进式披露"原则：不要一次性获取所有服务的完整信息。
+This extension follows the principle of "progressive information disclosure": do not fetch complete information for all services at once.
 
-**标准使用流程**：
-1. `set_server_url` — 设置服务端地址（如未设置，默认连接 https://api.open-aaas.com）
-2. `register` — 注册获取 api_key（仅需一次）
-3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
-4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
-5. 根据 usage 内容，构造正确的 task_prompt 和 output_prompt
-6. `submit_task` — 提交任务（可附带文件），保存返回的 task_id
-7. `list_history` — 查看当前 Session 中所有任务历史（上下文压缩后可用来恢复记忆）
-8. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-9. `download_result` — 任务完成后下载结果文件
+**Standard Usage Flow**:
+1. `set_server_url` — Set server address (if not set, defaults to https://api.open-aaas.com)
+2. `register` — Register to get api_key (only once)
+3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
+4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
+5. Based on usage content, construct correct task_prompt and output_prompt
+6. `submit_task` — Submit task (with optional files), save returned task_id
+7. `list_history` — View all task history in the current Session (can be used to restore memory after context compression)
+8. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
+9. `download_result` — Download result files after task completion
 
-**为什么这样设计**：
-- `list_services` 返回轻量摘要，不占用 LLM 上下文
-- `usage` 通常包含大量文本（能力说明、调用规范、示例等），只应在确定使用该服务时获取
-- 避免一次性加载所有服务的完整文档导致上下文溢出
+**Why this design**:
+- `list_services` returns a lightweight summary, not occupying LLM context
+- `usage` usually contains large amounts of text (capability descriptions, calling conventions, examples, etc.), and should only be retrieved when the service is determined to be used
+- Avoid loading complete documentation for all services at once, which could cause context overflow
 
-## 自动监控
+## Automatic Monitoring
 
-调用 `submit_task` 提交任务后，扩展会自动在后台监控任务状态：
+After calling `submit_task` to submit a task, the extension will automatically monitor task status in the background:
 
-- **Widget 实时显示**：在编辑器下方显示活跃任务（pending / accepted / running / cancelling）的统计信息和任务列表，状态变更时自动刷新
-- **UI 通知**：任务完成、失败或取消时自动推送通知
-- **无需轮询**：LLM 不需要主动调用 `get_task` 轮询状态，等待用户告知任务完成后再获取结果即可
-- **Widget 可见性约束**：widget 实时显示的任务状态仅对用户可见，你无法直接看到。如果你需要回答用户关于某个任务当前状态的任何问题（例如"任务现在是什么状态""完成了吗"），必须先调用 `get_task` 重新查询最新状态，不要引用之前调用返回的旧状态
-- **轮询间隔**：首次 10 秒，后续 30 秒
-- **Session 持久化**：任务状态会保存到当前会话中，切换会话树后自动重建监控
-- **Session 重建自动提醒**：当 session 被压缩重建后，扩展会自动发送消息到对话中，告知当前有哪些任务仍在监控，防止 LLM 失忆
+- **Widget real-time display**: Shows active task (pending / accepted / running / cancelling) statistics and task list below the editor, automatically refreshing on status changes
+- **UI notifications**: Automatically push notifications when tasks complete, fail, or are cancelled
+- **No polling needed**: The LLM does not need to actively call `get_task` to poll status; wait for the user to inform that the task is complete before retrieving results
+- **Widget visibility constraint**: The widget's real-time task status is only visible to the user; you cannot see it directly. If you need to answer the user about any task's current status (e.g. "What is the task status now?" "Is it complete?"), you must call `get_task` to re-query the latest status, do not reference the old status returned by previous calls
+- **Polling interval**: First 10 seconds, then 30 seconds
+- **Session persistence**: Task status is saved to the current session, and monitoring is automatically reconstructed after switching the session tree
+- **Session reconstruction reminder**: After the session is compressed and reconstructed, the extension will automatically send a message to the conversation, informing which tasks are still being monitored, to prevent LLM amnesia
 
-## 命令
+## Commands
 
 ### `/OpenAaaS-tasks`
 
-弹出面板显示当前会话中的任务（包括终态任务，最多 20 个），按 `Escape` 或 `Ctrl+C` 关闭，30 秒无操作自动关闭。
+Pops up a panel showing tasks in the current session (including terminal tasks, up to 20), press `Escape` or `Ctrl+C` to close, automatically closes after 30 seconds of inactivity.
 
-## 注册约束
+## Registration Constraints
 
-- 每个服务器别名可以独立注册。如果**当前服务器**已有 `api_key`，说明已完成注册，**请勿重复调用 `register`**
-- 如需修改用户名，请使用 `update_profile`（示例：`OpenAaaS(action: "update_profile", name: "new-name")`）
-- **`name` 参数约束**：长度不超过 64 个字符，不能包含控制字符及以下非法字符：`/ \ < > | & ; $`
-- **服务器地址保护**：`set_server_url` 不会自动覆盖已有注册信息的服务器。如果该服务器已有 `api_key`，修改地址会被阻止，防止意外丢失注册信息
-- 如需切换到新服务器地址，请使用新的 `server` 别名（多服务器配置），或先用 `remove_server` 删除旧配置
-- **删除服务器**：如需删除某个服务器配置，使用 `remove_server`。注意不能删除默认服务器，删除前需先用 `set_default_server` 切换默认服务器
+- Each server alias can be registered independently. If the **current server** already has an `api_key`, registration is complete, **do not call `register` repeatedly**
+- To modify the user name, use `update_profile` (example: `OpenAaaS(action: "update_profile", name: "new-name")`)
+- **`name` parameter constraint**: Length does not exceed 64 characters, cannot contain control characters and the following illegal characters: `/ \ < > | & ; $`
+- **Server URL protection**: `set_server_url` will not automatically overwrite servers with existing registration information. If the server already has an `api_key`, address modification will be blocked to prevent accidental loss of registration information
+- To switch to a new server address, use a new `server` alias (multi-server configuration), or first delete the old configuration with `remove_server`
+- **Delete server**: To delete a server configuration, use `remove_server`. Note that the default server cannot be deleted; switch the default server with `set_default_server` first
 
-## 使用示例
+## Usage Examples
 
-1. 设置服务器地址（可选，默认 https://api.open-aaas.com）：
+1. Set server URL (optional, default https://api.open-aaas.com):
    ```
    OpenAaaS(action: "set_server_url", server_url: "https://www.open-aaas.com")
    ```
 
-   可选：发现服务端信息：
+   Optional: Discover server information:
    ```
    OpenAaaS(action: "discover")
    ```
 
-1.5. 切换到其他服务器操作：
+1.5. Switch to another server for operations:
    ```
    OpenAaaS(action: "list_services", server: "prod")
    OpenAaaS(action: "submit_task", server: "local", service_id: "my-service", task_prompt: "...")
    ```
 
-2. 注册客户端：
+2. Register client:
    ```
    OpenAaaS(action: "register", name: "my-client")
    ```
 
-3. 列出服务并筛选候选：
+3. List services and filter candidates:
    ```
    OpenAaaS(action: "list_services")
    ```
 
-4. 对目标服务获取详细 usage：
+4. Get detailed usage for the target service:
    ```
    OpenAaaS(action: "get_service_usage", service_id: "my-service")
    ```
 
-5. 提交任务（带文件上传）：
+5. Submit task (with file upload):
    ```
    OpenAaaS(
      action: "submit_task",
      service_id: "my-service",
-     task_prompt: "分析数据",
-     output_prompt: "返回 JSON",
+     task_prompt: "Analyze data",
+     output_prompt: "Return JSON",
      input_files: ["./data.csv"],
-     session_id: "可选，用于保持对话上下文"
+     session_id: "Optional, for maintaining conversation context"
    )
    ```
-   文件上传限制：最多支持 10 个文件，单文件不超过 100MB；只能上传当前工作目录下的文件，不支持符号链接。
+   File upload limits: Up to 10 files supported, single file not exceeding 100MB; only files in the current working directory can be uploaded, symbolic links are not supported.
 
-6. 列出当前 Session 任务历史：
+6. List current Session task history:
    ```
    OpenAaaS(action: "list_history")
    ```
 
-7. 查询任务（仅在用户要求时调用）：
+7. Query task (only call when the user requests it):
    ```
    OpenAaaS(action: "get_task", task_id: "xxx")
    ```
 
-8. 下载结果：
+8. Download result:
    ```
    OpenAaaS(action: "download_result", task_id: "xxx")
    ```
 
-9. 删除服务器配置：
+9. Delete server configuration:
    ```
    OpenAaaS(action: "remove_server", server: "old-server")
    ```

--- a/dash/README.md
+++ b/dash/README.md
@@ -2,42 +2,42 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-> **⚠️ Positioning Note**: This is a **debugging and admin control tool** for developers and system administrators, used for monitoring and managing OpenAaaS tasks and system status. **It is NOT the OpenAaaS user interface / main UI (Main UI)**.
+> **⚠️ 定位说明**：这是一个面向开发者和系统管理员的**调试与管理员控制工具**，用于监控和管理 OpenAaaS 的任务与系统状态。**它不是 OpenAaaS 的用户界面 / 主界面（Main UI）**。
 
-A Streamlit-based web UI for debugging, monitoring and administering OpenAaaS tasks.
+基于 Streamlit 的 Web UI，用于调试、监控和管理 OpenAaaS 任务。
 
-## Features
+## 功能特性
 
-- 📊 **Task Overview & Debugging**: View all tasks in a card layout, inspect task details (input/output/files, etc.), and cancel tasks
-- 🔧 **Admin View**: View all user tasks, filter tasks by user
-- 🔄 **Auto Refresh**: Real-time updates with configurable refresh interval
-- 🔍 **Status Filtering**: Filter tasks by status (All/Pending/Running/Completed/Failed/Cancelled/Cancelling)
-- ⚙️ **Flexible Configuration**: Supports CLI arguments, environment variables, and configuration files
+- 📊 **任务概览与调试**：以卡片布局查看所有任务，查看任务详情（输入/输出/文件等），支持取消任务
+- 🔧 **管理员视图**：查看所有用户任务，按用户筛选任务
+- 🔄 **自动刷新**：实时更新，支持可配置刷新间隔
+- 🔍 **状态过滤**：按状态筛选任务（All/Pending/Running/Completed/Failed/Cancelled/Cancelling）
+- ⚙️ **灵活配置**：支持 CLI 参数、环境变量和配置文件
 
-## Installation
+## 安装
 
-### Using `uv` (recommended)
+### 使用 uv（推荐）
 
 ```bash
 uv tool install open-aaas-dashboard
 ```
 
-### Using `pip`
+### 使用 pip
 
 ```bash
 pip install open-aaas-dashboard
 ```
 
-### Development Install
+### 开发安装
 
 ```bash
 cd OpenAaaS/dash
 pip install -e .
 ```
 
-## Usage
+## 用法
 
-### Command Line
+### 命令行
 
 ```bash
 # With command line arguments
@@ -49,24 +49,24 @@ export OAAS_API_KEY=ak_xxx
 aaas-dashboard
 ```
 
-### Configuration Priority
+### 配置优先级
 
-Configuration is loaded in the following priority (highest first):
+配置按以下优先级加载（从高到低）：
 
-1. **Command line arguments**: `--server-url`, `--api-key`
-2. **Environment variables**: `OAAS_SERVER_URL`, `OAAS_API_KEY`
-3. **Config file**: `~/.config/aaas-dashboard/config.toml`
+1. **命令行参数**：`--server-url`, `--api-key`
+2. **环境变量**：`OAAS_SERVER_URL`, `OAAS_API_KEY`
+3. **配置文件**：`~/.config/aaas-dashboard/config.toml`
 
-### Config File Format
+### 配置文件格式
 
-Create `~/.config/aaas-dashboard/config.toml`:
+创建 `~/.config/aaas-dashboard/config.toml`：
 
 ```toml
 server_url = "http://localhost:8080"
 api_key = "ak_xxx"
 ```
 
-## Development
+## 开发
 
 ```bash
 # Install dependencies
@@ -76,6 +76,6 @@ pip install -e ".[dev]"
 streamlit run src/aaas_dashboard/app.py
 ```
 
-## License
+## 许可证
 
-MIT License
+MIT 许可证

--- a/dash/README.zh.md
+++ b/dash/README.zh.md
@@ -2,19 +2,19 @@
 
 <p align="right"><a href="./README.md">English</a> | 中文</p>
 
-> **⚠️ 定位说明**：这是一个面向开发者和系统管理员的**调试与管理员控制工具**，用于监控和管理 OpenAaaS 的任务与系统状态。**它不是 OpenAaaS 的用户界面 / 主界面（Main UI）**。
+> **⚠️ Positioning Note**: This is a **debugging and admin control tool** for developers and system administrators, used for monitoring and managing OpenAaaS tasks and system status. **It is NOT the OpenAaaS user interface / main UI (Main UI)**.
 
-基于 Streamlit 的 Web UI，用于调试、监控和管理 OpenAaaS 任务。
+A Streamlit-based web UI for debugging, monitoring and administering OpenAaaS tasks.
 
-## 功能特性
+## Features
 
-- 📊 **任务概览与调试**：以卡片布局查看所有任务，查看任务详情（输入/输出/文件等），支持取消任务
-- 🔧 **管理员视图**：查看所有用户任务，按用户筛选任务
-- 🔄 **自动刷新**：实时更新，支持可配置刷新间隔
-- 🔍 **状态过滤**：按状态筛选任务（All/Pending/Running/Completed/Failed/Cancelled/Cancelling）
-- ⚙️ **灵活配置**：支持 CLI 参数、环境变量和配置文件
+- 📊 **Task Overview & Debugging**: View all tasks in a card layout, inspect task details (input/output/files, etc.), and cancel tasks
+- 🔧 **Admin View**: View all user tasks, filter tasks by user
+- 🔄 **Auto Refresh**: Real-time updates with configurable refresh interval
+- 🔍 **Status Filtering**: Filter tasks by status (All/Pending/Running/Completed/Failed/Cancelled/Cancelling)
+- ⚙️ **Flexible Configuration**: Supports CLI arguments, environment variables, and configuration files
 
-## 安装
+## Installation
 
 ### Using `uv` (recommended)
 
@@ -28,16 +28,16 @@ uv tool install open-aaas-dashboard
 pip install open-aaas-dashboard
 ```
 
-### 开发安装
+### Development Install
 
 ```bash
 cd OpenAaaS/dash
 pip install -e .
 ```
 
-## 用法
+## Usage
 
-### 命令行
+### Command Line
 
 ```bash
 # With command line arguments
@@ -49,24 +49,24 @@ export OAAS_API_KEY=ak_xxx
 aaas-dashboard
 ```
 
-### 配置优先级
+### Configuration Priority
 
-配置按以下优先级加载（从高到低）：
+Configuration is loaded in the following priority (highest first):
 
-1. **命令行参数**：`--server-url`, `--api-key`
-2. **环境变量**：`OAAS_SERVER_URL`, `OAAS_API_KEY`
-3. **配置文件**：`~/.config/aaas-dashboard/config.toml`
+1. **Command line arguments**: `--server-url`, `--api-key`
+2. **Environment variables**: `OAAS_SERVER_URL`, `OAAS_API_KEY`
+3. **Config file**: `~/.config/aaas-dashboard/config.toml`
 
-### 配置文件格式
+### Config File Format
 
-创建 `~/.config/aaas-dashboard/config.toml`：
+Create `~/.config/aaas-dashboard/config.toml`:
 
 ```toml
 server_url = "http://localhost:8080"
 api_key = "ak_xxx"
 ```
 
-## 开发
+## Development
 
 ```bash
 # Install dependencies
@@ -76,6 +76,6 @@ pip install -e ".[dev]"
 streamlit run src/aaas_dashboard/app.py
 ```
 
-## 许可证
+## License
 
-MIT 许可证
+MIT License

--- a/server/README.md
+++ b/server/README.md
@@ -2,113 +2,113 @@
 
 <p align="right"><a href="./README.zh.md">中文</a> | English</p>
 
-The HTTP server for OpenAaaS, responsible for receiving client tasks, dispatching them to agents for execution, and managing the task lifecycle.
+OpenAaaS 的 HTTP 服务端，负责接收 Client 任务、调度给 Agent 执行，并管理任务生命周期。
 
-## Build & Install
+## 编译安装
 
-Requires the Rust toolchain (1.85+):
+需要安装 Rust 工具链（1.85+）：
 
 ```bash
 cd server
 cargo build --release
 ```
 
-The compiled binary is located at `target/release/open-aaas-server`.
+编译产物为 `target/release/open-aaas-server`。
 
-## Command Usage
+## 命令用法
 
 ```bash
 open-aaas-server [OPTIONS] <COMMAND>
 ```
 
-### Global Options
+### 全局选项
 
-| Option | Description |
-|--------|-------------|
-| `--config <FILE>` | Specify the configuration file path; defaults to `config.toml` in the current directory |
+| 选项 | 说明 |
+|------|------|
+| `--config <FILE>` | 指定配置文件路径，默认读取当前目录的 `config.toml` |
 
-### Subcommands
+### 子命令
 
-| Command | Description |
-|---------|-------------|
-| `run` | Run the server in the foreground |
-| `run-detached` | Run the server in the background |
-| `stop` | Stop the background server |
-| `status` | Check the server status |
+| 命令 | 说明 |
+|------|------|
+| `run` | 前台运行服务器 |
+| `run-detached` | 后台运行服务器 |
+| `stop` | 停止后台服务器 |
+| `status` | 查看服务器状态 |
 
-## First Launch
+## 首次启动
 
-When running `run` for the first time, if no `config.toml` exists in the current directory, an interactive configuration will start:
+首次执行 `run` 时，若当前目录没有 `config.toml`，会进入交互式配置：
 
 ```bash
 $ ./open-aaas-server run
-Data directory [./data]:                # Press Enter to confirm or enter a new path
-Admin API Key []:                       # Press Enter to generate randomly, or enter a custom value
+Data directory [./data]:                # 回车确认或输入新路径
+Admin API Key []:                       # 回车随机生成，或输入自定义值
 ```
 
-The server will automatically perform the following initialization steps:
+服务端会自动完成以下初始化：
 
-1. Create the data directory (default: `./data`)
-2. Set the SQLite database path: `{data_dir}/app.db`
-3. Set the file storage path: `{data_dir}/files`
-4. Generate a random `secret_key` (if not configured)
-5. Create the `admin_api_key` (either the value you entered or a randomly generated one)
-6. Write the final configuration to `config.toml`
+1. 创建数据目录（默认 `./data`）
+2. 写入 SQLite 数据库路径：`{data_dir}/app.db`
+3. 写入文件存储路径：`{data_dir}/files`
+4. 生成随机 `secret_key`（若未配置）
+5. 创建 `admin_api_key`（你输入的值或随机生成）
+6. 将最终配置写入 `config.toml`
 
-The service will then start normally.
+随后正常启动服务。
 
-## Foreground Run
+## 前台运行
 
 ```bash
 ./open-aaas-server run
 ```
 
-After starting, it listens on the default address `0.0.0.0:8080`. Press `Ctrl+C` or send `SIGTERM` for a graceful shutdown.
+启动后监听默认地址 `0.0.0.0:8080`。按 `Ctrl+C` 或发送 `SIGTERM` 可优雅关闭。
 
-If `config.toml` already exists in the current directory, it will load the configuration and start directly without prompting.
+如果当前目录已有 `config.toml`，会直接加载配置启动，不再询问。
 
-## Background Run
+## 后台运行
 
 ```bash
 ./open-aaas-server run-detached
 ```
 
-- Linux/macOS: Runs in the background via `nohup`, with logs output to `{data_dir}/server.log`
-- Windows: Runs in the background via `cmd /C start /B`
+- Linux/macOS：通过 `nohup` 后台运行，日志输出到 `{data_dir}/server.log`
+- Windows：通过 `cmd /C start /B` 后台运行
 
-After starting in the background, a pidfile will be written for subsequent management and status queries.
+后台启动后会写入 pidfile，用于后续管理和状态查询。
 
-## Check Status
+## 查看状态
 
 ```bash
 ./open-aaas-server status
 ```
 
-Example output:
+输出示例：
 
 ```
-Config file:    /path/to/config.toml
-Data directory: /path/to/data
-Listen address: 0.0.0.0:8080
-Status:         Running (PID: 12345)
+配置文件:    /path/to/config.toml
+数据目录:    /path/to/data
+监听地址:    0.0.0.0:8080
+运行状态:    运行中 (PID: 12345)
 ```
 
-## Stop Service
+## 停止服务
 
 ```bash
 ./open-aaas-server stop
 ```
 
-Sends `SIGTERM` to the background process, waiting up to 5 seconds for a graceful exit; if timed out, sends `SIGKILL` to force termination and cleans up the pidfile.
+向后台进程发送 `SIGTERM`，等待最多 5 秒优雅退出；超时则发送 `SIGKILL` 强制终止，并清理 pidfile。
 
-## Environment Variables
+## 环境变量
 
-The server automatically loads the `.env` file in the current directory (if it exists) on startup.
+服务端启动时会自动加载当前目录的 `.env` 文件（如果存在）。
 
-The following environment variables can override the corresponding items in the configuration file, with the prefix `APP__` and levels separated by double underscores:
+以下环境变量可覆盖配置文件中的对应项，前缀为 `APP__`，层级用双下划线分隔：
 
-| Environment Variable | Corresponding Config Item |
-|----------------------|---------------------------|
+| 环境变量 | 对应配置项 |
+|----------|-----------|
 | `APP__SECRET_KEY` | `secret_key` |
 | `APP__ADMIN_API_KEY` | `admin_api_key` |
 | `APP__LOG_LEVEL` | `log_level` |
@@ -119,48 +119,48 @@ The following environment variables can override the corresponding items in the 
 | `APP__TASK__FILE_STORAGE_PATH` | `task.file_storage_path` |
 | `APP__TASK__MAX_FILE_SIZE_MB` | `task.max_file_size_mb` |
 
-Example:
+示例：
 
 ```bash
 APP__SERVER__ADDR="0.0.0.0:3000" APP__LOG_LEVEL=debug ./open-aaas-server run
 ```
 
-The `ADMIN_API_KEY` environment variable (without prefix) can also directly override the admin API key, taking precedence over the configuration file.
+`ADMIN_API_KEY` 环境变量（无前缀）也可以直接覆盖管理员 API Key，优先级高于配置文件。
 
-## Configuration File
+## 配置文件说明
 
-Complete `config.toml` example:
+`config.toml` 完整示例：
 
 ```toml
-secret_key = "xxx"          # HMAC key, auto-generated on first launch
-admin_api_key = "xxx"       # Admin API key
+secret_key = "xxx"          # HMAC 密钥，首次启动自动生成
+admin_api_key = "xxx"       # 管理员 API Key
 log_level = "info"          # trace / debug / info / warn / error
 
 [server]
-addr = "0.0.0.0:8080"       # Listen address
-timeout_secs = 30           # HTTP request timeout (seconds)
-max_body_size = 10485760    # Maximum request body size (10MB)
+addr = "0.0.0.0:8080"       # 监听地址
+timeout_secs = 30           # HTTP 请求超时（秒）
+max_body_size = 10485760    # 最大请求体大小（10MB）
 
 [database]
-url = "sqlite:./data/app.db" # SQLite database path
+url = "sqlite:./data/app.db" # SQLite 数据库路径
 
 [agent]
-heartbeat_timeout_secs = 60  # Agent heartbeat timeout (seconds)
+heartbeat_timeout_secs = 60  # Agent 心跳超时（秒）
 
 [task]
-result_retention_days = 7    # Task result retention days
-file_storage_path = "./data/files" # File storage path
-max_file_size_mb = 50        # Single file size limit (MB)
+result_retention_days = 7    # 任务结果保留天数
+file_storage_path = "./data/files" # 文件存储路径
+max_file_size_mb = 50        # 单文件大小限制（MB）
 ```
 
-No manual modification is needed after the first launch. If adjustments are required, simply edit `config.toml` and restart.
+首次启动后无需手动修改。若需调整，直接编辑 `config.toml` 后重启即可。
 
-## Admin API Key
+## 管理员 API Key
 
-The Admin API Key is used to call admin interfaces (creating services, viewing all tasks, etc.). Ways to obtain it:
+Admin API Key 用于调用管理员接口（创建服务、查看全量任务等）。获取方式：
 
-1. **Auto-generated on first launch**: The console will print `Admin API Key: ak_admin_xxx`, and it will also be written to `config.toml`
-2. **Environment variable override**: Set `ADMIN_API_KEY` or `APP__ADMIN_API_KEY` before starting
-3. **Check config file**: Read the `admin_api_key` field from `config.toml`
+1. **首次启动自动生成**：控制台会打印 `Admin API Key: ak_admin_xxx`，同时写入 `config.toml`
+2. **环境变量覆盖**：启动前设置 `ADMIN_API_KEY` 或 `APP__ADMIN_API_KEY`
+3. **查看配置文件**：从 `config.toml` 的 `admin_api_key` 字段读取
 
-Please keep it safe and avoid leakage.
+请务必妥善保存，避免泄露。

--- a/server/README.zh.md
+++ b/server/README.zh.md
@@ -1,114 +1,114 @@
 # OpenAaaS Server
 
-<p align="right">中文 | <a href="./README.md">English</a></p>
+<p align="right"><a href="./README.md">English</a> | 中文</p>
 
-OpenAaaS 的 HTTP 服务端，负责接收 Client 任务、调度给 Agent 执行，并管理任务生命周期。
+The HTTP server for OpenAaaS, responsible for receiving client tasks, dispatching them to agents for execution, and managing the task lifecycle.
 
-## 编译安装
+## Build & Install
 
-需要安装 Rust 工具链（1.85+）：
+Requires the Rust toolchain (1.85+):
 
 ```bash
 cd server
 cargo build --release
 ```
 
-编译产物为 `target/release/open-aaas-server`。
+The compiled binary is located at `target/release/open-aaas-server`.
 
-## 命令用法
+## Command Usage
 
 ```bash
 open-aaas-server [OPTIONS] <COMMAND>
 ```
 
-### 全局选项
+### Global Options
 
-| 选项 | 说明 |
-|------|------|
-| `--config <FILE>` | 指定配置文件路径，默认读取当前目录的 `config.toml` |
+| Option | Description |
+|--------|-------------|
+| `--config <FILE>` | Specify the configuration file path; defaults to `config.toml` in the current directory |
 
-### 子命令
+### Subcommands
 
-| 命令 | 说明 |
-|------|------|
-| `run` | 前台运行服务器 |
-| `run-detached` | 后台运行服务器 |
-| `stop` | 停止后台服务器 |
-| `status` | 查看服务器状态 |
+| Command | Description |
+|---------|-------------|
+| `run` | Run the server in the foreground |
+| `run-detached` | Run the server in the background |
+| `stop` | Stop the background server |
+| `status` | Check the server status |
 
-## 首次启动
+## First Launch
 
-首次执行 `run` 时，若当前目录没有 `config.toml`，会进入交互式配置：
+When running `run` for the first time, if no `config.toml` exists in the current directory, an interactive configuration will start:
 
 ```bash
 $ ./open-aaas-server run
-Data directory [./data]:                # 回车确认或输入新路径
-Admin API Key []:                       # 回车随机生成，或输入自定义值
+Data directory [./data]:                # Press Enter to confirm or enter a new path
+Admin API Key []:                       # Press Enter to generate randomly, or enter a custom value
 ```
 
-服务端会自动完成以下初始化：
+The server will automatically perform the following initialization steps:
 
-1. 创建数据目录（默认 `./data`）
-2. 写入 SQLite 数据库路径：`{data_dir}/app.db`
-3. 写入文件存储路径：`{data_dir}/files`
-4. 生成随机 `secret_key`（若未配置）
-5. 创建 `admin_api_key`（你输入的值或随机生成）
-6. 将最终配置写入 `config.toml`
+1. Create the data directory (default: `./data`)
+2. Set the SQLite database path: `{data_dir}/app.db`
+3. Set the file storage path: `{data_dir}/files`
+4. Generate a random `secret_key` (if not configured)
+5. Create the `admin_api_key` (either the value you entered or a randomly generated one)
+6. Write the final configuration to `config.toml`
 
-随后正常启动服务。
+The service will then start normally.
 
-## 前台运行
+## Foreground Run
 
 ```bash
 ./open-aaas-server run
 ```
 
-启动后监听默认地址 `0.0.0.0:8080`。按 `Ctrl+C` 或发送 `SIGTERM` 可优雅关闭。
+After starting, it listens on the default address `0.0.0.0:8080`. Press `Ctrl+C` or send `SIGTERM` for a graceful shutdown.
 
-如果当前目录已有 `config.toml`，会直接加载配置启动，不再询问。
+If `config.toml` already exists in the current directory, it will load the configuration and start directly without prompting.
 
-## 后台运行
+## Background Run
 
 ```bash
 ./open-aaas-server run-detached
 ```
 
-- Linux/macOS：通过 `nohup` 后台运行，日志输出到 `{data_dir}/server.log`
-- Windows：通过 `cmd /C start /B` 后台运行
+- Linux/macOS: Runs in the background via `nohup`, with logs output to `{data_dir}/server.log`
+- Windows: Runs in the background via `cmd /C start /B`
 
-后台启动后会写入 pidfile，用于后续管理和状态查询。
+After starting in the background, a pidfile will be written for subsequent management and status queries.
 
-## 查看状态
+## Check Status
 
 ```bash
 ./open-aaas-server status
 ```
 
-输出示例：
+Example output:
 
 ```
-配置文件:    /path/to/config.toml
-数据目录:    /path/to/data
-监听地址:    0.0.0.0:8080
-运行状态:    运行中 (PID: 12345)
+Config file:    /path/to/config.toml
+Data directory: /path/to/data
+Listen address: 0.0.0.0:8080
+Status:         Running (PID: 12345)
 ```
 
-## 停止服务
+## Stop Service
 
 ```bash
 ./open-aaas-server stop
 ```
 
-向后台进程发送 `SIGTERM`，等待最多 5 秒优雅退出；超时则发送 `SIGKILL` 强制终止，并清理 pidfile。
+Sends `SIGTERM` to the background process, waiting up to 5 seconds for a graceful exit; if timed out, sends `SIGKILL` to force termination and cleans up the pidfile.
 
-## 环境变量
+## Environment Variables
 
-服务端启动时会自动加载当前目录的 `.env` 文件（如果存在）。
+The server automatically loads the `.env` file in the current directory (if it exists) on startup.
 
-以下环境变量可覆盖配置文件中的对应项，前缀为 `APP__`，层级用双下划线分隔：
+The following environment variables can override the corresponding items in the configuration file, with the prefix `APP__` and levels separated by double underscores:
 
-| 环境变量 | 对应配置项 |
-|----------|-----------|
+| Environment Variable | Corresponding Config Item |
+|----------------------|---------------------------|
 | `APP__SECRET_KEY` | `secret_key` |
 | `APP__ADMIN_API_KEY` | `admin_api_key` |
 | `APP__LOG_LEVEL` | `log_level` |
@@ -119,48 +119,48 @@ Admin API Key []:                       # 回车随机生成，或输入自定�
 | `APP__TASK__FILE_STORAGE_PATH` | `task.file_storage_path` |
 | `APP__TASK__MAX_FILE_SIZE_MB` | `task.max_file_size_mb` |
 
-示例：
+Example:
 
 ```bash
 APP__SERVER__ADDR="0.0.0.0:3000" APP__LOG_LEVEL=debug ./open-aaas-server run
 ```
 
-`ADMIN_API_KEY` 环境变量（无前缀）也可以直接覆盖管理员 API Key，优先级高于配置文件。
+The `ADMIN_API_KEY` environment variable (without prefix) can also directly override the admin API key, taking precedence over the configuration file.
 
-## 配置文件说明
+## Configuration File
 
-`config.toml` 完整示例：
+Complete `config.toml` example:
 
 ```toml
-secret_key = "xxx"          # HMAC 密钥，首次启动自动生成
-admin_api_key = "xxx"       # 管理员 API Key
+secret_key = "xxx"          # HMAC key, auto-generated on first launch
+admin_api_key = "xxx"       # Admin API key
 log_level = "info"          # trace / debug / info / warn / error
 
 [server]
-addr = "0.0.0.0:8080"       # 监听地址
-timeout_secs = 30           # HTTP 请求超时（秒）
-max_body_size = 10485760    # 最大请求体大小（10MB）
+addr = "0.0.0.0:8080"       # Listen address
+timeout_secs = 30           # HTTP request timeout (seconds)
+max_body_size = 10485760    # Maximum request body size (10MB)
 
 [database]
-url = "sqlite:./data/app.db" # SQLite 数据库路径
+url = "sqlite:./data/app.db" # SQLite database path
 
 [agent]
-heartbeat_timeout_secs = 60  # Agent 心跳超时（秒）
+heartbeat_timeout_secs = 60  # Agent heartbeat timeout (seconds)
 
 [task]
-result_retention_days = 7    # 任务结果保留天数
-file_storage_path = "./data/files" # 文件存储路径
-max_file_size_mb = 50        # 单文件大小限制（MB）
+result_retention_days = 7    # Task result retention days
+file_storage_path = "./data/files" # File storage path
+max_file_size_mb = 50        # Single file size limit (MB)
 ```
 
-首次启动后无需手动修改。若需调整，直接编辑 `config.toml` 后重启即可。
+No manual modification is needed after the first launch. If adjustments are required, simply edit `config.toml` and restart.
 
-## 管理员 API Key
+## Admin API Key
 
-Admin API Key 用于调用管理员接口（创建服务、查看全量任务等）。获取方式：
+The Admin API Key is used to call admin interfaces (creating services, viewing all tasks, etc.). Ways to obtain it:
 
-1. **首次启动自动生成**：控制台会打印 `Admin API Key: ak_admin_xxx`，同时写入 `config.toml`
-2. **环境变量覆盖**：启动前设置 `ADMIN_API_KEY` 或 `APP__ADMIN_API_KEY`
-3. **查看配置文件**：从 `config.toml` 的 `admin_api_key` 字段读取
+1. **Auto-generated on first launch**: The console will print `Admin API Key: ak_admin_xxx`, and it will also be written to `config.toml`
+2. **Environment variable override**: Set `ADMIN_API_KEY` or `APP__ADMIN_API_KEY` before starting
+3. **Check config file**: Read the `admin_api_key` field from `config.toml`
 
-请务必妥善保存，避免泄露。
+Please keep it safe and avoid leakage.


### PR DESCRIPTION
## 变更
- 将所有子模块的默认 README.md 改为中文内容
- 原英文内容移至 README.zh.md
- 更新全部 22 个文件顶部的语言切换链接
- 修复根目录 README.zh.md 中的相对链接显示文本
- dash/README.md 中残留的英文安装小标题改为中文