### PR TITLE
feat: add PUT /api/v1/services/{id} endpoint

### DIFF
--- a/dash/src/aaas_dashboard/client.py
+++ b/dash/src/aaas_dashboard/client.py
@@ -737,6 +737,50 @@ class OaaSClient:
             print(f"[ERROR] Network error in grant_service_permission: {e}")
             return False
 
+    def update_service(
+        self,
+        service_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        usage: Optional[str] = None,
+        is_public: Optional[bool] = None,
+    ) -> Optional[dict]:
+        """Update a service (admin only).
+
+        Args:
+            service_id: Service ID to update
+            name: New service name
+            description: New description
+            usage: New usage description
+            is_public: New public status
+
+        Returns:
+            Updated service dict if successful, None otherwise
+        """
+        payload: dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if usage is not None:
+            payload["usage"] = usage
+        if is_public is not None:
+            payload["is_public"] = is_public
+
+        if not payload:
+            # No fields to update, fetch current service info
+            try:
+                return self._get(f"/api/v1/services/{service_id}")
+            except requests.RequestException as e:
+                print(f"[ERROR] Network error in update_service: {e}")
+                return None
+
+        try:
+            return self._put(f"/api/v1/services/{service_id}", json_data=payload)
+        except requests.RequestException as e:
+            print(f"[ERROR] Network error in update_service: {e}")
+            return None
+
 
 class MockOaaSClient(OaaSClient):
     """Mock client for testing without a real server."""
@@ -1110,3 +1154,27 @@ class MockOaaSClient(OaaSClient):
             self._permissions[user_id].append(service_id)
             return True
         return False
+
+    def update_service(
+        self,
+        service_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        usage: Optional[str] = None,
+        is_public: Optional[bool] = None,
+    ) -> Optional[dict]:
+        """Update a mock service."""
+        service = next((s for s in self._services if s["id"] == service_id), None)
+        if service is None:
+            return None
+
+        if name is not None:
+            service["name"] = name
+        if description is not None:
+            service["description"] = description
+        if usage is not None:
+            service["usage"] = usage
+        if is_public is not None:
+            service["is_public"] = is_public
+
+        return dict(service)

--- a/dash/src/aaas_dashboard/pages/02_Admin.py
+++ b/dash/src/aaas_dashboard/pages/02_Admin.py
@@ -80,6 +80,8 @@ with tab_services:
             with st.container():
                 svc_id = svc.get('id')
                 service_name = svc.get("name", "-") or "-"
+                if not svc_id:
+                    continue
                 svc_tasks = [t for t in all_tasks if t.service_id == svc_id]
                 pending_count = sum(1 for t in svc_tasks if t.status == "pending")
                 running_count = sum(1 for t in svc_tasks if t.status == "running")
@@ -100,8 +102,13 @@ with tab_services:
                     is_public = svc.get('is_public', False)
                     st.write("🌍 Public" if is_public else "🔒 Restricted")
                 with col6:
+                    if st.button("✏️ Edit", key=f"edit_svc_{svc_id}"):
+                        st.session_state[f"edit_svc_open_{svc_id}"] = True
+                        st.session_state[f"delete_svc_confirming_{svc_id}"] = False
+
                     if st.button("🗑️ Delete", key=f"delete_svc_{svc_id}"):
                         st.session_state[f"delete_svc_confirming_{svc_id}"] = True
+                        st.session_state[f"edit_svc_open_{svc_id}"] = False
 
                 if st.session_state.get(f"delete_svc_confirming_{svc_id}", False):
                     st.warning("Delete will remove this service only if the server allows it. It will not force-cancel associated tasks.")
@@ -135,6 +142,41 @@ with tab_services:
                         if st.button("Cancel", key=f"cancel_delete_svc_{svc_id}", use_container_width=True):
                             st.session_state[f"delete_svc_confirming_{svc_id}"] = False
                             st.rerun()
