### PR TITLE
chore: enrich glama.json with project description and MCP usage

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,57 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["Wolido"]
+  "maintainers": ["Wolido"],
+  "name": "OpenAaaS",
+  "description": {
+    "en": "An agent orchestration network for AI for Science. Intelligence flows, data stays still.",
+    "zh": "OpenAaaS 是一个面向 AI for Science 的 Agent 编排网络（Agent Orchestration Network）。智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/Wolido/OpenAaaS",
+  "website": "https://www.open-aaas.com",
+  "publicServer": "https://api.open-aaas.com",
+  "mcpAdapter": {
+    "packageName": "openaaas-mcp-adapter",
+    "packageUrl": "https://pypi.org/project/openaaas-mcp-adapter/",
+    "coreTools": 14,
+    "sdk": "MCP Python SDK",
+    "supportedClients": [
+      "Claude Desktop",
+      "Cursor",
+      "Cline"
+    ],
+    "installation": {
+      "recommended": {
+        "method": "uvx",
+        "command": "uvx openaaas-mcp-adapter",
+        "note": "Zero-installation, recommended"
+      },
+      "alternatives": [
+        {
+          "method": "pipx",
+          "installCommand": "pipx install openaaas-mcp-adapter",
+          "runCommand": "openaaas-mcp-adapter"
+        },
+        {
+          "method": "pip",
+          "installCommand": "pip install openaaas-mcp-adapter"
+        },
+        {
+          "method": "docker",
+          "runCommand": "docker run --rm -it wolido/openaaas-mcp-adapter:latest"
+        }
+      ]
+    },
+    "configuration": {
+      "configPath": "~/.openaaas-mcp-adapter/config.json",
+      "autoCreate": true,
+      "defaultServer": "https://api.open-aaas.com"
+    }
+  },
+  "mcpServers": {
+    "openaaas": {
+      "command": "uvx",
+      "args": ["openaaas-mcp-adapter"]
+    }
+  }
 }


### PR DESCRIPTION
## 变更

- 增加项目名称、多语言描述（en/zh）
- 增加许可证（MIT）、仓库地址、官网地址
- 增加公共服务器地址
- 增加 MCP 适配器详细信息（包名、PyPI 链接、14 个核心 Tool、支持客户端）
- 增加多种 MCP 安装方式（uvx / pipx / pip / docker）
- 增加 MCP 客户端配置示例（mcpServers）
- 增加适配器配置文件路径和默认服务器信息

## 动机
原 glama.json 仅包含 maintainers 字段，过于简单。增强后便于 Glama 平台展示项目完整信息，也方便用户快速接入 MCP。