### PR TITLE
docs: 在 README 中突出预编译二进制下载方式

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -241,6 +241,8 @@ The desktop client is ideal for:
 
 📖 See [client-app/README.en.md](./client-app/README.en.md) for details.
 
+> macOS and Windows users can download `.dmg` or `.msi` installers directly from [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases).
+
 <p align="center">
   <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
 </p>
@@ -259,6 +261,37 @@ If your Agent does not have an OpenAaaS plugin, simply have it access <https://a
 Launch OpenAaaS on a local server in your machine room or lab, and register local analysis capabilities as network nodes. Any Agent in the research group — pi, Kimi, Claude, or a self-built system — can query node status, submit analysis tasks, and retrieve result data through a unified entry point.
 
 ### Local Deployment
+
+#### Prebuilt Binaries (Recommended)
+
+Precompiled binaries are available for all components. **No Rust installation, no compilation — just download and run.**
+
+- **Download**: [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
+
+| Component | Binary Name | Use Case |
+|-----------|-------------|----------|
+| Server | `open-aaas-server` | Network scheduling hub |
+| Agent Core | `agent-core` | Execution node |
+
+Supported platforms:
+- **Server / Agent Core**: Linux x64 (musl static linking), Linux arm64 (musl static linking), macOS arm64, Windows x64
+- **Desktop Client (client-app)**: macOS, Windows
+
+> 💡 Linux builds use musl static linking and do not depend on system glibc, so they run on any Linux distribution out of the box.
+
+**Quick start (Server example)**:
+
+```bash
+# Download and extract the archive for your platform
+chmod +x open-aaas-server   # Unix users; Windows users run .exe directly
+./open-aaas-server run
+```
+
+`config.toml` and the SQLite database are auto-generated on first launch.
+
+#### Build from Source
+
+If you need to customize the code, build from source.
 
 **Deploy Server (Scheduling Center)**:
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Rust + Docker — 部署在数据本地
 
 📖 详见 [client-app/README.md](./client-app/README.md)
 
+> macOS 和 Windows 用户可直接从 [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) 下载 `.dmg` 或 `.msi` 安装包。
+
 <p align="center">
   <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
 </p>
@@ -259,6 +261,37 @@ Rust + Docker — 部署在数据本地
 在机房或实验室的本地服务器上启动 OpenAaaS，将本地分析能力注册为网络节点。课题组内的任何 Agent——pi、Kimi、Claude 或自研系统——都能通过统一入口查询节点状态、提交分析任务、获取结果数据。
 
 ### 本地部署
+
+#### 预编译二进制（推荐）
+
+OpenAaaS 为每个组件提供了预编译二进制文件，**无需安装 Rust，无需编译，下载即可运行**。
+
+- **下载地址**: [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
+
+| 组件 | 二进制文件名 | 适用场景 |
+|------|-------------|----------|
+| Server | `open-aaas-server` | 网络调度中心 |
+| Agent Core | `agent-core` | 执行节点 |
+
+支持平台：
+- **Server / Agent Core**：Linux x64 (musl 静态链接)、Linux arm64 (musl 静态链接)、macOS arm64、Windows x64
+- **桌面客户端（client-app）**：macOS、Windows
+
+> 💡 Linux 版本采用 musl 静态链接，不依赖系统 glibc，可在任意 Linux 发行版直接运行。
+
+**快速开始（以 Server 为例）**：
+
+```bash
+# 下载对应平台的压缩包并解压后
+chmod +x open-aaas-server   # Unix 用户；Windows 用户直接运行 .exe
+./open-aaas-server run
+```
+
+首次启动自动生成 `config.toml` 和 SQLite 数据库。
+
+#### 从源码编译
+
+如果你需要自定义修改代码，可以从源码编译。
 
 **部署 Server（调度中心）**：
 


### PR DESCRIPTION
## 改动摘要

在「本地部署」部分最前面新增醒目的「预编译二进制（推荐）」章节，将原有源码编译方式降级为次级选项。

### 具体变更

1. **README.md / README.en.md**
   - 新增「预编译二进制（推荐）」章节，放在「本地部署」最前面
   - 提供各组件二进制文件名称、支持平台列表（Linux x64/arm64 musl、macOS arm64、Windows x64）
   - 强调 **无需 Rust、无需编译、下载即可运行**
   - 新增快速开始示例（下载 → chmod → 运行）
   - 将原有的 `cargo build --release` 编译方式移至「从源码编译」次级选项
   - 在桌面客户端部分补充 GitHub Releases 下载提示（.dmg / .msi）

### 目的

让没有 Rust 环境的用户也能快速上手 OpenAaaS，降低首次体验门槛。