+
+                # Edit form
+                if st.session_state.get(f"edit_svc_open_{svc_id}", False):
+                    with st.container(border=True):
+                        st.markdown(f"**✏️ Edit Service: `{service_name}`**")
+                        original_name = svc.get("name") or ""
+                        original_desc = svc.get("description") or ""
+                        original_usage = svc.get("usage") or ""
+                        original_public = svc.get("is_public") or False
+
+                        edit_name = st.text_input("Name", value=original_name, key=f"edit_name_{svc_id}")
+                        edit_desc = st.text_area("Description", value=original_desc, key=f"edit_desc_{svc_id}")
+                        edit_usage = st.text_area("Usage", value=original_usage, key=f"edit_usage_{svc_id}")
+                        edit_public = st.checkbox("Public", value=original_public, key=f"edit_public_{svc_id}")
+
+                        edit_cols = st.columns([1.2, 1, 3.8])
+                        with edit_cols[0]:
+                            if st.button("💾 Save", key=f"save_edit_{svc_id}", type="primary", use_container_width=True):
+                                updated = client.update_service(
+                                    service_id=svc_id,
+                                    name=edit_name if edit_name != original_name else None,
+                                    description=edit_desc if edit_desc != original_desc else None,
+                                    usage=edit_usage if edit_usage != original_usage else None,
+                                    is_public=edit_public if edit_public != original_public else None,
+                                )
+                                if updated:
+                                    st.success("Service updated!")
+                                    st.session_state[f"edit_svc_open_{svc_id}"] = False
+                                    st.rerun()
+                                else:
+                                    st.error("Failed to update service.")
+                        with edit_cols[1]:
+                            if st.button("Cancel", key=f"cancel_edit_{svc_id}", use_container_width=True):
+                                st.session_state[f"edit_svc_open_{svc_id}"] = False
+                                st.rerun()
 
                 # Force delete expander on a new full-width row
                 with st.expander("⚠️ Force Delete", expanded=False):

--- a/dash/src/aaas_dashboard/pages/02_Admin.py
+++ b/dash/src/aaas_dashboard/pages/02_Admin.py
@@ -149,7 +149,9 @@ with tab_services:
                         st.markdown(f"**✏️ Edit Service: `{service_name}`**")
                         original_name = svc.get("name") or ""
                         original_desc = svc.get("description") or ""
-                        original_usage = svc.get("usage") or ""
+                        # list_services 返回的 ServiceListItem 不包含 usage，需要单独获取
+                        usage_info = client.get_service_usage(svc_id)
+                        original_usage = (usage_info.get("usage") if usage_info else None) or ""
                         original_public = svc.get("is_public") or False
 
                         edit_name = st.text_input("Name", value=original_name, key=f"edit_name_{svc_id}")

--- a/dash/tests/test_client.py
+++ b/dash/tests/test_client.py
@@ -1067,6 +1067,99 @@ class TestClientServices:
         result = client.get_service_usage("nonexistent")
         assert result is None
 
+    @responses.activate
+    def test_client_update_service_success(self, client, mock_server_url):
+        """Test updating a service with all fields."""
+        responses.add(
+            responses.PUT,
+            f"{mock_server_url}/api/v1/services/svc-1",
+            json={
+                "id": "svc-1",
+                "name": "updated-name",
+                "description": "updated-desc",
+                "usage": "updated-usage",
+                "is_public": False,
+                "agent_status": "online",
+                "registration_status": "active",
+            },
+            status=200,
+        )
+        result = client.update_service(
+            "svc-1",
+            name="updated-name",
+            description="updated-desc",
+            usage="updated-usage",
+            is_public=False,
+        )
+        assert result is not None
+        assert result["name"] == "updated-name"
+        assert result["description"] == "updated-desc"
+        assert result["usage"] == "updated-usage"
+        assert result["is_public"] is False
+        # Verify only changed fields were sent
+        request_body = responses.calls[0].request.body
+        import json
+        payload = json.loads(request_body)
+        assert payload == {
+            "name": "updated-name",
+            "description": "updated-desc",
+            "usage": "updated-usage",
+            "is_public": False,
+        }
+
+    @responses.activate
+    def test_client_update_service_partial(self, client, mock_server_url):
+        """Test updating a service with only some fields."""
+        responses.add(
+            responses.PUT,
+            f"{mock_server_url}/api/v1/services/svc-1",
+            json={"id": "svc-1", "name": "only-name-changed"},
+            status=200,
+        )
+        result = client.update_service("svc-1", name="only-name-changed")
+        assert result is not None
+        assert result["name"] == "only-name-changed"
+        import json
+        payload = json.loads(responses.calls[0].request.body)
+        assert payload == {"name": "only-name-changed"}
+
+    @responses.activate
+    def test_client_update_service_empty_payload_fallback(self, client, mock_server_url):
+        """Test that empty payload falls back to GET current service info."""
+        responses.add(
+            responses.GET,
+            f"{mock_server_url}/api/v1/services/svc-1",
+            json={"id": "svc-1", "name": "current-name"},
+            status=200,
+        )
+        result = client.update_service("svc-1")
+        assert result is not None
+        assert result["name"] == "current-name"
+        # Verify GET was called, not PUT
+        assert responses.calls[0].request.method == "GET"
+
+    @responses.activate
+    def test_client_update_service_not_found(self, client, mock_server_url):
+        """Test updating a non-existent service returns None."""
+        responses.add(
+            responses.PUT,
+            f"{mock_server_url}/api/v1/services/nonexistent",
+            status=404,
+        )
+        result = client.update_service("nonexistent", name="new-name")
+        assert result is None
+
+    @responses.activate
+    def test_client_update_service_network_error(self, client, mock_server_url):
+        """Test network error in update_service."""
+        responses.add(
+            responses.PUT,
+            f"{mock_server_url}/api/v1/services/svc-1",
+            body=requests.ConnectionError("Connection refused"),
+        )
+        result = client.update_service("svc-1", name="new-name")
+        assert result is None
+
 
 class TestMockClient:
     """Test MockOaaSClient functionality."""
