### PR TITLE
fix(notebook): use task.status check instead of non-existent is_completed()

### DIFF
--- a/binder/quickstart.ipynb
+++ b/binder/quickstart.ipynb
@@ -132,7 +132,7 @@
     "while True:\n",
     "    task = client.get_task(task.id)\n",
     "    elapsed = time.time() - start_time\n",
-    "    if task.is_completed():\n",
+    "    if task.status in (\"completed\", \"failed\"):\n",
     "        clear_output(wait=True)\n",
     "        print(f\"✅ Task completed after {elapsed:.1f}s\")\n",
     "        print(f\"Final status: {task.status}\")\n",


### PR DESCRIPTION
修复 binder/quickstart.ipynb 中 cell-9-wait 调用不存在的方法 task.is_completed()，改为检查 task.status in ('completed', 'failed')。