### PR TITLE
统一 sqlx 版本：将 agent-core 从 0.7 升级到 0.8

### DIFF
--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-04
+
+### Changed
+- 升级 sqlx 依赖从 0.7 到 0.8，与 server 保持一致 (#81)
+
 ## [0.4.0] - 2026-05-28
 
 ### Changed

--- a/agent-core/Cargo.toml
+++ b/agent-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "OpenAaaS Agent Core - 调度与执行框架"
 

--- a/agent-core/Cargo.toml
+++ b/agent-core/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # SQLx chrono 支持
-sqlx = { version = "0.7", features = ["runtime-tokio", "sqlite", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono"] }
 
 
 


### PR DESCRIPTION
## 修复内容

将 agent-core 中的 sqlx 依赖从 0.7 升级到 0.8，与 server 保持一致，解决同一项目内依赖版本不统一的问题。

## 变更

- agent-core/Cargo.toml：sqlx version 从 "0.7" 改为 "0.8"

## 验证

- `cargo check` 通过
- `cargo test --features test-utils` 通过（153 项测试全部通过）

Fixes #81