@@ -1330,4 +1423,53 @@ class TestMockClient:
 
         # Test non-existent service
         result = client.get_service_usage("nonexistent")
+        assert result is None
+
+    def test_mock_client_update_service(self):
+        """Test mock client update service."""
+        client = MockOaaSClient()
+        result = client.update_service(
+            "svc-001",
+            name="updated-name",
+            description="updated-desc",
+            usage="updated-usage",
+            is_public=False,
+        )
+        assert result is not None
+        assert result["name"] == "updated-name"
+        assert result["description"] == "updated-desc"
+        assert result["usage"] == "updated-usage"
+        assert result["is_public"] is False
+        # Verify in-memory service was updated
+        svc = next(s for s in client.list_services() if s["id"] == "svc-001")
+        assert svc["name"] == "updated-name"
+        assert svc["is_public"] is False
+
+    def test_mock_client_update_service_partial(self):
+        """Test mock client partial update."""
+        client = MockOaaSClient()
+        original = next(s for s in client.list_services() if s["id"] == "svc-001")
+        original_name = original["name"]
+        result = client.update_service("svc-001", name="only-name-changed")
+        assert result is not None
+        assert result["name"] == "only-name-changed"
+        # Other fields should remain unchanged
+        svc = next(s for s in client.list_services() if s["id"] == "svc-001")
+        assert svc["description"] == original["description"]
+        assert svc["usage"] == original["usage"]
+
+    def test_mock_client_update_service_empty_payload(self):
+        """Test mock client update with no fields returns current service."""
+        client = MockOaaSClient()
+        result = client.update_service("svc-001")
+        assert result is not None
+        assert result["id"] == "svc-001"
+        # Service should remain unchanged
+        svc = next(s for s in client.list_services() if s["id"] == "svc-001")
+        assert svc["name"] == result["name"]
+
+    def test_mock_client_update_service_not_found(self):
+        """Test mock client update non-existent service returns None."""
+        client = MockOaaSClient()
+        result = client.update_service("nonexistent", name="new-name")
         assert result is None

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-29
+
+### Added
+- 新增 `PUT /api/v1/services/{id}` 接口，支持管理员更新服务信息（name、description、usage、is_public）
+- 支持部分更新，仅传入需要修改的字段
+- 空请求体时直接返回当前服务信息
+
 ## [0.7.0] - 2026-05-28
 
 ### Changed
@@ -75,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.7.1]: https://github.com/Wolido/OpenAaaS/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Wolido/OpenAaaS/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Wolido/OpenAaaS/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Wolido/OpenAaaS/compare/v0.5.1...v0.6.0

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 
 [dependencies]

--- a/server/src/handlers/services.rs
+++ b/server/src/handlers/services.rs
@@ -17,7 +17,7 @@ use chrono::Utc;
 use crate::{
     auth::require_admin,
     error::{AppError, Result},
-    models::service::{CreateServiceRequest, DeleteServiceResponse, Service, ServiceListItem, ServiceResponse, CreateServiceResponse},
+    models::service::{CreateServiceRequest, DeleteServiceResponse, Service, ServiceListItem, ServiceResponse, CreateServiceResponse, UpdateServiceRequest},
     state::AppState,
 };
 
@@ -25,7 +25,7 @@ use crate::{
 pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
         .route("/", get(list_services).post(create_service))
-        .route("/{id}", get(get_service).delete(delete_service))
+        .route("/{id}", get(get_service).put(update_service).delete(delete_service))
         .layer(middleware::from_fn(require_admin))
         .layer(middleware::from_fn_with_state(state, crate::auth::require_auth))
 }
