### PR TITLE
docs: remove Linux from desktop client platform list

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -47,7 +47,7 @@
 | Method | Entry |
 |---|---|
 | **Try it now** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) — Run `examples/quickstart.ipynb` directly in your browser |
-| **Download App** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows / Linux desktop client |
+| **Download App** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows desktop client |
 
 ---
 
@@ -112,7 +112,7 @@ Click the Binder badge above to run `examples/quickstart.ipynb` directly in your
 
 ### Desktop Client
 
-A cross-platform desktop app built with Tauri, supporting macOS, Windows, and Linux. Ideal for non-technical users to manage multiple servers, drag-and-drop upload files, and track task progress in real time.
+A cross-platform desktop app built with Tauri, supporting macOS and Windows. Ideal for non-technical users to manage multiple servers, drag-and-drop upload files, and track task progress in real time.
 
 > macOS and Windows users can download `.dmg` or `.msi` installers directly from [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases). On first launch, macOS users may need to go to **System Settings → Privacy & Security → Security** and click **"Open Anyway"**.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 | 方式 | 入口 |
 |---|---|
 | **在线体验** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=examples%2Fquickstart.ipynb) — 浏览器直接运行 `examples/quickstart.ipynb` |
-| **下载客户端** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows / Linux 桌面客户端 |
+| **下载客户端** | [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) — macOS / Windows 桌面客户端 |
 
 ---
 
@@ -112,7 +112,7 @@ Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker �
 
 ### 桌面客户端
 
-基于 Tauri 的跨平台桌面应用，支持 macOS、Windows 和 Linux。适合非技术用户管理多个服务器、拖拽上传文件、实时查看任务进度。
+基于 Tauri 的跨平台桌面应用，支持 macOS 和 Windows。适合非技术用户管理多个服务器、拖拽上传文件、实时查看任务进度。
 
 > macOS 和 Windows 用户可直接从 [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) 下载 `.dmg` 或 `.msi` 安装包。macOS 首次打开需前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"。
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker �
 > macOS 和 Windows 用户可直接从 [GitHub Releases](https://github.com/Wolido/OpenAaaS/releases) 下载 `.dmg` 或 `.msi` 安装包。macOS 首次打开需前往 **系统设置 → 隐私与安全性 → 安全性** 点击"仍要打开"。
 
 <p align="center">
-  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81f68-76da-47c6-a535-83227b27b8bd" width="800" />
+  <img alt="OpenAaaS Client" src="https://github.com/user-attachments/assets/8bc81d68-76da-47c6-a535-83227b27b8bd" width="800" />
 </p>
 
 详见 [client-app/README.md](./client-app/README.md)。


### PR DESCRIPTION
桌面客户端实际只支持 macOS 和 Windows，移除 README 中对 Linux 的错误声明。