### PR TITLE
docs: restructure README and add Binder quickstart notebook

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -106,7 +106,9 @@ Public server: **<https://api.open-aaas.com>**
 
 ### Jupyter Notebook (Binder)
 
-Click the Binder badge above to run `examples/quickstart.ipynb` in your browser — no installation required.
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb)
+
+Click the Binder badge above to run `examples/quickstart.ipynb` directly in your browser, no installation required.
 
 ### Desktop Client
 

--- a/README.en.md
+++ b/README.en.md
@@ -9,12 +9,12 @@
 <p align="center">
   <a href="https://www.open-aaas.com">Website</a> ·
   <a href="https://arxiv.org/abs/2605.13618">Paper</a> ·
-  <a href="./server/README.en.md">Server Docs</a> ·
-  <a href="./agent-core/README.en.md">Agent Core Docs</a> ·
-  <a href="#Usage">Usage Guide</a> ·
-  <a href="./client-extension/README.en.md">Client Extensions</a> ·
+  <a href="./server/README.md">Server Docs</a> ·
+  <a href="./agent-core/README.md">Agent Core Docs</a> ·
+  <a href="#how-to-use">Usage Guide</a> ·
+  <a href="./client-extension/README.md">Client Extensions</a> ·
   <a href="./pyopenaaas/README.md">Python SDK</a> ·
-  <a href="./client-app/README.en.md">Desktop Client</a>
+  <a href="./client-app/README.md">Desktop Client</a>
 </p>
 
 <p align="center">
@@ -37,82 +37,186 @@
 
 <p align="center">
   📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/57"><b>Design Blog: Don't Move Data, Distill an Administrator.skill</b></a><br>
-  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/79"><b>User Story: Beyond the Lab — I Built My Wife a Copy Editor with OpenAaaS</b></a>
+  📝 <a href="https://github.com/Wolido/OpenAaaS/discussions/79"><b>User Story: Not Just for the Lab — I Built My Wife a Copy Editor with OpenAaaS</b></a>
 </p>
 
 ---
 
-**Intelligence flows, data stays still — bring Agents to the data, instead of handing data over to Agents.**
+## 🚀 Quick Start
 
-**OpenAaaS is an Agent Orchestration Network built for AI for Science: data stays where it was created, and Agent capabilities flow through the network to reach it.**
+| Method | Entry |
+|---|---|
+| **Try it now** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) — Run `examples/quickstart.ipynb` directly in your browser |
+| **Download App** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows / Linux desktop client |
 
-In the practice of AI for Science, the bottleneck has shifted from "can the model do it" to "can scientific capabilities be easily accessed." "Data being forced to migrate" is a harder constraint than models: every lab has accumulated unique data, algorithms, and workflows, but they are scattered in silos and cannot be discovered or invoked by any Agent. OpenAaaS builds an Agent Orchestration Network for AI for Science, enabling any Agent to discover, delegate to, and compose other Agents on scientific nodes around the world — data is processed in place, while Agent capabilities flow through the network.
+---
 
-Any Agent — whether Claude Code, pi mono, Kimi Cli, or a self-built system — can discover and compose other Agents on scientific nodes across the network.
+## What is OpenAaaS?
 
-At the same time, we strive to minimize the barrier to using the network, even for general-purpose LLM apps on mobile phones.
+> **Intelligence flows, data stays still — bring Agents to the data, instead of handing data over to Agents.**
+
+OpenAaaS is an Agent Orchestration Network for AI for Science: data stays where it was created, and Agent capabilities flow through the network to reach it.
 
 | Demo Video | Screenshots |
 |:---:|:---:|
 | <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **Connect to Network**<br><img width="372" height="113" alt="Screenshot 2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**View Node List**<br><img width="379" height="406" alt="Screenshot 2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**Task Result Returned**<br><img width="371" height="391" alt="Screenshot 2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