@@ -131,6 +131,85 @@ pub async fn get_service(
         .await
         .map_err(AppError::Database)?
         .ok_or(AppError::NotFound)?;
+
+    Ok(Json(ServiceResponse::from(service)))
+}
+
+/// 更新服务信息
+pub async fn update_service(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateServiceRequest>,
+) -> Result<Json<ServiceResponse>> {
+    // 检查服务是否存在
+    let exists: bool = sqlx::query_scalar::<_, i32>("SELECT 1 FROM services WHERE id = ?")
+        .bind(&id)
+        .fetch_optional(state.db.pool())
+        .await
+        .map_err(AppError::Database)?
+        .is_some();
+
+    if !exists {
+        return Err(AppError::NotFound);
+    }
+
+    // 构建动态更新
+    let mut query_parts = vec![];
+    if req.name.is_some() {
+        query_parts.push("name = ?");
+    }
+    if req.description.is_some() {
+        query_parts.push("description = ?");
+    }
+    if req.usage.is_some() {
+        query_parts.push("usage = ?");
+    }
+    if req.is_public.is_some() {
+        query_parts.push("is_public = ?");
+    }
+
+    if query_parts.is_empty() {
+        // 没有要更新的字段，直接返回当前服务
+        let service: Service = sqlx::query_as::<_, Service>("SELECT * FROM services WHERE id = ?")
+            .bind(&id)
+            .fetch_one(state.db.pool())
+            .await
+            .map_err(AppError::Database)?;
+        return Ok(Json(ServiceResponse::from(service)));
+    }
+
+    let query = format!(
+        "UPDATE services SET {} WHERE id = ?",
+        query_parts.join(", ")
+    );
+
+    let mut sql = sqlx::query(&query);
+    if let Some(name) = req.name {
+        sql = sql.bind(name);
+    }
+    if let Some(description) = req.description {
+        sql = sql.bind(description);
+    }
+    if let Some(usage) = req.usage {
+        sql = sql.bind(usage);
+    }
+    if let Some(is_public) = req.is_public {
+        sql = sql.bind(is_public);
+    }
+    sql = sql.bind(&id);
+
+    sql.execute(state.db.pool())
+        .await
+        .map_err(AppError::Database)?;
+
+    tracing::info!("更新服务: service_id={}", id);
+
+    // 返回更新后的服务
+    let service: Service = sqlx::query_as::<_, Service>("SELECT * FROM services WHERE id = ?")
+        .bind(&id)
+        .fetch_one(state.db.pool())
+        .await
+        .map_err(AppError::Database)?;
 
     Ok(Json(ServiceResponse::from(service)))
 }

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -6,6 +6,6 @@ pub mod task;
 pub mod user;
 
 pub use file::{TaskFile, FileCreatedBy, UploadFileResponse, FileInfoResponse, FileListResponse};
-pub use service::{Service, ServiceResponse, ServiceListItem, AgentStatus};
+pub use service::{Service, ServiceResponse, ServiceListItem, AgentStatus, UpdateServiceRequest};
 pub use task::{Task, TaskStatus, TaskResponse, ListTasksQuery};
 pub use user::{User, UserRole, UserResponse};

--- a/server/src/models/service.rs
+++ b/server/src/models/service.rs
@@ -102,6 +102,15 @@ fn default_true() -> bool {
     true
 }
 
