### PR TITLE
fix: correct README language switch links and filenames

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 <p align="center">
   <img src="./assets/logo.png" width="360" alt="OpenAaaS Logo">
@@ -9,11 +9,11 @@
 <p align="center">
   <a href="https://www.open-aaas.com">Website</a> ·
   <a href="https://arxiv.org/abs/2605.13618">Paper</a> ·
-  <a href="./server/README.zh.md">Server Docs</a> ·
-  <a href="./agent-core/README.zh.md">Agent Core Docs</a> ·
+  <a href="./server/README.en.md">Server Docs</a> ·
+  <a href="./agent-core/README.en.md">Agent Core Docs</a> ·
   <a href="#Usage">Usage Guide</a> ·
-  <a href="./client-extension/README.zh.md">Client Extensions</a> ·
-  <a href="./client-app/README.zh.md">Desktop Client</a>
+  <a href="./client-extension/README.en.md">Client Extensions</a> ·
+  <a href="./client-app/README.en.md">Desktop Client</a>
 </p>
 
 <p align="center">
@@ -200,7 +200,7 @@ Or better yet, you can have your Agent set it up for you directly.
   <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
 </p>
 
-See [client-extension/openaaas-mcp-adapter/README.zh.md](./client-extension/openaaas-mcp-adapter/README.zh.md) for details.
+See [client-extension/openaaas-mcp-adapter/README.en.md](./client-extension/openaaas-mcp-adapter/README.en.md) for details.
 
 ### Using the Desktop Client
 
@@ -211,7 +211,7 @@ The desktop client is ideal for:
 - Managing multiple servers and browsing services visually
 - Drag-and-drop file uploads and real-time task progress tracking
 
-📖 See [client-app/README.zh.md](./client-app/README.zh.md) for details.
+📖 See [client-app/README.en.md](./client-app/README.en.md) for details.
 
 <p align="center">
   <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
