### PR TITLE
docs: add service status notice to READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,3 +1,5 @@
+> ⚠️ **Service Status Notice**: Due to domain name filing (ICP备案), the public service nodes at `api.open-aaas.com` and `www.open-aaas.com` are temporarily inaccessible. Service is expected to resume in approximately one week. In the meantime, you can continue using OpenAaaS via [local deployment](#deploy-your-own-node) or the [Binder online demo](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=binder%2Fquickstart.ipynb).
+
 <p align="right"><a href="./README.md">中文</a> | English</p>
 
 <p align="center">

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **Service Status Notice**: Due to domain name filing (ICP备案), the public service nodes at `api.open-aaas.com` and `www.open-aaas.com` are temporarily inaccessible. Service is expected to resume in approximately one week. In the meantime, you can continue using OpenAaaS via [local deployment](#deploy-your-own-node) or the [Binder online demo](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=binder%2Fquickstart.ipynb).
+> ⚠️ **Service Status Notice**: Due to domain name filing (ICP备案), the public service nodes at `api.open-aaas.com` and `www.open-aaas.com` are temporarily inaccessible. Service is expected to resume in approximately one week. In the meantime, you can continue using OpenAaaS via [local deployment](#deploy-your-own-node).
 
 <p align="right"><a href="./README.md">中文</a> | English</p>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> ⚠️ **服务状态提醒**：由于域名备案中，`api.open-aaas.com` 及 `www.open-aaas.com` 公开服务节点暂时无法访问，预计约一周恢复。在此期间，您可以通过 [本地部署](#部署自己的节点) 或 [Binder 在线体验](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=binder%2Fquickstart.ipynb) 继续使用 OpenAaaS。
+
 <p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> ⚠️ **服务状态提醒**：由于域名备案中，`api.open-aaas.com` 及 `www.open-aaas.com` 公开服务节点暂时无法访问，预计约一周恢复。在此期间，您可以通过 [本地部署](#部署自己的节点) 或 [Binder 在线体验](https://mybinder.org/v2/gh/Wolido/OpenAaaS/main?filepath=binder%2Fquickstart.ipynb) 继续使用 OpenAaaS。
+> ⚠️ **服务状态提醒**：由于域名备案中，`api.open-aaas.com` 及 `www.open-aaas.com` 公开服务节点暂时无法访问，预计约一周恢复。在此期间，您可以通过 [本地部署](#部署自己的节点) 继续使用 OpenAaaS。
 
 <p align="right">中文 | <a href="./README.en.md">English</a></p>
 


### PR DESCRIPTION
## 变更

- 在中文和英文 README 顶部添加服务状态提醒 banner，告知用户公开服务节点因域名备案暂时无法访问（预计约一周恢复）
- 提供替代方案：本地部署（Binder 在线体验也默认连接公共节点，暂不可用）
- 修复中文文案语义重复（"预计约一周左右恢复" → "预计约一周恢复"）

> ⚠️ 域名恢复后可移除这两个 banner。