+/// 更新服务请求（admin）
+#[derive(Debug, Deserialize)]
+pub struct UpdateServiceRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub usage: Option<String>,
+    pub is_public: Option<bool>,
+}
+
 /// 创建服务响应（admin）- 包含 registration_token
 #[derive(Debug, Serialize)]
 pub struct CreateServiceResponse {

--- a/server/tests/integration/services_api.rs
+++ b/server/tests/integration/services_api.rs
@@ -916,3 +916,186 @@ async fn test_get_restricted_service_usage_with_permission_success() {
     
     app.cleanup().await;
 }
+
+// ============================================================================
+// 更新服务测试
+// ============================================================================
+
+#[tokio::test]
+async fn test_admin_update_service_success() {
+    let app = TestApp::new().await;
+    
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    let (service_id, _, _) = create_test_service(app.pool(), "update_me", "Original Name", true).await;
+    
+    let request_body = json!({
+        "name": "Updated Name",
+        "description": "Updated description",
+        "usage": "Updated usage",
+        "is_public": false
+    });
+    
+    let response = app
+        .router
+        .clone()
+        .oneshot(Request::builder()
+            .method("PUT")
+            .uri(&format!("/api/v1/services/{}", service_id))
+            .header("Content-Type", "application/json")
+            .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+            .body(Body::from(request_body.to_string()))
+            .unwrap())
+        .await
+        .unwrap();
+    
+    assert_eq!(response.status(), StatusCode::OK);
+    
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    
+    assert_eq!(json["id"].as_str(), Some(service_id.as_str()));
+    assert_eq!(json["name"].as_str(), Some("Updated Name"));
+    assert_eq!(json["description"].as_str(), Some("Updated description"));
+    assert_eq!(json["usage"].as_str(), Some("Updated usage"));
+    assert_eq!(json["is_public"].as_bool(), Some(false));
+    
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_admin_update_service_partial() {
+    let app = TestApp::new().await;
+    
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    let (service_id, _, _) = create_test_service(app.pool(), "partial_update", "Original Name", true).await;
+    
+    // 只更新 name
+    let request_body = json!({
+        "name": "Only Name Updated"
+    });
+    
+    let response = app
+        .router
+        .clone()
+        .oneshot(Request::builder()
+            .method("PUT")
+            .uri(&format!("/api/v1/services/{}", service_id))
+            .header("Content-Type", "application/json")
+            .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+            .body(Body::from(request_body.to_string()))
+            .unwrap())
+        .await
+        .unwrap();
+    
+    assert_eq!(response.status(), StatusCode::OK);
+    
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    
+    assert_eq!(json["name"].as_str(), Some("Only Name Updated"));
+    // 其他字段应保持不变
+    assert_eq!(json["is_public"].as_bool(), Some(true));
+    
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_admin_update_service_not_found() {
+    let app = TestApp::new().await;
+    
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    
+    let request_body = json!({
+        "name": "Should Not Update"
+    });
+    
+    let response = app
+        .router
+        .clone()
+        .oneshot(Request::builder()
+            .method("PUT")
+            .uri("/api/v1/services/non-existent-service")
+            .header("Content-Type", "application/json")
+            .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+            .body(Body::from(request_body.to_string()))
+            .unwrap())
+        .await
+        .unwrap();
+    
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_client_update_service_forbidden() {
+    let app = TestApp::new().await;
+    
+    let (_, client_api_key, _) = create_test_user(app.pool(), "clientuser", UserRole::Client).await;
+    let (service_id, _, _) = create_test_service(app.pool(), "test_service", "Test Service", true).await;
+    
+    let request_body = json!({
+        "name": "Unauthorized Update"
+    });
+    
+    let response = app
+        .router
+        .clone()
+        .oneshot(Request::builder()
+            .method("PUT")
+            .uri(&format!("/api/v1/services/{}", service_id))
+            .header("Content-Type", "application/json")
+            .header(auth_header(&client_api_key).0, auth_header(&client_api_key).1)
+            .body(Body::from(request_body.to_string()))
+            .unwrap())
+        .await
+        .unwrap();
+    
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    
+    // 验证服务名称未被修改
+    let name: (String,) = sqlx::query_as("SELECT name FROM services WHERE id = ?")
+        .bind(&service_id)
+        .fetch_one(app.pool())
+        .await
+        .unwrap();
+    
+    assert_eq!(name.0, "Test Service");
+    
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_admin_update_service_empty_body() {
+    let app = TestApp::new().await;
+    
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    let (service_id, _, _) = create_test_service(app.pool(), "empty_update", "Empty Update", true).await;
+    
+    // 空请求体（没有字段要更新）
+    let request_body = json!({});
+    
+    let response = app
+        .router
+        .clone()
+        .oneshot(Request::builder()
+            .method("PUT")
+            .uri(&format!("/api/v1/services/{}", service_id))
+            .header("Content-Type", "application/json")
+            .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+            .body(Body::from(request_body.to_string()))
+            .unwrap())
+        .await
+        .unwrap();
+    
+    assert_eq!(response.status(), StatusCode::OK);
+    
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    
+    // 应返回原始服务信息，未被修改
+    assert_eq!(json["id"].as_str(), Some(service_id.as_str()));
+    assert_eq!(json["name"].as_str(), Some("Empty Update"));
+    
+    app.cleanup().await;
+}


### PR DESCRIPTION
## 变更

- 新增 UpdateServiceRequest 模型，支持部分更新（name, description, usage, is_public）
- 新增 update_service handler，动态 SQL 构建，仅更新传入的字段
- 在 /api/v1/services/{id} 注册 PUT 路由
- 空请求体时直接返回当前服务信息
- 新增 5 个集成测试（完整更新、部分更新、404、权限、空请求体）

## 测试

- cargo test 通过（366 passed, 0 failed）