@@ -260,7 +260,7 @@ The Agent executor image needs to be built in advance (under the agent-core dire
 cd executor-example && docker build -t open-aaas-executor:latest .
 ```
 
-See [agent-core/README.zh.md](./agent-core/README.zh.md) for details.
+See [agent-core/README.en.md](./agent-core/README.en.md) for details.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 <p align="center">
   <img src="./assets/logo.png" width="360" alt="OpenAaaS Logo">

--- a/agent-core/README.en.md
+++ b/agent-core/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Agent Core
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 The Agent scheduler for OpenAaaS, responsible for registering with the Server, polling for tasks, and executing tasks in isolated Docker containers.
 
@@ -21,7 +21,7 @@ Agent Core executes tasks in isolated Docker containers, so a Docker image must 
 
 The interaction contract is simple: **Agent Core mounts `task.json` and input files into the container, and the container writes result files to the workspace after execution**. Agent Core does not care how the container is implemented internally, as long as this protocol is satisfied.
 
-The `executor-example/` directory provides a **sample image** (based on node + python3, using pi-coding-agent as the execution logic) to demonstrate this interaction process. You can modify it directly or build your own image from scratch. See `executor-example/README.zh.md` for details.
+The `executor-example/` directory provides a **sample image** (based on node + python3, using pi-coding-agent as the execution logic) to demonstrate this interaction process. You can modify it directly or build your own image from scratch. See `executor-example/README.en.md` for details.
 
 Build the sample image:
 

--- a/agent-core/README.md
+++ b/agent-core/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Agent Core
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 OpenAaaS 的 Agent 调度器，负责向 Server 注册、轮询获取任务，并通过 Docker 容器隔离执行任务。
 

--- a/agent-core/executor-example/README.en.md
+++ b/agent-core/executor-example/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Executor Example
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 This is **a sample Docker executor image for OpenAaaS**.
 

--- a/agent-core/executor-example/README.md
+++ b/agent-core/executor-example/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Executor Example
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
 

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.en.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.en.md
@@ -1,4 +1,4 @@
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 # subagent-isolation
 

--- a/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
+++ b/agent-core/executor-example/pi/agent/extensions/subagent-isolation/README.md
@@ -1,4 +1,4 @@
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 # subagent-isolation
 

--- a/client-app/README.en.md
+++ b/client-app/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Desktop Client
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 The desktop client for OpenAaaS, providing visual server management, service marketplace browsing, and task submission.
 

--- a/client-app/README.md
+++ b/client-app/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Desktop Client
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 OpenAaaS 的桌面客户端，提供可视化的服务器管理、服务市场浏览和任务提交能力。
 

--- a/client-extension/README.en.md
+++ b/client-extension/README.en.md
@@ -1,6 +1,6 @@
 ## Client Extensions
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 `client-extension/` is the collection of client extensions for OpenAaaS, enabling different Agent clients (pi, Kimi, etc.) to connect to the OpenAaaS network, discover remote services, submit tasks, and retrieve results.
 

--- a/client-extension/README.md
+++ b/client-extension/README.md
@@ -1,6 +1,6 @@
 ## Client Extensions
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 `client-extension/` 是 OpenAaaS 的客户端扩展集合，让不同的 Agent 客户端（pi、Kimi 等）能够连接到 OpenAaaS 网络，发现远程服务、提交任务并获取结果。
 

--- a/client-extension/kimi-plugin/README.en.md
+++ b/client-extension/kimi-plugin/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Kimi Plugin
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 A Kimi Code plugin for OpenAaaS, enabling Kimi to connect to the OpenAaaS network, discover remote Agent services, submit tasks, and retrieve results.
 

--- a/client-extension/kimi-plugin/README.md
+++ b/client-extension/kimi-plugin/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Kimi 插件
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 OpenAaaS 的 Kimi Code 插件，让 Kimi 能够连接 OpenAaaS 网络，发现远程 Agent 服务、提交任务并获取结果。
 

--- a/client-extension/openaaas-mcp-adapter/README.en.md
+++ b/client-extension/openaaas-mcp-adapter/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS MCP Adapter
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 The MCP (Model Context Protocol) adapter for OpenAaaS, enabling MCP-enabled AI clients such as Claude Desktop, Cursor, and Cline to connect to the OpenAaaS Server, discover remote services, submit tasks, and retrieve results.
 

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS MCP Adapter
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 OpenAaaS 的 MCP（Model Context Protocol）适配器，让 Claude Desktop、Cursor、Cline 等支持 MCP 的 AI 客户端能够连接 OpenAaaS Server，发现远程服务、提交任务并获取结果。
 

--- a/client-extension/pi-extension/README.en.md
+++ b/client-extension/pi-extension/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS pi Extension
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 An OpenAaaS extension for [pi](https://github.com/badlogic/pi-mono), providing a unified `OpenAaaS` tool for service discovery, client registration, task submission, and result download.
 

--- a/client-extension/pi-extension/README.md
+++ b/client-extension/pi-extension/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS pi Extension
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 为 [pi](https://github.com/badlogic/pi-mono) 开发的 OpenAaaS 扩展，提供统一的 `OpenAaaS` 工具，用于服务发现、客户端注册、任务提交及结果下载。
 

--- a/dash/README.en.md
+++ b/dash/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Dashboard
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 > **⚠️ Positioning Note**: This is a **debugging and admin control tool** for developers and system administrators, used for monitoring and managing OpenAaaS tasks and system status. **It is NOT the OpenAaaS user interface / main UI (Main UI)**.
 

--- a/dash/README.md
+++ b/dash/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Dashboard
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 > **⚠️ 定位说明**：这是一个面向开发者和系统管理员的**调试与管理员控制工具**，用于监控和管理 OpenAaaS 的任务与系统状态。**它不是 OpenAaaS 的用户界面 / 主界面（Main UI）**。
 

--- a/server/README.en.md
+++ b/server/README.en.md
@@ -1,6 +1,6 @@
 # OpenAaaS Server
 
-<p align="right"><a href="./README.md">English</a> | 中文</p>
+<p align="right"><a href="./README.md">中文</a> | English</p>
 
 The HTTP server for OpenAaaS, responsible for receiving client tasks, dispatching them to agents for execution, and managing the task lifecycle.
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # OpenAaaS Server
 
-<p align="right"><a href="./README.zh.md">中文</a> | English</p>
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 OpenAaaS 的 HTTP 服务端，负责接收 Client 任务、调度给 Agent 执行，并管理任务生命周期。
 


### PR DESCRIPTION
## 修复内容

项目中所有 README 的中英文语言切换全部搞反了：
- `README.md` 实际内容是中文，但点击顶部 "中文" 链接会跳转到英文文档
- `README.zh.md` 实际内容是英文，文件名命名错误

## 变更

- 将 11 个 `README.zh.md` 重命名为 `README.en.md`
- 修正 11 个 `README.md`（中文页）顶部语言栏：`中文 | [English]`
- 修正 11 个 `README.en.md`（英文页）顶部语言栏：`[中文] | English`
- 更新所有内部交叉引用链接（`README.zh.md` → `README.en.md`）