### PR TITLE
refactor(server&agent-core): separate poll from heartbeat and optimize offline detection

### DIFF
--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-28
+
+### Changed
+- 心跳间隔从 30 秒调整为 20 秒，与 server 固定超时 60 秒形成 T/3 比例，容错 3 次连续丢包
+
 ## [0.3.1] - 2026-05-16
 
 ### Changed
@@ -50,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.4.0]: https://github.com/Wolido/OpenAaaS/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Wolido/OpenAaaS/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Wolido/OpenAaaS/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Wolido/OpenAaaS/compare/v0.2.0...v0.2.1

--- a/agent-core/Cargo.toml
+++ b/agent-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-core"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "OpenAaaS Agent Core - 调度与执行框架"
 

--- a/agent-core/src/scheduler.rs
+++ b/agent-core/src/scheduler.rs
@@ -88,7 +88,7 @@ impl<E: Executor + 'static> Scheduler<E> {
         self.recover_tasks().await?;
 
         // 创建心跳间隔
-        let mut heartbeat_interval = interval(Duration::from_secs(30));
+        let mut heartbeat_interval = interval(Duration::from_secs(20));
 
         // 创建轮询间隔
         let poll_interval = Duration::from_secs(self.config.server.poll_interval_secs);

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-28
+
+### Changed
+- `poll_handler` 不再更新心跳时间戳，poll 变为纯读操作，心跳完全由独立 heartbeat 接口负责
+- 离线检测后台任务间隔从 30 秒调整为 10 秒
+
 ## [0.6.1] - 2026-05-25
 
 ### Fixed
@@ -69,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.7.0]: https://github.com/Wolido/OpenAaaS/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Wolido/OpenAaaS/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Wolido/OpenAaaS/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Wolido/OpenAaaS/compare/v0.5.0...v0.5.1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]

--- a/server/src/bg_tasks.rs
+++ b/server/src/bg_tasks.rs
@@ -5,7 +5,7 @@ use open_aaas_server::state::AppState;
 pub fn spawn_heartbeat_task(state: AppState, shutdown_tx: watch::Sender<()>) -> tokio::task::JoinHandle<()> {
     let mut shutdown_rx = shutdown_tx.subscribe();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        let mut interval = tokio::time::interval(Duration::from_secs(10));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {

--- a/server/src/handlers/agent.rs
+++ b/server/src/handlers/agent.rs
@@ -292,9 +292,6 @@ pub async fn poll_handler(
         return Err(AppError::Forbidden);
     }
 
-    // 更新心跳
-    update_service_heartbeat(state.db.pool(), &service_id).await?;
-
     // ===== 1. 优先检查是否有 running 的任务需要取消（最高优先级） =====
     let cancelling_task = sqlx::query_as::<_, Task>(
         "SELECT * FROM tasks WHERE service_id = ? AND status = 'cancelling' LIMIT 1"


### PR DESCRIPTION
## Changes

- **poll_handler**: Removed database heartbeat write, now read-only for task polling
- **agent-core heartbeat**: Interval reduced from 30s to 20s
- **server offline detection**: Background check interval reduced from 30s to 10s
- **Design**: Fixed timeout = 60s, heartbeat interval = 20s (T/3), check interval = 10s (T/6)
  - Tolerates 3 consecutive heartbeat failures before marking agent offline
  - Reduces max detection delay from ~90s to ~70s