### PR TITLE
feat(server): 清理任务时保留数据库记录，仅删除本地磁盘文件

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-01
+
+### Changed
+- 后台清理任务仅删除本地磁盘文件，保留 tasks 和 task_files 数据库记录（此前会同时删除数据库记录）
+- 更新相关配置注释和文档注释，明确保留策略
+
 ## [0.7.1] - 2026-05-29
 
 ### Added
@@ -82,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.8.0]: https://github.com/Wolido/OpenAaaS/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Wolido/OpenAaaS/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Wolido/OpenAaaS/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Wolido/OpenAaaS/compare/v0.6.0...v0.6.1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 
 [dependencies]

--- a/server/src/bg_tasks.rs
+++ b/server/src/bg_tasks.rs
@@ -173,7 +173,7 @@ async fn migrate_tasks_from_offline_services(
     Ok(migrated_count + cancelled_count)
 }
 
-/// 清理过期任务
+/// 清理过期任务的本地磁盘文件（数据库记录保留）
 /// 删除 completed/failed/cancelled 状态且超过保留期限的任务
 async fn cleanup_expired_tasks(state: &AppState, retention_days: i64) {
     if retention_days <= 0 {
@@ -183,8 +183,8 @@ async fn cleanup_expired_tasks(state: &AppState, retention_days: i64) {
 
     let cutoff_date = chrono::Utc::now() - chrono::Duration::days(retention_days);
 
-    // 先获取要删除的任务ID列表（用于后续清理文件）
-    let tasks_to_delete: Vec<String> = sqlx::query_scalar(
+    // 获取已过期任务ID列表（用于清理本地磁盘文件，数据库记录保留）
+    let expired_tasks: Vec<String> = sqlx::query_scalar(
         r#"
         SELECT id FROM tasks 
         WHERE status IN ('completed', 'failed', 'cancelled') 
@@ -196,47 +196,30 @@ async fn cleanup_expired_tasks(state: &AppState, retention_days: i64) {
     .await
     .unwrap_or_default();
 
-    // 清理这些任务的文件
-    for task_id in &tasks_to_delete {
+    // 清理这些任务的本地磁盘文件（数据库记录保留）
+    for task_id in &expired_tasks {
         if let Err(e) = cleanup_task_files(state, task_id).await {
             tracing::error!("Failed to cleanup files for task {}: {}", task_id, e);
         }
     }
 
-    match sqlx::query(
-        r#"
-        DELETE FROM tasks 
-        WHERE status IN ('completed', 'failed', 'cancelled') 
-        AND completed_at < ?
-        "#,
-    )
-    .bind(cutoff_date.to_rfc3339())
-    .execute(state.db.pool())
-    .await
-    {
-        Ok(result) => {
-            let deleted = result.rows_affected();
-            if deleted > 0 {
-                tracing::info!(
-                    "Cleaned up {} expired task(s) older than {} days",
-                    deleted,
-                    retention_days
-                );
-            } else {
-                tracing::debug!(
-                    "No expired tasks to cleanup (retention: {} days)",
-                    retention_days
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to cleanup expired tasks: {}", e);
-        }
+    let cleaned_count = expired_tasks.len();
+    if cleaned_count > 0 {
+        tracing::info!(
+            "Attempted cleanup for {} expired task(s) older than {} days (database records retained)",
+            cleaned_count,
+            retention_days
+        );
+    } else {
+        tracing::debug!(
+            "No expired tasks to cleanup (retention: {} days)",
+            retention_days
+        );
     }
 }
 
-/// 清理任务的文件
-/// 删除数据库记录和对应的磁盘文件
+/// 清理任务的本地磁盘文件
+/// 仅删除磁盘文件和空目录，不删除数据库记录
 async fn cleanup_task_files(state: &AppState, task_id: &str) -> anyhow::Result<()> {
     use open_aaas_server::models::file::TaskFile;
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -63,7 +63,7 @@ impl Default for AgentConfig {
 /// 任务配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskConfig {
-    /// 任务结果保留时间(天)
+    /// 任务文件保留时间(天)，仅删除本地磁盘文件，数据库记录永久保留
     #[serde(default = "default_result_retention_days")]
     pub result_retention_days: i64,
     /// 文件存储路径
@@ -212,7 +212,7 @@ impl AppConfig {
         ));
         lines.push("".to_string());
         lines.push("[task]".to_string());
-        lines.push("# 任务结果保留时间(天)".to_string());
+        lines.push("# 任务文件保留时间(天)，仅删除本地磁盘文件，数据库记录永久保留".to_string());
         lines.push(format!(
             "result_retention_days = {}",
             self.task.result_retention_days


### PR DESCRIPTION
## 变更内容

后台清理任务的行为从同时删除本地磁盘文件和数据库记录调整为仅删除本地磁盘文件，保留数据库记录。

## 具体改动

- server/src/bg_tasks.rs：清理逻辑改为仅删除磁盘文件，不再删除 tasks / task_files 表记录
- server/src/config.rs：更新配置注释和文档注释，明确保留策略
- server/Cargo.toml：版本号从 0.7.1 升级至 0.8.0
- server/CHANGELOG.md：按 Keep a Changelog 格式更新 0.8.0 版本记录
