### PR TITLE
fix: sync mcp adapter version in Dockerfile with pyproject.toml

### DIFF
--- a/client-extension/openaaas-mcp-adapter/Dockerfile
+++ b/client-extension/openaaas-mcp-adapter/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install package, create non-root user, fix permissions in one layer
-RUN pip install --no-cache-dir openaaas-mcp-adapter==0.1.1 && \
+RUN pip install --no-cache-dir openaaas-mcp-adapter==0.2.0 && \
     useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
 


### PR DESCRIPTION
### 修复内容
- Dockerfile 中 hardcoded 的 openaaas-mcp-adapter 版本号从 <code>0.1.1</code> 更新为 <code>0.2.0</code>，与 pyproject.toml 保持一致。

### 变更文件
- <code>client-extension/openaaas-mcp-adapter/Dockerfile</code>

### 审查要点
- 确认版本号与 pyproject.toml 中 <code>version = "0.2.0"</code> 一致。