----
-
-### 📄 Paper
-
-Technical design and implementation details: [arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
+**Paper**: Technical design and implementation details in [arXiv:2605.13618](https://arxiv.org/abs/2605.13618).
 
 ---
 
-## Infrastructure for AI for Science
+## Why OpenAaaS?
 
-OpenAaaS does not train new models, nor does it build a unified data warehouse. It does one thing: **make scientific capabilities flow like water** — turning the unique data, algorithms, and workflows accumulated in every lab into discoverable, delegable, and composable services on the network, while raw data always stays where it is.
+### 1. Agent Orchestration, Nodes as Agents
 
----
+The network schedules not scripts, but full Agent instances with complete toolchains. Inside the Docker container on each node runs a complete Agent capable of autonomous decision-making, execution, and sub-Agent invocation. Any Agent (Claude Code, pi mono, Kimi, etc.) can discover, delegate to, and compose other Agents across global nodes as easily as calling a tool.
 
-## What is an Agent Orchestration Network
+### 2. Data Stays Put, Zero Migration
 
-A single Agent can only do so much. Complex research problems often require multiple capabilities working together — literature search, data parsing, simulation, visualization — scattered across different labs and servers.
+Raw data always stays where it was created, while remote Agents work directly beside it. The network only transmits task descriptions and results (KB–MB scale), never touching raw data (TB scale).
 
-An Agent Orchestration Network solves this by letting one Agent discover, schedule, and compose the capabilities of other Agents, breaking down complex tasks and distributing them. It's not simply "remotely executing a script"; it's **multi-Agent collaborative orchestration**.
-
-Existing solutions like Google's [A2A](https://a2a-protocol.org) already enable Agent-to-Agent interoperability, but assume good network conditions — every Agent needs an exposed address and long-lived connections. In research environments, firewalls kill long connections, NAT silently drops packets, and IT won't open ports.
-
-OpenAaaS is built for restrictive networks: nodes check in every few seconds, reaching out like a browser with only outbound requests, no public IP needed. Each subordinate Agent runs beside the data with a complete toolchain, making autonomous decisions and executing independently. The master Agent discovers, delegates, and integrates results.
-
-So OpenAaaS isn't a script-calling tool, and it isn't a general-purpose internet protocol. **It's an Agent Orchestration Network that actually works in real lab networks.**
-
----
-
-## Four Core Propositions
-
-### Agent Orchestration: Nodes are Agents
-
-The network schedules not scripts or services, but full Agent instances with complete toolchains. Inside the Docker container on each node runs a complete Agent capable of autonomous decision-making, execution, and sub-Agent invocation. Any Agent can discover, delegate to, and compose other Agents across global nodes as easily as calling a tool.
-
-### Zero Data Migration
-
-Traditional solutions demand that data be aggregated into a centralized platform — inevitably introducing format conversion distortion, metadata loss, version divergence, and broken compliance audit chains. OpenAaaS builds no unified data warehouse. Data remains at its point of origin, preserved in its original storage format, directory structure, and access permissions. The remote Agent works autonomously next to the data; results are sent back. Raw data never leaves.
-
-### Schema-Free Onboarding, Native Agent Capability as a Service
-
-We impose no upfront format requirements on data. JSON, CSV, Excel, MATLAB `.mat`, HDF5, vendor-specific binary formats from instruments — the local parsing and processing scripts on each node are themselves part of the network's capability. Agents invoke a combined "parse + analyze" service, rather than being required to pre-clean, standardize, or structure the data. Whatever format a lab already has, it is service-ready from day one.
-
-### Near-Data Computing
-
-Computation happens next to the data, not the other way around. Remote Agents make autonomous decisions and execute tasks beside the data. The network only transmits task descriptions and execution results (KB–MB scale); raw data is processed on-site. For TB-scale datasets and regulated sensitive samples, this means no upload wait, no bandwidth bottleneck, and no outbound compliance review — the marginal cost of moving data approaches zero.
-
-## Core Design Philosophy
-
-Traditional cloud solutions require data to leave the premises: TB-scale datasets must be migrated and uploaded, sensitive samples are handed to third parties, and lab firewalls are forced to open inbound ports. OpenAaaS takes the opposite approach — deploying Agent execution nodes directly where the data resides. The network only transmits task descriptions, task files, and results; raw data stays in place.
-
-| | Traditional Cloud Solution | OpenAaaS Near-Data Solution |
+| | Traditional Cloud | OpenAaaS |
 |---|---|---|
 | Data Flow | Local → Cloud → Local | **Raw data stays in place** |
-| Network Transfer | Raw data (TB scale) | Task descriptions, task files, and results (KB–MB scale) |
+| Network Transfer | Raw data (TB scale) | Task descriptions and results (KB–MB scale) |
 | Firewall Requirements | Inbound ports required | **Outbound HTTP only** |
 | Sensitive Data | Must leave the domain | **Never leaves the lab** |
-| Latency | Bandwidth-limited | Local compute, extremely low latency |
+
+### 3. Zero-Normalization Plug-and-Play
+
+No unified data format required — JSON, CSV, Excel, MATLAB, HDF5, vendor-specific binary formats are all handled in place. Zero-config node onboarding: `open-aaas-server run` auto-generates `config.toml` and SQLite on first launch. Self-describing API + progressive capability discovery — Agents understand and invoke all services without plugins.
+
+### 4. Near-Data Computing, Low-Barrier Deployment
+
+Single Rust binary + embedded SQLite, zero-dependency deployment, copy and run. Docker-isolated execution, each task in its own sandbox. Nodes join the network with unidirectional outbound access only — no public IP, no open ports, no SSH — designed specifically for lab firewalls and NAT environments.
+
+---
+
+## How to use?
+
+Public server: **<https://api.open-aaas.com>**
+
+| Method | For | Entry |
+|---|---|---|
+| Jupyter Notebook (Binder) | Try without installing | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) |
+| Desktop Client | Non-technical users | [Download](https://github.com/Wolido/OpenAaaS/releases) |
+| Python SDK | Python / Jupyter users | `pip install pyopenaaas` |
+| MCP Adapter | Claude / Cursor / Cline users | `uvx openaaas-mcp-adapter` |
+| pi / kimi Plugin | Conversational Agent users | Invoke directly in chat |
+
+### Jupyter Notebook (Binder)
+
+Click the Binder badge above to run `examples/quickstart.ipynb` in your browser — no installation required.
+
+### Desktop Client
+
+A cross-platform desktop app built with Tauri, supporting macOS, Windows, and Linux. Ideal for non-technical users to manage multiple servers, drag-and-drop upload files, and track task progress in real time.
+
+> macOS and Windows users can download `.dmg` or `.msi` installers directly from [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases). On first launch, macOS users may need to go to **System Settings → Privacy & Security → Security** and click **"Open Anyway"**.
+
+<p align="center">
+  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
+</p>
+
+See [client-app/README.md](./client-app/README.md).
+
+### Python SDK
+
+```bash
+pip install pyopenaaas
+```
+
+```python
+import pyopenaaas
+
+client = pyopenaaas.Client()
+client.register(name="your-name")
+
+services = client.list_services()
+task = client.submit_task(
+    service_id=services[0].id,
+    task_prompt="Your task description",
+)
+task = client.wait_for_task(task.id)
+paths = client.download_all_files(task.id)
+```
+
+See [pyopenaaas/README.md](./pyopenaaas/README.md).
+
+### MCP Adapter
+
+`openaaas-mcp-adapter` is published on PyPI. MCP-compatible clients (Claude Desktop, Cursor, Cline, etc.) can connect with a single configuration entry:
+
+```json
+{
+  "mcpServers": {
+    "openaaas": {
+      "command": "uvx",
+      "args": ["openaaas-mcp-adapter"]
+    }
+  }
+}
+```
+
+After configuring, restart the client to invoke all capabilities in conversation.
+
+<p align="center">
+  <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
+</p>
+
+See [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md).
+
+### pi / kimi Plugin
+
+Just say in the conversation:
+
+> "Set my OpenAaaS server to <https://api.open-aaas.com> and submit a data analysis task"
+
+The client Agent automatically completes registration, service discovery, task submission, and result retrieval.
+
+<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
+
+### Generic Agent Framework
+
+If your Agent has no OpenAaaS plugin, simply have it access <https://api.open-aaas.com>. No authentication required; complete API documentation and usage instructions are returned. The Agent can then automatically complete registration, service discovery, and task submission after reading them.
+
+---
+
+## Deploy your own node
+
+### Precompiled Binaries (Recommended)
+
+No Rust installation needed — download and run: [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
+
+| Component | Binary Name |
+|---|---|
+| Server | `open-aaas-server` |
+| Agent Core | `agent-core` |
+
+Supported platforms:
+- **Server / Agent Core**: Linux x64 (musl static linking), Linux arm64 (musl static linking), macOS arm64, Windows x64
+- **Desktop Client**: macOS, Windows
+
+> Linux builds use musl static linking and do not depend on system glibc, so they run on any Linux distribution out of the box.
+
+```bash
+chmod +x open-aaas-server   # Unix users
+./open-aaas-server run
+```
+
+`config.toml` and the SQLite database are auto-generated on first launch.
+
+### Build from Source
+
+```bash
+cd server
+cargo build --release
+./target/release/open-aaas-server run
+```
+
+For Agent Core deployment, see [agent-core/README.md](./agent-core/README.md).
+
+---
 
 ## Architecture
 
@@ -150,231 +254,36 @@ Rust + Docker — Deployed locally where data resides
 | Network Hub | Server — Capability registration and scheduling center (Rust + SQLite) | Service registration, task routing, node heartbeat, file relay |
 | Network Node | agent-core — Capability execution node + Docker, runs a **full Agent instance** in container | Register capabilities to the network, poll for tasks, launch full Agent in sandbox isolation, report results |
 
-## Design Rationale
-
-| Principle | Description | Effect |
-|------|------|------|
-| Rust + Single Binary | `cargo build --release` produces one executable | Zero-dependency deployment, copy and run |
-| Embedded SQLite | Database starts with the process, no separate service | Zero operations, single node is sufficient |
-| Docker Isolation | Each task runs in an independent container with workspace mounted | Secure and controllable, reproducible environment |
-| Full Agent Instance | Containers run full Agent instances (not scripts) with autonomous toolchains such as read/write/bash/grep/subagent | Remote Agents make autonomous decisions and execute complex tasks; the client only needs to describe the goal |
-| Self-Organizing Nodes | Nodes actively register with the network and poll for tasks; Server only maintains an index. Raw data never leaves the domain; task files flow through the Server | Nodes need no public IP; unidirectional outbound is enough to join the network; data is processed on-site, naturally adapting to lab firewall environments |
-
-## Features
-
-### Data In-Situ Retention & Cross-Node Capability Flow
-
-- **🤖 Agent Calls Agent, Not Script** — Remote nodes run full Agents with complete toolchains, capable of autonomous decision-making and executing complex tasks, rather than passively running preset scripts.
-- **🔗 Composable Agent Capabilities** — Any Agent can discover, delegate to, and compose other Agents across global nodes as easily as calling a tool, enabling multi-Agent collaboration.
-- **🔌 Zero-Learning-Cost Agent Integration, Self-Describing API Auto-Exposes Service Docs** — No authentication required; returns complete API documentation and usage instructions. Agents can understand and invoke other Agents on scientific nodes without any plugins.
-- **🧩 Progressive Capability Discovery, Avoiding Context Overflow** — Initial queries return lightweight summaries; detailed usage is returned on demand. A progressive disclosure design similar to SKILL.md protects the Agent's context window.
-
-### Zero Data Migration
-
-- **🔒 Data Never Leaves the Premises** — Agent execution nodes are deployed directly on lab servers or instrument workstations. Raw large datasets are processed in-place via local mounts; sensitive data never crosses the firewall. The network only transmits task descriptions, task files, and results; it never touches raw data.
-- **💾 Single Binary, Zero Operations** — SQLite database + local file storage; no Redis/MySQL required. A single node is enough for deployment, ideal for lab edge nodes.
-- **⚖️ Nodes Join via Reverse Connection, No Public IP Needed** — Nodes self-manage concurrency and task claiming; Server only does lightweight queue management. Lab nodes only need unidirectional outbound access to join; no open ports or SSH required.
-
-### Schema-Free Onboarding & Near-Data Computing
-
-- **🐳 Independent Sandbox per Experiment, Reproducible Results** — Each task runs in an isolated container with workspace mounts for input and output. Environment isolation makes results traceable and reproducible.
-- **🔧 Zero-Config Node Onboarding** — `open-aaas-server run` auto-generates `config.toml`, SQLite database, and keys on first launch. No manual configuration; ready to use out of the box.
-- **🔗 MCP Standard Protocol Compatible** — Through `openaaas-mcp-adapter`, any MCP-compatible client such as Claude Desktop, Cursor, or Cline can connect with one click, without writing any plugins.
-
-## Usage
-
-Public Server: **<https://api.open-aaas.com>**
-
-We provide three trial scientific services on the public server:
-
-- IDM-Alpha Materials Science Literature Research Assistant based on hundreds of thousands of real papers (supports literature Q&A and in-depth reading report generation)
-- Trillion-Scale Hexa-High-Entropy Alloy Descriptor Database
-- Fuyao Multi-Agent Roundtable System
-
-You can have your Agent connect to the public server to use them.
-
-### Quick Start
-
-**Scenario 1: Use the Public Server**
-
-No need to build your own infrastructure. Simply configure your Agent to connect to the public server and start invoking community-shared scientific Agents. Ideal for individual researchers to get started quickly.
-
-### Using the pi / Kimi Plugin
-
-Just say in the conversation:
-
-> "Help me set the OpenAaaS server address to <https://api.open-aaas.com>, then submit a data analysis task"
-
-The client Agent will automatically complete registration, service discovery, task submission, and result retrieval.
-
-<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
-
-### Using an MCP Client
-
-`openaaas-mcp-adapter` is available on PyPI. If you are using **OpenClaw** or any other Agent that supports MCP (Model Context Protocol), connecting to the OpenAaaS network is nearly zero-cost — no plugins to write, just one configuration entry to invoke all capabilities.
-
-```json
-{
-  "mcpServers": {
-    "openaaas": {
-      "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
-    }
-  }
-}
-```
-
-After configuring, restart the client, and you can invoke OpenAaaS's 14 standard Tools (`set_server_url`, `register`, `list_services`, `submit_task`, etc.) directly in conversation without installing any plugins.
-
-Or better yet, you can have your Agent set it up for you directly.
-
-<p align="center">
-  <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
-</p>
-
-See [client-extension/openaaas-mcp-adapter/README.en.md](./client-extension/openaaas-mcp-adapter/README.en.md) for details.
-
-### Using the Python SDK
-
-If you prefer interacting with OpenAaaS directly from Python code, use **`pyopenaaas`** — a Pythonic SDK for researchers.
-
-```bash
-pip install pyopenaaas
-```
-
-```python
-import pyopenaaas
-
-client = pyopenaaas.Client()
-client.register(name="your-name")
-
-services = client.list_services()
-task = client.submit_task(
-    service_id=services[0].id,
-    task_prompt="Your task description",
-)
-task = client.wait_for_task(task.id)
-paths = client.download_all_files(task.id)
-```
-
-📖 See [pyopenaaas/README.md](./pyopenaaas/README.md) for details.
-
-### Using the Desktop Client
-
-If you prefer a graphical interface, use the **OpenAaaS Desktop Client** — a cross-platform desktop application based on Tauri, supporting macOS, Windows, and Linux.
-
-The desktop client is ideal for:
-- Non-technical users who don't want to configure command-line tools or plugins
-- Managing multiple servers and browsing services visually
-- Drag-and-drop file uploads and real-time task progress tracking
-
-📖 See [client-app/README.en.md](./client-app/README.en.md) for details.
-
-> macOS and Windows users can download `.dmg` or `.msi` installers directly from [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases).
-
-<p align="center">
-  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
-</p>
-
-> macOS users: The app is ad-hoc signed. On first launch, go to **System Settings → Privacy & Security → Security** and click **"Open Anyway"**.
-
-### Using a General Agent Framework
-
-If your Agent does not have an OpenAaaS plugin, simply have it access <https://api.open-aaas.com>:
-
-- No authentication required; complete API documentation and usage instructions are returned
-- The Agent can then automatically complete registration, service discovery, and task submission after reading them
-
-**Scenario 2: Deploy on a Lab Server and Connect Local Capabilities**
-
-Launch OpenAaaS on a local server in your machine room or lab, and register local analysis capabilities as network nodes. Any Agent in the research group — pi, Kimi, Claude, or a self-built system — can query node status, submit analysis tasks, and retrieve result data through a unified entry point.
-
-### Local Deployment
-
-#### Prebuilt Binaries (Recommended)
-
-Precompiled binaries are available for all components. **No Rust installation, no compilation — just download and run.**
-
-- **Download**: [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
-
-| Component | Binary Name | Use Case |
-|-----------|-------------|----------|
-| Server | `open-aaas-server` | Network scheduling hub |
-| Agent Core | `agent-core` | Execution node |
-
-Supported platforms:
-- **Server / Agent Core**: Linux x64 (musl static linking), Linux arm64 (musl static linking), macOS arm64, Windows x64
-- **Desktop Client (client-app)**: macOS, Windows
-
-> 💡 Linux builds use musl static linking and do not depend on system glibc, so they run on any Linux distribution out of the box.
-
-**Quick start (Server example)**:
-
-```bash
-# Download and extract the archive for your platform
-chmod +x open-aaas-server   # Unix users; Windows users run .exe directly
-./open-aaas-server run
-```
-
-`config.toml` and the SQLite database are auto-generated on first launch.
-
-#### Build from Source
-
-If you need to customize the code, build from source.
-
-**Deploy Server (Scheduling Center)**:
-
-```bash
-cd server
-cargo build --release
-./target/release/open-aaas-server run
-```
-
-On first launch, `config.toml` and the SQLite database are auto-generated.
-
-**Deploy Agent Core (Execution Node)**:
-
-```bash
-cd agent-core
-cargo build --release
-./target/release/agent-core init
-./target/release/agent-core register --token <registration_token> --name my-agent
-./target/release/agent-core run
-```
-
-The `registration_token` must be obtained by creating a Service on the Server first. Admins can use the API Key from the Server logs to call `POST /api/v1/services/` to create one.
-
-The Agent executor image needs to be built in advance (under the agent-core directory):
-
-```bash
-cd executor-example && docker build -t open-aaas-executor:latest .
-```
-
-See [agent-core/README.en.md](./agent-core/README.en.md) for details.
+---
 
 ## Project Structure
 
 ```
 OpenAaaS/
-├── server/           # Network Hub (Scheduling Center) (Rust) — Task scheduling, queuing, auth, file relay
-├── agent-core/       # Network Node (Execution Node) (Rust) — Registration, polling, Docker-isolated execution
-├── client-app/       # Desktop Client (Tauri + Vue 3) — Node browsing, task submission, result viewing
-├── dash/             # Debug and admin tools (Python/Streamlit)
-├── client-extension/ # Client extensions — pi plugin, Kimi plugin, MCP adapter (Claude Desktop / Cursor / Cline)
-└── pyopenaaas/       # Python SDK — A Pythonic SDK for researchers, supporting sync/async calls
+├── server/           # Network Hub (Scheduling Center) (Rust)
+├── agent-core/       # Network Node (Execution Node) (Rust)
+├── client-app/       # Desktop Client (Tauri + Vue 3)
+├── dash/             # Debug and Admin Tools (Python/Streamlit)
+├── client-extension/ # Client Extensions — pi plugin, Kimi plugin, MCP adapter
+├── pyopenaaas/       # Python SDK
+└── examples/         # Example notebooks and scripts
 ```
 
-## Research Vision
+---
 
-OpenAaaS's vision is to make every lab a **composable Agent node** in the Agentic Science network. Data is no longer degraded by migration, and knowledge is no longer stalled by silos. Every research group's data morphology, analysis workflows, and domain methods — however unique their storage formats may be — can be discovered, invoked, and orchestrated by any Agent across the network.
+## Paper
 
-When Agent capabilities can flow through the network to where data lives, an Agent's knowledge boundary expands from the closed loop of a single lab to an open ecosystem of global Agent collaboration. The marginal cost of moving data approaches zero, meaning datasets of any scale can be invoked on demand by Agents anywhere. The frontier of scientific innovation is no longer limited by a single team's data volume or domain depth.
+arXiv:2605.13618 — [https://arxiv.org/abs/2605.13618](https://arxiv.org/abs/2605.13618)
+
+---
 
 ## Contributing
 
-We welcome contributions! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, coding guidelines, and how to get involved.
+Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## Open Source License
+---
+
+## License
 
 MIT License © IDM Explorer Lab
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://arxiv.org/abs/2605.13618">论文</a> ·
   <a href="./server/README.md">server 文档</a> ·
   <a href="./agent-core/README.md">agent-core 文档</a> ·
-  <a href="#使用">使用指南</a> ·
+  <a href="#如何使用">使用指南</a> ·
   <a href="./client-extension/README.md">客户端插件</a> ·
   <a href="./pyopenaaas/README.md">Python SDK</a> ·
   <a href="./client-app/README.md">桌面客户端</a>
@@ -42,77 +42,181 @@
 
 ---
 
-**智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。**
+## 🚀 Quick Start
 
-**OpenAaaS 是一个面向 AI for Science 的 Agent 编排网络（Agent Orchestration Network）：数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边。**
+| 方式 | 入口 |
+|---|---|
+| **在线体验** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) — 浏览器直接运行 `examples/quickstart.ipynb` |
+| **下载客户端** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows / Linux 桌面客户端 |
 
-在 AI for Science 的实践中，瓶颈已从"模型能不能做"转向"科研能力能不能被方便地调用"。"数据被迫迁移"是比模型更硬的约束——每个实验室都沉淀了独特的数据、算法与流程，但它们分散在孤岛中，无法被任意 Agent 发现与调用。OpenAaaS 构建一个面向 AI for Science 的 Agent 编排网络，让任意 Agent 都能发现、委派并组合全球科研节点上的其他 Agent——数据原地处理，Agent 能力在网络中流动。
+---
 
-任何 Agent——无论是 Claude Code、pi mono、Kimi Cli 还是自研系统——都可以通过网络发现并组合全球科研节点上的其他 Agent。
+## 什么是 OpenAaaS?
 
-同时，我们致力于让网络的使用门槛降到最低，哪怕是手机上的通用大模型 App。
+> **智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。**
+
+OpenAaaS 是一个面向 AI for Science 的 Agent 编排网络（Agent Orchestration Network）：数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边。
 
 | 操作视频 | 截图 |
 |:---:|:---:|
 | <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **接入网络**<br><img width="372" height="113" alt="截屏2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**查看节点列表**<br><img width="379" height="406" alt="截屏2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**任务结果返回**<br><img width="371" height="391" alt="截屏2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
----
-
-### 📄 论文
-
-技术设计与实现细节详见：[arXiv:2605.13618](https://arxiv.org/abs/2605.13618)
+**论文**：技术设计与实现细节详见 [arXiv:2605.13618](https://arxiv.org/abs/2605.13618)。
 
 ---
 
-## AI for Science 的基础设施
+## 为什么选择 OpenAaaS?
 
-OpenAaaS 不训练新模型，也不做统一的数据仓库。它做一件事：**让科研能力像水一样流动**——将每个实验室沉淀的独特数据、算法与流程，转化为网络中可被任意 Agent 发现、委派、组合的服务，而原始数据始终留在原地。
+### 1. Agent 编排，节点即 Agent
 
----
+网络调度的对象不是脚本，而是拥有完整工具链的 Agent 实例。每个节点上的 Docker 容器内运行完整 Agent，能够自主决策、自主执行、自主调用子 Agent。任意 Agent（Claude Code、pi mono、Kimi 等）都可以像调用工具一样发现、委派并组合全球节点的其他 Agent。
 
-## 什么是 Agent 编排网络
+### 2. 数据原地处理，零迁移
 
-一个 Agent 能做的事情总是有限的。复杂的科研问题往往需要多种能力协作——文献检索、数据解析、模拟计算、结果可视化——这些能力分散在不同的实验室和服务器上。
+原始数据始终留在产生它的位置，远程 Agent 直接在数据旁工作。网络只传输任务描述与结果（KB~MB 级），不触碰原始数据（TB 级）。
 
-Agent 编排网络解决的就是这个问题：让一个 Agent 能够发现、调度、组合其他 Agent 的能力，把复杂任务拆开来分发给不同的 Agent 完成。它不是简单的"远程执行一段脚本"，而是**多 Agent 的协作编排**。
-
-现有的方案（如 Google 的 [A2A](https://a2a-protocol.org)）已经实现了 Agent 之间的互操作，但假设网络条件良好——每个 Agent 需要暴露地址、维持长连接。在科研环境中，防火墙会掐断长连接，NAT 会静默丢包，IT 也不会给你开端口。
-
-OpenAaaS 专为受限网络设计：节点每隔几秒主动问一次，像浏览器一样只发出站请求，不需要公网 IP。每个子 Agent 运行在数据本地，拥有完整的工具链，像一位"数字同事"一样自主决策、自主执行。主 Agent 负责发现、委派、整合结果。
-
-所以 OpenAaaS 不是调用脚本的工具，也不是互联网上的通用协议——**它是一个在实验室网络里真正跑得通的 Agent 编排网络**。
-
----
-
-## 四大核心主张
-
-### Agent 编排，节点即 Agent
-
-网络调度的对象不是脚本或服务，而是拥有完整工具链的 Agent 实例。每个节点上运行的 Docker 容器内都是一个完整的 Agent，能够自主决策、自主执行、自主调用子 Agent。任意 Agent 可以像调用工具一样发现、委派并组合全球节点的其他 Agent。
-
-### 原生数据零迁移
-
-传统方案要求数据汇聚到中心化平台，这不可避免地带来格式转换失真、元数据丢失、版本分叉、合规审计链断裂等问题。OpenAaaS 不建立统一的数据仓库，数据始终保留在产生它的位置，维持最初的存储格式、目录结构与访问权限。远程 Agent 直接在数据旁边自主工作，结果回传，原始数据从未离开本地。
-
-### 免规范化接入，Agent 原生能力即服务
-
-我们不对数据提出任何前置的格式要求。JSON、CSV、Excel、MATLAB `.mat`、HDF5、仪器厂商的专有二进制格式——节点本地的解析与处理脚本本身就是网络能力的一部分。Agent 调用的是"解析+分析"的组合服务，而非要求数据预先被清洗、标准化、结构化。实验室现有的任意数据，接入即服务。
-
-### 近数据端计算
-
-计算发生在数据旁边，而非数据被搬运到计算中心。远程 Agent 在数据旁边自主决策、自主执行，网络仅传输任务描述与执行结果（KB~MB 级），原始数据就地处理。对于 TB 级数据集和受监管敏感样本，这意味着无需等待上传、无需突破带宽瓶颈、无需面临出域合规审查——数据移动的边际成本趋近于零。
-
-## 核心设计理念
-
-传统云端方案要求数据离开本地：TB 级数据集必须迁移上传，敏感样本交给第三方，实验室防火墙被迫开放入站端口。OpenAaaS 反其道而行——将 Agent 执行节点直接部署在数据本地，网络只传输任务描述、任务文件及结果，原始数据原地不动。
-
-| | 传统云端方案 | OpenAaaS 近数据端方案 |
+| | 传统云端方案 | OpenAaaS |
 |---|---|---|
 | 数据流向 | 本地 → 云端 → 本地 | **原始数据原地不动** |
-| 网络传输 | 原始数据（TB 级） | 任务描述、任务文件及结果（KB~MB 级） |
+| 网络传输 | 原始数据（TB 级） | 任务描述与结果（KB~MB 级） |
 | 防火墙要求 | 需开放入站端口 | **仅出站 HTTP 即可** |
 | 敏感数据 | 必须出域 | **不出实验室** |
-| 延迟 | 受带宽限制 | 本地计算，极低延迟 |
+
+### 3. 免规范化接入，即插即用
+
+无需统一数据格式，JSON/CSV/Excel/MATLAB/HDF5/厂商二进制格式均可原地处理。节点零配置入网：`open-aaas-server run` 首次启动自动生成 `config.toml` 和 SQLite。自描述 API + 渐进式能力发现，Agent 无需插件即可理解并调用全部服务。
+
+### 4. 近数据端计算，低门槛部署
+
+Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker 隔离执行，每个任务独立沙箱。节点单向出站即可加入网络，无需公网 IP、无需开端口、无需 SSH——专为实验室防火墙和 NAT 环境设计。
+
+---
+
+## 如何使用？
+
+公共服务器：**<https://api.open-aaas.com>**
+
+| 方式 | 适合谁 | 入口 |
+|---|---|---|
+| Jupyter Notebook (Binder) | 想先体验，无需安装 | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) |
+| 桌面客户端 | 非技术用户 | [下载](https://github.com/Wolido/OpenAaaS/releases) |
+| Python SDK | Python/Jupyter 用户 | `pip install pyopenaaas` |
+| MCP 适配器 | Claude/Cursor/Cline 用户 | `uvx openaaas-mcp-adapter` |
+| pi / kimi 插件 | 对话型 Agent 用户 | 对话中直接调用 |
+
+### Jupyter Notebook (Binder)
+
+点击上方 Binder 徽章即可在浏览器中运行 `examples/quickstart.ipynb`，无需安装任何软件。
+
+### 桌面客户端
+
+基于 Tauri 的跨平台桌面应用，支持 macOS、Windows 和 Linux。适合非技术用户管理多个服务器、拖拽上传文件、实时查看任务进度。
+
+> macOS 和 Windows 用户可直接从 [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) 下载 `.dmg` 或 `.msi` 安装包。macOS 首次打开需前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"。
+
+<p align="center">
+  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81f68-76da-47c6-a535-83227b27b8bd" width="800" />
+</p>
+
+详见 [client-app/README.md](./client-app/README.md)。
+
+### Python SDK
+
+```bash
+pip install pyopenaaas
+```
+
+```python
+import pyopenaaas
+
+client = pyopenaaas.Client()
+client.register(name="your-name")
+
+services = client.list_services()
+task = client.submit_task(
+    service_id=services[0].id,
+    task_prompt="你的任务描述",
+)
+task = client.wait_for_task(task.id)
+paths = client.download_all_files(task.id)
+```
+
+详见 [pyopenaaas/README.md](./pyopenaaas/README.md)。
+
+### MCP 适配器
+
+`openaaas-mcp-adapter` 已发布至 PyPI。支持 MCP 的客户端（Claude Desktop、Cursor、Cline 等）只需一条配置即可接入：
+
+```json
+{
+  "mcpServers": {
+    "openaaas": {
+      "command": "uvx",
+      "args": ["openaaas-mcp-adapter"]
+    }
+  }
+}
+```
+
+配置后重启客户端，即可在对话中调用全部能力。
+
+<p align="center">
+  <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
+</p>
+
+详见 [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md)。
+
+### pi / kimi 插件
+
+在对话中直接说：
+
+> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后提交一个数据分析任务"
+
+客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
+
+<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
+
+### 通用 Agent 框架
+
+如果你的 Agent 没有 OpenAaaS 插件，直接访问 <https://api.open-aaas.com>。无需认证，返回完整 API 文档和使用说明，Agent 读取后即可自动完成注册、服务发现、任务提交。
+
+---
+
+## 部署自己的节点
+
+### 预编译二进制（推荐）
+
+无需安装 Rust，下载即可运行：[GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
+
+| 组件 | 二进制文件名 |
+|---|---|
+| Server | `open-aaas-server` |
+| Agent Core | `agent-core` |
+
+支持平台：
+- **Server / Agent Core**：Linux x64 (musl 静态链接)、Linux arm64 (musl 静态链接)、macOS arm64、Windows x64
+- **桌面客户端**：macOS、Windows
+
+> Linux 版本采用 musl 静态链接，不依赖系统 glibc，可在任意 Linux 发行版直接运行。
+
+```bash
+chmod +x open-aaas-server   # Unix 用户
+./open-aaas-server run
+```
+
+首次启动自动生成 `config.toml` 和 SQLite 数据库。
+
+### 从源码编译
+
+```bash
+cd server
+cargo build --release
+./target/release/open-aaas-server run
+```
+
+Agent Core 部署详见 [agent-core/README.md](./agent-core/README.md)。
+
+---
 
 ## 架构
 
@@ -150,229 +254,34 @@ Rust + Docker — 部署在数据本地
 | 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 服务注册、任务路由、节点心跳、文件中转 |
 | 网络节点 | agent-core — 能力执行节点 + Docker，容器内运行**完整 Agent 实例** | 向网络注册自身能力、轮询认领任务、在沙箱中启动完整 Agent 实例隔离执行、上报结果 |
 
-## 设计思路
-
-| 原则 | 说明 | 效果 |
-|------|------|------|
-| Rust + 单二进制 | `cargo build --release` 得到一个可执行文件 | 零依赖部署，复制即用 |
-| SQLite 嵌入式 | 数据库随进程启动，无单独服务 | 零运维，单节点足够 |
-| Docker 隔离 | 每个任务独立容器，workspace 挂载 | 安全可控，环境可复现 |
-| 完整 Agent 实例 | 容器内运行完整 Agent 实例（非脚本），拥有 read/write/bash/grep/subagent 等自主工具链 | 远程 Agent 自主决策、自主执行复杂任务，客户端只需描述目标 |
-| 节点自组网 | 节点主动向网络注册并轮询任务，Server 仅维护索引。原始数据不出域，任务文件经 Server 流转 | 节点无需公网 IP，单向出站即可加入网络；数据原地处理，天然适应实验室防火墙环境 |
-
-## 特性
-
-### 数据原位驻留与能力跨节点流动
-
-- **🤖 Agent 调用 Agent，而非调用脚本** — 远程节点上运行的是拥有完整工具链的 Agent，能够自主决策、自主执行复杂任务，而不是被动执行预设脚本。
-- **🔗 Agent 能力可组合** — 任意 Agent 可以像调用工具一样发现、委派并组合全球节点的其他 Agent，实现多 Agent 协作。
-- **🔌 Agent 零学习成本接入，自描述 API 自动暴露服务文档** — 无需认证，返回完整 API 文档和使用说明。Agent 无需插件即可理解并调用全部科研节点上的其他 Agent。
-- **🧩 渐进式能力发现，避免上下文溢出** — 初次查询返回轻量摘要，再按需返回详细用法。类似 SKILL.md 的渐进式披露设计，保护 Agent 的上下文窗口。
-
-### 原生数据零迁移
-
-- **🔒 数据不出域** — Agent 执行节点直接部署在实验室服务器或仪器工作站上，原始大数据集通过本地挂载原地处理，敏感数据不离开防火墙。网络只传输任务描述、任务文件及结果，不触碰原始数据。
-- **💾 单二进制零运维** — SQLite 数据库 + 本地文件存储，无需 Redis/MySQL。单节点即可部署，适合实验室边缘节点。
-- **⚖️ 节点反向入网，不需要公网 IP** — 节点自行控制并发和任务认领，Server 只做轻量队列管理。实验室节点只需要单向出站即可接入，无需开放端口或 SSH。
-
-### 免规范化接入与近数据端计算
-
-- **🐳 每个实验任务独立沙箱，结果可复现** — 每个任务在独立容器中运行，通过 workspace 挂载实现输入输出。环境隔离，结果可追溯、可复现。
-- **🔧 节点零配置入网** — `open-aaas-server run` 首次启动自动生成 `config.toml`、SQLite 数据库、密钥。无需手动配置，开箱即用。
-- **🔗 MCP 标准协议兼容** — 通过 `openaaas-mcp-adapter`，Claude Desktop、Cursor、Cline 等任意支持 MCP 的客户端均可一键接入，无需编写插件。
-
-## 使用
-
-公共服务器：**<https://api.open-aaas.com>**
-
-我们在公共服务器中提供了三项试用的科研服务：
-
-- 基于数十万真实文献的 IDM-Alpha 材料科学文献研究助手（支持文献问答与深度阅读报告生成）
-- 万亿规模六元高熵合金描述符数据库
-- 扶摇 Agent 圆桌会议系统
-
-你可以让 Agent 接入公共服务器使用这些服务。
-
-### 快速开始
-
-**场景一：使用公共服务器**
-
-无需自建基础设施，直接配置你的 Agent 接入公共服务器，即可调用社区共享的科研 Agent。适合个人研究者快速接入。
-
-### 用 pi / kimi 插件
-
-在对话中直接说：
-
-> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后提交一个数据分析任务"
-
-客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
-
-<video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
-
-### 用 MCP 客户端
-
-`openaaas-mcp-adapter` 已发布至 PyPI。如果你使用的是 **OpenClaw** 或其他支持 MCP（Model Context Protocol）的 Agent，接入 OpenAaaS 网络几乎是零成本的——无需编写任何插件，只需一条配置即可调用全部能力。
-
-```json
-{
-  "mcpServers": {
-    "openaaas": {
-      "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
-    }
-  }
-}
-```
-
-配置后重启客户端，即可在对话中调用 OpenAaaS 的 14 个标准 Tool（`set_server_url`、`register`、`list_services`、`submit_task` 等），无需安装任何插件。
-
-甚至，你可以直接让你的Agent帮你配置。
-
-<p align="center">
-  <img alt="mcp" src="https://github.com/user-attachments/assets/b7ff63bf-5fa8-46fa-906b-a8edbd950465" />
-</p>
-
-详见 [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaas-mcp-adapter/README.md)。
-
-### 用 Python SDK
-
-如果你偏好用 Python 代码直接与 OpenAaaS 交互，可以使用 **`pyopenaaas`** —— 面向科研用户的 Python SDK。
-
-```bash
-pip install pyopenaaas
-```
-
-```python
-import pyopenaaas
-
-client = pyopenaaas.Client()
-client.register(name="your-name")
-
-services = client.list_services()
-task = client.submit_task(
-    service_id=services[0].id,
-    task_prompt="你的任务描述",
-)
-task = client.wait_for_task(task.id)
-paths = client.download_all_files(task.id)
-```
-
-📖 详见 [pyopenaaas/README.md](./pyopenaaas/README.md)。
-
-### 用桌面客户端
-
-如果你偏好图形界面操作，可以使用 **OpenAaaS 桌面客户端**——一个基于 Tauri 的跨平台桌面应用，支持 macOS、Windows 和 Linux。
-
-桌面客户端适合：
-- 不想配置命令行或插件的非技术用户
-- 需要管理多个服务器并直观浏览服务的场景
-- 希望拖拽上传文件、实时查看任务进度的用户
-
-📖 详见 [client-app/README.md](./client-app/README.md)
-
-> macOS 和 Windows 用户可直接从 [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) 下载 `.dmg` 或 `.msi` 安装包。
-
-<p align="center">
-  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
-</p>
-
-> macOS 用户请注意：应用使用 ad-hoc 自签名，首次打开时前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"即可。
-
-### 用通用 Agent 框架
-
-如果你的 Agent 没有 OpenAaaS 插件，让 Agent 直接访问 <https://api.open-aaas.com>
-
-- 无需认证，返回完整 API 文档和使用说明
-- Agent 读取后即可自动完成注册、服务发现、任务提交
-
-**场景二：部署在实验室服务器，接入本地能力**
-
-在机房或实验室的本地服务器上启动 OpenAaaS，将本地分析能力注册为网络节点。课题组内的任何 Agent——pi、Kimi、Claude 或自研系统——都能通过统一入口查询节点状态、提交分析任务、获取结果数据。
-
-### 本地部署
-
-#### 预编译二进制（推荐）
-
-OpenAaaS 为每个组件提供了预编译二进制文件，**无需安装 Rust，无需编译，下载即可运行**。
-
-- **下载地址**: [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases)
-
-| 组件 | 二进制文件名 | 适用场景 |
-|------|-------------|----------|
-| Server | `open-aaas-server` | 网络调度中心 |
-| Agent Core | `agent-core` | 执行节点 |
-
-支持平台：
-- **Server / Agent Core**：Linux x64 (musl 静态链接)、Linux arm64 (musl 静态链接)、macOS arm64、Windows x64
-- **桌面客户端（client-app）**：macOS、Windows
-
-> 💡 Linux 版本采用 musl 静态链接，不依赖系统 glibc，可在任意 Linux 发行版直接运行。
-
-**快速开始（以 Server 为例）**：
-
-```bash
-# 下载对应平台的压缩包并解压后
-chmod +x open-aaas-server   # Unix 用户；Windows 用户直接运行 .exe
-./open-aaas-server run
-```
-
-首次启动自动生成 `config.toml` 和 SQLite 数据库。
-
-#### 从源码编译
-
-如果你需要自定义修改代码，可以从源码编译。
-
-**部署 Server（调度中心）**：
-
-```bash
-cd server
-cargo build --release
-./target/release/open-aaas-server run
-```
-
-首次启动自动生成 `config.toml`和 SQLite 数据库。
-
-**部署 Agent Core（执行节点）**：
-
-```bash
-cd agent-core
-cargo build --release
-./target/release/agent-core init
-./target/release/agent-core register --token <registration_token> --name my-agent
-./target/release/agent-core run
-```
-
-`registration_token` 需要先在 Server 上创建 Service 获取。Admin 可使用 Server 日志中的 API Key 调用 `POST /api/v1/services/` 创建。
-
-Agent 执行器镜像需要提前构建（在 agent-core 目录下）：
-
-```bash
-cd executor-example && docker build -t open-aaas-executor:latest .
-```
-
-详见 [agent-core/README.md](./agent-core/README.md)
+---
 
 ## 项目结构
 
 ```
 OpenAaaS/
-├── server/           # 网络枢纽（调度中心） (Rust) — 任务调度、队列、鉴权、文件中转
-├── agent-core/       # 网络节点（执行节点） (Rust) — 注册、轮询、Docker 隔离执行
-├── client-app/       # 桌面客户端 (Tauri + Vue 3) — 节点浏览、任务提交、结果查看
+├── server/           # 网络枢纽（调度中心） (Rust)
+├── agent-core/       # 网络节点（执行节点） (Rust)
+├── client-app/       # 桌面客户端 (Tauri + Vue 3)
 ├── dash/             # 调试与管理员工具 (Python/Streamlit)
-├── client-extension/ # 客户端扩展 — pi 插件、kimi 插件、MCP 适配器（Claude Desktop / Cursor / Cline）
-└── pyopenaaas/       # Python SDK — 面向科研用户的 Pythonic SDK，支持同步/异步调用
+├── client-extension/ # 客户端扩展 — pi 插件、kimi 插件、MCP 适配器
+├── pyopenaaas/       # Python SDK
+└── examples/         # 示例 notebook 与脚本
 ```
 
-## 科研愿景
+---
 
-OpenAaaS 的愿景是让每个实验室都成为 Agentic Science 网络中的一个**可组合的 Agent 节点**。数据不再因迁移而损耗，知识不再因孤岛而停滞。每个课题组沉淀的数据形态、分析流程与领域方法——无论其存储格式多么独特——都可以通过网络被任意 Agent 发现、调用与编排。
+## 论文
 
-当 Agent 能力能够通过网络流动到数据身边，一个 Agent 的知识边界将从单个实验室的闭环，扩展到全球 Agent 协作的开放生态。数据移动的边际成本趋近于零，意味着任意规模的 Dataset 都可以被任意位置的 Agent 即时调用。科研创新的边界，不再受限于单个团队的数据规模或领域深度。
+arXiv:2605.13618 — [https://arxiv.org/abs/2605.13618](https://arxiv.org/abs/2605.13618)
+
+---
 
 ## 参与贡献
 
-欢迎参与贡献！请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md) 了解如何搭建开发环境、提交代码和参与社区讨论。
+欢迎参与贡献！请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)。
+
+---
 
 ## 开源许可
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker �
 
 ### Jupyter Notebook (Binder)
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb)
+
 点击上方 Binder 徽章即可在浏览器中运行 `examples/quickstart.ipynb`，无需安装任何软件。
 
 ### 桌面客户端

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-1-title",
+   "metadata": {},
+   "source": [
+    "# OpenAaaS 快速入门 / OpenAaaS Quick Start\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb)\n",
+    "\n",
+    "在浏览器中直接体验 OpenAaaS Python SDK，无需本地安装。\n",
+    "Run OpenAaaS Python SDK directly in your browser, no local installation needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2-intro",
+   "metadata": {},
+   "source": [
+    "## 简介 / Introduction\n",
+    "\n",
+    "**OpenAaaS**（Open Agent-as-a-Service）是一个面向科学研究的智能体编排平台。\n",
+    "**OpenAaaS** (Open Agent-as-a-Service) is an agent orchestration platform for scientific research.\n",
+    "\n",
+    "本 Notebook 将带你完成一次完整的科研任务流程：注册账号 → 发现服务 → 提交任务 → 获取并展示结果。\n",
+    "This notebook walks you through a complete research workflow: register → discover services → submit a task → retrieve and display results.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "每一步都配有代码示例，点击上方的 **Binder** 徽章即可在浏览器中直接运行。\n",
+    "Each step includes runnable code examples. Click the **Binder** badge above to run everything in your browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3-install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 安装 pyopenaaas\n",
+    "# Install pyopenaaas\n",
+    "!pip install pyopenaaas -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-4-init",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyopenaaas\n",
+    "\n",
+    "# 创建客户端，默认连接公共服务器 https://api.open-aaas.com\n",
+    "# Create client, default public server\n",
+    "client = pyopenaaas.Client()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5-register",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 注册获取 API Key（无需预先准备，自动生成随机用户名）\n",
+    "# Register to get an API Key (auto-generated random username)\n",
+    "result = client.register()\n",
+    "print(\"API Key:\", result[\"api_key\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6-discover",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 查看公共服务器上有哪些科研服务\n",
+    "# Discover available scientific services\n",
+    "services = client.list_services()\n",
+    "for svc in services:\n",
+    "    print(f\"- {svc.name} (ID: {svc.id})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7-usage",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 获取第一个服务的详细用法说明\n",
+    "# Get detailed usage for the first service\n",
+    "usage = client.get_service_usage(services[0].id)\n",
+    "print(usage.usage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8-submit",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 提交一个科研任务\n",
+    "# Submit a research task\n",
+    "task = client.submit_task(\n",
+    "    service_id=services[0].id,\n",
+    "    task_prompt=\"为我调研一下如何设计具有高温塑性且抗氧化的高熵合金\",\n",
+    "    output_prompt=\"\",\n",
+    ")\n",
+    "print(f\"Task ID: {task.id}, Status: {task.status}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9-wait",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 自动轮询等待任务完成（每10秒检查一次）\n",
+    "# Poll until task completes (check every 10 seconds)\n",
+    "task = client.wait_for_task(task.id, poll_interval=10.0)\n",
+    "print(f\"Final status: {task.status}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-10-download",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 下载所有结果文件到本地 .OpenAaaS/downloads/<task_id>/\n",
+    "# Download all result files\n",
+    "if task.is_success():\n",
+    "    paths = client.download_all_files(task.id)\n",
+    "    for p in paths:\n",
+    "        print(f\"Saved: {p}\")\n",
+    "else:\n",
+    "    print(f\"Task failed: {task.error_message}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11-display",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "# 找到下载目录中的 response.md 文件并直接渲染展示\n",
+    "# Find the downloaded response.md and render it directly\n",
+    "download_dir = pyopenaaas._utils._get_download_dir(task.id)\n",
+    "md_files = list(download_dir.glob(\"*.md\"))\n",
+    "\n",
+    "if md_files:\n",
+    "    for md_file in md_files:\n",
+    "        print(f\"\\n{'='*60}\")\n",
+    "        print(f\"📄 {md_file.name}\")\n",
+    "        print(f\"{'='*60}\\n\")\n",
+    "        display(Markdown(md_file.read_text(encoding=\"utf-8\")))\n",
+    "else:\n",
+    "    print(\"No .md files found in download directory.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12-summary",
+   "metadata": {},
+   "source": [
+    "## 总结与扩展 / Summary & Next Steps\n",
+    "\n",
+    "恭喜！你已经完成了 OpenAaaS 的第一次科研任务。接下来你还可以尝试：\n",
+    "Congratulations! You've completed your first research task with OpenAaaS. Here are more things to explore:\n",
+    "\n",
+    "- **探索更多服务** — 使用 `client.list_services()` 查看其他科研智能体。\n",
+    "  **Explore more services** — Use `client.list_services()` to discover other scientific agents.\n",
+    "- **上传本地文件** — 通过 `input_files` 参数将论文、数据等作为任务输入上传。\n",
+    "  **Upload local files** — Pass `input_files` to upload papers, data, etc. as task inputs.\n",
+    "- **使用异步 API** — 在大型工作流中尝试 `pyopenaaas.AsyncClient` 并发提交多个任务。\n",
+    "  **Use the async API** — Try `pyopenaaas.AsyncClient` to submit multiple tasks concurrently in large workflows.\n",
+    "- **查看任务输出** — 通过 `task.result.stdout` 查看智能体的执行日志。\n",
+    "  **Check task output** — Inspect `task.result.stdout` for the agent's execution logs.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "📖 更多文档请参阅 SDK 源码与 API 文档。\n",
+    "📖 For more documentation, please refer to the SDK source code and API docs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -109,6 +109,7 @@
     "# Submit a research task\n",
     "task = client.submit_task(\n",
     "    service_id=services[0].id,\n",
+    "    # task_prompt=\"Research how to design high-entropy alloys with high-temperature ductility and oxidation resistance\",\n",
     "    task_prompt=\"为我调研一下如何设计具有高温塑性且抗氧化的高熵合金\",\n",
     "    output_prompt=\"\",\n",
     ")\n",

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+pyopenaaas


### PR DESCRIPTION
## 变更

- 重构 README.md / README.en.md：
  - 新增 Quick Start 区块（Binder + 桌面客户端）
  - 合并冗余内容（四大主张、理念对比、设计思路、特性）为精简的 Why OpenAaaS
  - 重构使用指南为横向选择表 + 逐一展开
  - 总长度精简 ~47%
- 新增 examples/quickstart.ipynb（中英双语 Binder Notebook）
- 新增 examples/requirements.txt（Binder 依赖）

## 关联

延续 #97 的文档更新。