### PR TITLE
test(server): add bg_tasks cleanup tests

### DIFF
--- a/server/src/bg_tasks.rs
+++ b/server/src/bg_tasks.rs
@@ -1,8 +1,11 @@
+use open_aaas_server::state::AppState;
 use std::time::Duration;
 use tokio::sync::watch;
-use open_aaas_server::state::AppState;
 
-pub fn spawn_heartbeat_task(state: AppState, shutdown_tx: watch::Sender<()>) -> tokio::task::JoinHandle<()> {
+pub fn spawn_heartbeat_task(
+    state: AppState,
+    shutdown_tx: watch::Sender<()>,
+) -> tokio::task::JoinHandle<()> {
     let mut shutdown_rx = shutdown_tx.subscribe();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(10));
@@ -53,7 +56,11 @@ pub fn spawn_heartbeat_task(state: AppState, shutdown_tx: watch::Sender<()>) -> 
     })
 }
 
-pub fn spawn_cleanup_task(state: AppState, shutdown_tx: watch::Sender<bool>, retention_days: i64) -> tokio::task::JoinHandle<()> {
+pub fn spawn_cleanup_task(
+    state: AppState,
+    shutdown_tx: watch::Sender<bool>,
+    retention_days: i64,
+) -> tokio::task::JoinHandle<()> {
     let mut shutdown_rx = shutdown_tx.subscribe();
     tokio::spawn(async move {
         // 每天执行一次清理
@@ -281,4 +288,373 @@ async fn cleanup_task_files(state: &AppState, task_id: &str) -> anyhow::Result<(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use open_aaas_server::{
+        config::AppConfig,
+        models::file::{FileCreatedBy, TaskFile},
+        state::AppState,
+    };
+    use uuid::Uuid;
+
+    async fn setup_test_state() -> (AppState, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = AppConfig::default();
+        config.database.url = "sqlite::memory:".to_string();
+        config.task.file_storage_path = temp_dir.path().to_str().unwrap().to_string();
+        let state = AppState::new(config).await.unwrap();
+        state.db.init_tables().await.unwrap();
+        (state, temp_dir)
+    }
+
+    async fn create_test_user_and_service(state: &AppState) -> (String, String) {
+        let user_id = format!("user-{}", Uuid::new_v4());
+        let service_id = format!("service-{}", Uuid::new_v4());
+
+        sqlx::query("INSERT INTO users (id, api_key, name, role) VALUES (?, ?, ?, ?)")
+            .bind(&user_id)
+            .bind("ak_test")
+            .bind("Test User")
+            .bind("client")
+            .execute(state.db.pool())
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO services (id, name, description, usage, agent_api_key, registration_status, agent_status, agent_capacity, agent_current_load, is_public, created_at) VALUES (?, ?, ?, ?, ?, 'active', 'online', 1, 0, 1, ?)"
+        )
+        .bind(&service_id)
+        .bind("Test Service")
+        .bind("Description")
+        .bind("Usage")
+        .bind("ak_agent")
+        .bind(Utc::now())
+        .execute(state.db.pool())
+        .await
+        .unwrap();
+
+        (user_id, service_id)
+    }
+
+    async fn create_test_task(
+        state: &AppState,
+        user_id: &str,
+        service_id: &str,
+        status: &str,
+        completed_at: Option<chrono::DateTime<Utc>>,
+    ) -> String {
+        let task_id = format!("task-{}", Uuid::new_v4());
+        let session_id = format!("session-{}", Uuid::new_v4());
+        let input = serde_json::json!({"test": "input"});
+        let created_at = Utc::now() - chrono::Duration::days(10);
+
+        sqlx::query(
+            r#"
+            INSERT INTO tasks (id, user_id, service_id, status, input, session_id, retry_count, created_at, completed_at)
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+            "#
+        )
+        .bind(&task_id)
+        .bind(user_id)
+        .bind(service_id)
+        .bind(status)
+        .bind(&input)
+        .bind(&session_id)
+        .bind(created_at)
+        .bind(completed_at.map(|d| d.to_rfc3339()))
+        .execute(state.db.pool())
+        .await
+        .unwrap();
+
+        task_id
+    }
+
+    async fn create_test_file(state: &AppState, task_id: &str) -> std::path::PathBuf {
+        let file_id = Uuid::new_v4().to_string();
+        let storage_path = format!("{}/{}", task_id, file_id);
+        let full_path = std::path::PathBuf::from(state.file_storage_path()).join(&storage_path);
+
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await.unwrap();
+        }
+        tokio::fs::write(&full_path, b"test content").await.unwrap();
+
+        let file = TaskFile::new(
+            task_id,
+            "test.txt",
+            Some("text/plain".to_string()),
+            12,
+            &storage_path,
+            FileCreatedBy::Client,
+        );
+
+        sqlx::query(
+            r#"
+            INSERT INTO task_files (id, task_id, filename, mime_type, size_bytes, storage_path, created_by, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            "#
+        )
+        .bind(&file.id)
+        .bind(&file.task_id)
+        .bind(&file.filename)
+        .bind(&file.mime_type)
+        .bind(file.size_bytes)
+        .bind(&file.storage_path)
+        .bind("client")
+        .bind(file.created_at)
+        .execute(state.db.pool())
+        .await
+        .unwrap();
+
+        full_path
+    }
+
+    /// 测试1：retention_days = 0 时跳过清理
+    #[tokio::test]
+    async fn test_cleanup_skipped_when_retention_disabled() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+        let completed_at = Some(Utc::now() - chrono::Duration::days(10));
+        let task_id =
+            create_test_task(&state, &user_id, &service_id, "completed", completed_at).await;
+        let file_path = create_test_file(&state, &task_id).await;
+
+        cleanup_expired_tasks(&state, 0).await;
+
+        assert!(
+            file_path.exists(),
+            "File should still exist when retention_days = 0"
+        );
+    }
+
+    /// 测试2：核心测试——仅删除文件，保留数据库记录
+    #[tokio::test]
+    async fn test_cleanup_deletes_only_files_retains_records() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+        let completed_at = Some(Utc::now() - chrono::Duration::days(10));
+        let task_id =
+            create_test_task(&state, &user_id, &service_id, "completed", completed_at).await;
+        let file_path = create_test_file(&state, &task_id).await;
+
+        cleanup_expired_tasks(&state, 7).await;
+
+        assert!(
+            !file_path.exists(),
+            "Expired task file should be deleted from disk"
+        );
+
+        let task_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks WHERE id = ?")
+            .bind(&task_id)
+            .fetch_one(state.db.pool())
+            .await
+            .unwrap();
+        assert_eq!(task_count, 1, "Task database record should be retained");
+
+        let file_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM task_files WHERE task_id = ?")
+                .bind(&task_id)
+                .fetch_one(state.db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            file_count, 1,
+            "Task file database record should be retained"
+        );
+    }
+
+    /// 测试3：状态过滤——pending 和 running 任务不被清理
+    #[tokio::test]
+    async fn test_cleanup_respects_status_filter() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+
+        let pending_task_id =
+            create_test_task(&state, &user_id, &service_id, "pending", None).await;
+        let pending_file_path = create_test_file(&state, &pending_task_id).await;
+
+        let running_task_id =
+            create_test_task(&state, &user_id, &service_id, "running", None).await;
+        let running_file_path = create_test_file(&state, &running_task_id).await;
+
+        cleanup_expired_tasks(&state, 7).await;
+
+        assert!(
+            pending_file_path.exists(),
+            "Pending task file should not be deleted"
+        );
+        assert!(
+            running_file_path.exists(),
+            "Running task file should not be deleted"
+        );
+    }
+
+    /// 测试4：时间过滤——未过期的任务不被清理
+    #[tokio::test]
+    async fn test_cleanup_respects_time_filter() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+        let completed_at = Some(Utc::now() - chrono::Duration::days(3));
+        let task_id =
+            create_test_task(&state, &user_id, &service_id, "completed", completed_at).await;
+        let file_path = create_test_file(&state, &task_id).await;
+
+        cleanup_expired_tasks(&state, 7).await;
+
+        assert!(
+            file_path.exists(),
+            "File should still exist for task within retention period"
+        );
+    }
+
+    /// 测试5：幂等性——重复调用 cleanup_task_files 不应报错
+    #[tokio::test]
+    async fn test_cleanup_task_files_idempotent() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+        let completed_at = Some(Utc::now() - chrono::Duration::days(10));
+        let task_id =
+            create_test_task(&state, &user_id, &service_id, "completed", completed_at).await;
+        let file_path = create_test_file(&state, &task_id).await;
+
+        let result1 = cleanup_task_files(&state, &task_id).await;
+        assert!(result1.is_ok(), "First cleanup should succeed");
+
+        let result2 = cleanup_task_files(&state, &task_id).await;
+        assert!(
+            result2.is_ok(),
+            "Second cleanup should succeed (idempotent)"
+        );
+
+        assert!(
+            !file_path.exists(),
+            "File should still not exist after second cleanup"
+        );
+
+        let file_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM task_files WHERE task_id = ?")
+                .bind(&task_id)
+                .fetch_one(state.db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            file_count, 1,
+            "Task file database record should be retained"
+        );
+    }
+
+    /// 测试6：验证 cleanup_expired_tasks 不会漏掉任何一个过期任务
+    #[tokio::test]
+    async fn test_cleanup_batch_no_leak() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+
+        let task1_id = create_test_task(
+            &state,
+            &user_id,
+            &service_id,
+            "completed",
+            Some(Utc::now() - chrono::Duration::days(10)),
+        )
+        .await;
+        let file1_path = create_test_file(&state, &task1_id).await;
+
+        let task2_id = create_test_task(
+            &state,
+            &user_id,
+            &service_id,
+            "completed",
+            Some(Utc::now() - chrono::Duration::days(10)),
+        )
+        .await;
+        let file2_path = create_test_file(&state, &task2_id).await;
+
+        cleanup_expired_tasks(&state, 7).await;
+
+        assert!(
+            !file1_path.exists(),
+            "First expired task file should be deleted"
+        );
+        assert!(
+            !file2_path.exists(),
+            "Second expired task file should be deleted"
+        );
+
+        let task_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks WHERE id IN (?, ?)")
+            .bind(&task1_id)
+            .bind(&task2_id)
+            .fetch_one(state.db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            task_count, 2,
+            "Both task database records should be retained"
+        );
+
+        let file_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM task_files WHERE task_id IN (?, ?)")
+                .bind(&task1_id)
+                .bind(&task2_id)
+                .fetch_one(state.db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            file_count, 2,
+            "Both task file database records should be retained"
+        );
+    }
+
+    /// 测试7：failed 和 cancelled 状态的过期任务文件也应被清理
+    #[tokio::test]
+    async fn test_cleanup_deletes_failed_and_cancelled_files() {
+        let (state, _temp_dir) = setup_test_state().await;
+        let (user_id, service_id) = create_test_user_and_service(&state).await;
+        let completed_at = Some(Utc::now() - chrono::Duration::days(10));
+
+        let failed_task_id =
+            create_test_task(&state, &user_id, &service_id, "failed", completed_at).await;
+        let failed_file_path = create_test_file(&state, &failed_task_id).await;
+
+        let cancelled_task_id =
+            create_test_task(&state, &user_id, &service_id, "cancelled", completed_at).await;
+        let cancelled_file_path = create_test_file(&state, &cancelled_task_id).await;
+
+        cleanup_expired_tasks(&state, 7).await;
+
+        assert!(
+            !failed_file_path.exists(),
+            "Failed task file should be deleted"
+        );
+        assert!(
+            !cancelled_file_path.exists(),
+            "Cancelled task file should be deleted"
+        );
+
+        let task_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks WHERE id IN (?, ?)")
+            .bind(&failed_task_id)
+            .bind(&cancelled_task_id)
+            .fetch_one(state.db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            task_count, 2,
+            "Both task database records should be retained"
+        );
+
+        let file_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM task_files WHERE task_id IN (?, ?)")
+                .bind(&failed_task_id)
+                .bind(&cancelled_task_id)
+                .fetch_one(state.db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            file_count, 2,
+            "Both task file database records should be retained"
+        );
+    }
 }


### PR DESCRIPTION
补充 6 个自动化测试，覆盖 bg_tasks 清理逻辑的边界情况：

- 当 retention_days = 0 时跳过清理
- 核心行为：仅删除磁盘文件，保留 tasks 和 task_files 数据库记录
- pending / running 状态的任务文件不被清理
- 未过期的 completed 任务文件不被清理
- cleanup_task_files 重复调用具有幂等性
- 多个过期任务同时被处理，无遗漏

确保清理策略从"同时删文件和数据库记录"改为"仅删文件、保留记录"后不会回退。