### PR TITLE
feat(admin): add endpoint to list authorized users for a service

### DIFF
--- a/server/src/handlers/admin.rs
+++ b/server/src/handlers/admin.rs
@@ -38,6 +38,20 @@ pub struct AdminListTasksQuery {
 }
 
 #[derive(Debug, Serialize, FromRow)]
+pub struct ServiceUserResponse {
+    pub user_id: String,
+    pub user_name: Option<String>,
+    pub role: String,
+    pub granted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServiceUsersListResponse {
+    pub is_public: bool,
+    pub users: Vec<ServiceUserResponse>,
+}
+
+#[derive(Debug, Serialize, FromRow)]
 pub struct AdminTaskResponse {
     pub id: String,
     pub user_id: String,
@@ -63,6 +77,7 @@ pub fn routes(state: AppState) -> Router<AppState> {
         .route("/users/{id}", delete(delete_user))
         .route("/users/{id}/role", put(update_user_role))
         .route("/users/{id}/permissions", get(list_user_permissions))
+        .route("/services/{id}/users", get(list_service_users))
         .route(
             "/services/{service_id}/users/{user_id}",
             delete(revoke_service_permission),
@@ -263,6 +278,39 @@ pub async fn list_user_permissions(
     .map_err(AppError::Database)?;
 
     Ok(Json(permissions))
+}
+
+/// 列出某服务的授权用户
+///
+/// 注意：返回的 `role` 是用户在系统中的全局角色（client/admin），
+/// 而非服务级角色（当前 schema 中 user_service_permissions 无 role 字段）。
+pub async fn list_service_users(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServiceUsersListResponse>> {
+    let is_public: bool =
+        sqlx::query_scalar::<_, bool>("SELECT is_public FROM services WHERE id = ?")
+            .bind(&id)
+            .fetch_optional(state.db.pool())
+            .await
+            .map_err(AppError::Database)?
+            .ok_or(AppError::NotFound)?;
+
+    let users: Vec<ServiceUserResponse> = sqlx::query_as::<_, ServiceUserResponse>(
+        r#"
+        SELECT u.id as user_id, u.name as user_name, u.role, p.granted_at
+        FROM user_service_permissions p
+        JOIN users u ON p.user_id = u.id
+        WHERE p.service_id = ?
+        ORDER BY p.granted_at DESC
+        "#,
+    )
+    .bind(&id)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(AppError::Database)?;
+
+    Ok(Json(ServiceUsersListResponse { is_public, users }))
 }
 
 /// 撤销用户对服务的权限

--- a/server/tests/integration/admin_api.rs
+++ b/server/tests/integration/admin_api.rs
@@ -1146,3 +1146,109 @@ async fn test_admin_api_invalid_auth() {
 
     app.cleanup().await;
 }
+
+// ============================================================================
+// 列出服务授权用户测试
+// ============================================================================
+
+#[tokio::test]
+async fn test_list_service_users_not_found() {
+    let app = TestApp::new().await;
+
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/admin/services/non-existent-service/users")
+                .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_list_service_users_public_empty() {
+    let app = TestApp::new().await;
+
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    let (service_id, _, _) =
+        create_test_service(app.pool(), "public_service", "Public Service", true).await;
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/admin/services/{}/users", service_id))
+                .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(json["is_public"].as_bool(), Some(true));
+    assert!(json["users"].as_array().unwrap().is_empty());
+
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_list_service_users_restricted_with_users() {
+    let app = TestApp::new().await;
+
+    let (_, admin_api_key, _) = create_test_user(app.pool(), "admin", UserRole::Admin).await;
+    let (user_id, _, _) = create_test_user(app.pool(), "normaluser", UserRole::Client).await;
+    let (service_id, _, _) = create_test_service(
+        app.pool(),
+        "restricted_service",
+        "Restricted Service",
+        false,
+    )
+    .await;
+
+    grant_service_permission(app.pool(), &user_id, &service_id).await;
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/admin/services/{}/users", service_id))
+                .header(auth_header(&admin_api_key).0, auth_header(&admin_api_key).1)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(json["is_public"].as_bool(), Some(false));
+    let users = json["users"].as_array().unwrap();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0]["user_id"].as_str(), Some(user_id.as_str()));
+    assert_eq!(users[0]["user_name"].as_str(), Some("normaluser"));
+    assert_eq!(users[0]["role"].as_str(), Some("client"));
+    assert!(users[0]["granted_at"].is_string());
+
+    app.cleanup().await;
+}


### PR DESCRIPTION
## Summary
Add `GET /api/v1/admin/services/{id}/users` endpoint for administrators to query which users have been explicitly granted access to a restricted service.

## Changes
- New endpoint: `GET /api/v1/admin/services/{id}/users`
- Response includes `is_public` flag and list of authorized users
- Added integration tests covering 404, public empty, and restricted with users scenarios

## API Response
```json
{\n  "is_public": false,\n  "users": [\n    {\n      "user_id": "user-001",\n      "user_name": "Alice",\n      "role": "client",\n      "granted_at": "2024-01-01T00:00:00Z"\n    }\n  ]\n}\n```