### PR TITLE
feat(cli): add openaaas-admin CLI for server management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           cd agent-core
           cargo test --features test-utils
+      - name: Run admin-cli tests
+        run: |
+          cd admin-cli
+          cargo test
 
   frontend-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
           - server
           - agent-core
           - client-app
+          - admin-cli
         default: server
       version:
         description: "发布版本号（SemVer，例如 0.1.1）"
@@ -72,6 +73,8 @@ jobs:
             echo "binary_name=agent-core" >> "$GITHUB_OUTPUT"
           elif [[ "$COMPONENT" == "client-app" ]]; then
             echo "binary_name=openaaas-client" >> "$GITHUB_OUTPUT"
+          elif [[ "$COMPONENT" == "admin-cli" ]]; then
+            echo "binary_name=openaaas-admin" >> "$GITHUB_OUTPUT"
           else
             echo "Unknown component: $COMPONENT"
             exit 1

--- a/admin-cli/CHANGELOG.md
+++ b/admin-cli/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-06-06
+
+### Added
+- 初始版本发布
+- 服务管理：list, show, create, update, delete（含 force delete）
+- 用户管理：list, delete（含确认保护）
+- 权限管理：按用户/服务查询、grant、revoke
+- 任务统计概览（stats）
+- 配置管理：init（交互式，API Key 输入隐藏）、show
+- 健康检查：验证 Server 连通性和 Admin Key 有效性
+- 39 个单元/集成测试（含 wiremock HTTP 测试）
+- 安全配置：文件权限 0o600、API Key 脱敏、删除确认
+
+[0.1.0]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.0

--- a/admin-cli/Cargo.toml
+++ b/admin-cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/admin-cli/Cargo.toml
+++ b/admin-cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "openaaas-admin"
+version = "0.1.0"
+edition = "2024"
+authors = ["OpenAaaS Contributors"]
+description = "OpenAaaS Server Admin CLI"
+license = "MIT"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+toml = "0.8"
+tabled = "0.16"
+colored = "2.1"
+thiserror = "2.0"
+dirs = "5.0"
+chrono = { version = "0.4", features = ["serde"] }
+rpassword = "7.3"
+
+[dev-dependencies]
+tokio-test = "0.4"
+wiremock = "0.6"

--- a/admin-cli/README.en.md
+++ b/admin-cli/README.en.md
@@ -1,0 +1,273 @@
+# OpenAaaS Admin CLI
+
+<p align="right"><a href="./README.md">中文</a> | English</p>
+
+A command-line administration tool for OpenAaaS Server, providing administrators with pure CLI, table-oriented service management, user management, permission management, task statistics, and health checks.
+
+## Build & Install
+
+Requires the Rust toolchain (1.85+):
+
+```bash
+cd admin-cli
+cargo build --release
+```
+
+The compiled binary is located at `target/release/openaaas-admin`.
+
+## Command Overview
+
+```bash
+openaaas-admin [OPTIONS] <COMMAND>
+```
+
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--server-url <URL>` | Specify the Server URL, overrides config and environment variables |
+| `--api-key <KEY>` | Specify the Admin API Key, overrides config and environment variables |
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `config init` | Initialize configuration interactively or with parameters |
+| `config show` | Show current configuration |
+| `health` | Check Server health status and Admin Key validity |
+| `services list` | List all services |
+| `services show <id>` | Show service details |
+| `services create` | Create a new service |
+| `services update <id>` | Update service information |
+| `services delete <id>` | Delete a service (with confirmation prompt) |
+| `users list` | List all users |
+| `users delete <id>` | Delete a user (with confirmation prompt) |
+| `permissions list` | Query permissions by user or service |
+| `permissions grant` | Grant a user permission to a service |
+| `permissions revoke` | Revoke a user's permission to a service |
+| `stats` | Show task statistics overview |
+
+## Configuration
+
+Config file path: `~/.config/openaaas-admin/config.toml`
+
+### Initialize Config
+
+Interactively (recommended, API Key input is hidden):
+
+```bash
+openaaas-admin config init
+```
+
+With parameters:
+
+```bash
+openaaas-admin config init --server-url http://localhost:8080 --api-key ak_admin_xxx
+```
+
+Interactive example:
+
+```bash
+$ openaaas-admin config init
+Enter server URL [http://localhost:8080]:
+Enter admin API key:
+✓ Configuration saved to /home/user/.config/openaaas-admin/config.toml
+```
+
+### Show Config
+
+```bash
+openaaas-admin config show
+```
+
+Example output:
+
+```
++------------+------------------------+
+| Key        | Value                  |
++------------+------------------------+
+| server_url | http://localhost:8080  |
+| api_key    | ak_admin_12***         |
++------------+------------------------+
+```
+
+### Configuration Priority
+
+Config items are loaded with the following priority (highest first):
+
+1. CLI flags: `--server-url`, `--api-key`
+2. Environment variables: `OPENAAAS_SERVER_URL`, `OPENAAAS_API_KEY`
+3. Config file: `~/.config/openaaas-admin/config.toml`
+
+## Security Notice
+
+> ⚠️ **Avoid passing `--api-key` directly on the command line** — the value will be saved in your shell history. Prefer one of the following:
+> - Environment variable: `OPENAAAS_API_KEY=ak_admin_xxx openaaas-admin ...`
+> - Config file: `openaaas-admin config init`
+>
+> The config file is created with permissions `0o600` (owner-only read/write), and the API Key is automatically masked in `config show` output.
+
+## Detailed Command Usage
+
+### Health Check
+
+```bash
+openaaas-admin health
+```
+
+Checks both the public `/health` endpoint and the protected Admin endpoint to verify Server connectivity and Admin Key validity.
+
+Example output:
+
+```
+Checking server health at http://localhost:8080 ...
+  ● Health: healthy
+  ● Version: 0.9.0
+  ● Timestamp: 2026-06-06T12:00:00Z
+
+Checking admin API key ...
+  ● Admin API key is valid
+
+✓ All checks passed
+```
+
+### Service Management
+
+#### List all services
+
+```bash
+openaaas-admin services list
+```
+
+#### Show service details
+
+```bash
+openaaas-admin services show <id>
+```
+
+#### Create a service
+
+```bash
+openaaas-admin services create \
+  --name "code-agent" \
+  --description "Code review agent" \
+  --usage "Submit PRs for code review" \
+  --public
+```
+
+- `--public`: Public service, all users have access by default; omit for restricted services
+- Upon successful creation, the registration token (`registration_token`) will be printed. Save it for `agent-core` registration.
+
+#### Update a service
+
+```bash
+# Update name and description
+openaaas-admin services update <id> --name "new-name" --description "new desc"
+
+# Make public
+openaaas-admin services update <id> --public
+
+# Make restricted
+openaaas-admin services update <id> --restricted
+```
+
+Supports partial updates — only pass the fields you want to change. `--public` and `--restricted` cannot be used together.
+
+#### Delete a service
+
+Normal delete (with `y/N` confirmation):
+
+```bash
+openaaas-admin services delete <id>
+```
+
+Force delete (cancels active tasks, requires typing the service ID for secondary confirmation):
+
+```bash
+openaaas-admin services delete <id> --force
+```
+
+On successful force delete, the number of cancelled and retained tasks will be displayed.
+
+### User Management
+
+#### List all users
+
+```bash
+openaaas-admin users list
+```
+
+The API Key is automatically masked in output (first 8 chars + `***`).
+
+#### Delete a user
+
+```bash
+openaaas-admin users delete <id>
+```
+
+A confirmation prompt `Are you sure you want to delete user <id>? [y/N]:` is shown. Enter `y` or `yes` to confirm.
+
+### Permission Management
+
+#### List permissions by user
+
+```bash
+openaaas-admin permissions list --user <user_id>
+```
+
+#### List authorized users by service
+
+```bash
+openaaas-admin permissions list --service <service_id>
+```
+
+If the target service is public, a warning will indicate that all users have access by default.
+
+#### Grant permission
+
+```bash
+openaaas-admin permissions grant --user <user_id> --service <service_id>
+```
+
+#### Revoke permission
+
+```bash
+openaaas-admin permissions revoke --user <user_id> --service <service_id>
+```
+
+### Task Statistics
+
+```bash
+openaaas-admin stats
+```
+
+Fetches all tasks and counts them by status. Example output:
+
+```
++-----------+-------+
+| Metric    | Count |
++-----------+-------+
+| Total     |  152  |
+| Pending   |   3   |
+| Running   |   7   |
+| Completed |  128  |
+| Failed    |   9   |
+| Cancelled |   4   |
+| Cancelling|   1   |
++-----------+-------+
+```
+
+## Tech Stack
+
+- Rust 2024 edition
+- `clap` — command line parsing
+- `reqwest` — HTTP client
+- `tokio` — async runtime
+- `serde` / `serde_json` — serialization
+- `toml` — config persistence
+- `tabled` — table output
+- `colored` — colored terminal output
+- `thiserror` — error enums
+- `dirs` — config directory resolution
+- `rpassword` — hidden password input
+- `wiremock` — HTTP test mocking (dev)

--- a/admin-cli/README.md
+++ b/admin-cli/README.md
@@ -1,180 +1,273 @@
-# openaaas-admin
+# OpenAaaS Admin CLI
 
-OpenAaaS Server Admin CLI — A pure command-line, table-oriented administration tool for OpenAaaS Server.
+<p align="right">中文 | <a href="./README.en.md">English</a></p>
 
-## Features
+OpenAaaS Server 的命令行管理工具，面向管理员提供纯命令行、表格化的服务管理、用户管理、权限管理、任务统计和健康检查能力。
 
-- **Service Management**: list, show, create, update, delete (with force), services
-- **User Management**: list users, delete users
-- **Permission Management**: list, grant, revoke user service permissions
-- **Task Statistics**: overview of task counts by status
-- **Health Check**: verify server health and admin API key validity
-- **Configuration**: interactive or param-based config initialization
+## 编译安装
 
-## Requirements
-
-- Rust **1.85+** (required for the 2024 edition)
-
-## Installation
+需要安装 Rust 工具链（1.85+）：
 
 ```bash
 cd admin-cli
 cargo build --release
 ```
 
-The binary will be at `target/release/openaaas-admin`.
+编译产物为 `target/release/openaaas-admin`。
 
-## Security Notice
+## 命令总览
 
-> ⚠️ **Avoid passing `--api-key` directly on the command line** — the value will be saved in your shell history. Prefer one of the following:
-> - Environment variable: `OPENAAAS_API_KEY`
-> - Config file: `openaaas-admin config init`
+```bash
+openaaas-admin [OPTIONS] <COMMAND>
+```
 
-## Configuration
+### 全局选项
 
-Config file location: `~/.config/openaaas-admin/config.toml`
+| 选项 | 说明 |
+|------|------|
+| `--server-url <URL>` | 指定 Server 地址，覆盖配置和环境变量 |
+| `--api-key <KEY>` | 指定 Admin API Key，覆盖配置和环境变量 |
 
-### Initialize config
+### 子命令
 
-Interactive:
+| 命令 | 说明 |
+|------|------|
+| `config init` | 交互式或参数式初始化配置 |
+| `config show` | 查看当前配置 |
+| `health` | 检查 Server 健康状态和 Admin Key 有效性 |
+| `services list` | 列出所有服务 |
+| `services show <id>` | 查看服务详情 |
+| `services create` | 创建服务 |
+| `services update <id>` | 更新服务信息 |
+| `services delete <id>` | 删除服务（含确认保护） |
+| `users list` | 列出所有用户 |
+| `users delete <id>` | 删除用户（含确认保护） |
+| `permissions list` | 按用户或服务查询权限 |
+| `permissions grant` | 为用户授予服务权限 |
+| `permissions revoke` | 撤销用户的服务权限 |
+| `stats` | 查看任务统计概览 |
+
+## 配置说明
+
+配置文件路径：`~/.config/openaaas-admin/config.toml`
+
+### 初始化配置
+
+交互式（推荐，API Key 输入隐藏）：
+
 ```bash
 openaaas-admin config init
 ```
 
-With parameters:
+带参数初始化：
+
 ```bash
 openaaas-admin config init --server-url http://localhost:8080 --api-key ak_admin_xxx
 ```
 
-### Show config
+交互式流程示例：
+
+```bash
+$ openaaas-admin config init
+Enter server URL [http://localhost:8080]:
+Enter admin API key:
+✓ Configuration saved to /home/user/.config/openaaas-admin/config.toml
+```
+
+### 查看配置
 
 ```bash
 openaaas-admin config show
 ```
 
-### Priority
+输出示例：
 
-Configuration is loaded with the following priority (highest first):
+```
++------------+------------------------+
+| Key        | Value                  |
++------------+------------------------+
+| server_url | http://localhost:8080  |
+| api_key    | ak_admin_12***         |
++------------+------------------------+
+```
 
-1. CLI flags: `--server-url`, `--api-key`
-2. Environment variables: `OPENAAAS_SERVER_URL`, `OPENAAAS_API_KEY`
-3. Config file: `~/.config/openaaas-admin/config.toml`
+### 配置优先级
 
-## Commands
+配置项加载优先级（从高到低）：
 
-### Health Check
+1. CLI 参数：`--server-url`、`--api-key`
+2. 环境变量：`OPENAAAS_SERVER_URL`、`OPENAAAS_API_KEY`
+3. 配置文件：`~/.config/openaaas-admin/config.toml`
+
+## 安全提醒
+
+> ⚠️ **避免直接在命令行中传递 `--api-key`** —— 该值会被记录到 Shell 历史中。建议使用以下方式之一：
+> - 环境变量：`OPENAAAS_API_KEY=ak_admin_xxx openaaas-admin ...`
+> - 配置文件：`openaaas-admin config init`
+>
+> 配置文件默认权限为 `0o600`（仅所有者可读写），且 `config show` 输出中的 API Key 会自动脱敏显示。
+
+## 各命令详细用法
+
+### 健康检查
 
 ```bash
 openaaas-admin health
 ```
 
-Checks both the public `/health` endpoint and the admin `/api/v1/admin/users` endpoint.
+同时检查公共 `/health` 接口和受保护的 Admin 接口，验证 Server 连通性与 Admin Key 有效性。
 
-### Services
+输出示例：
 
-List all services:
+```
+Checking server health at http://localhost:8080 ...
+  ● Health: healthy
+  ● Version: 0.9.0
+  ● Timestamp: 2026-06-06T12:00:00Z
+
+Checking admin API key ...
+  ● Admin API key is valid
+
+✓ All checks passed
+```
+
+### 服务管理
+
+#### 列出所有服务
+
 ```bash
 openaaas-admin services list
 ```
 
-Show service details:
+#### 查看服务详情
+
 ```bash
 openaaas-admin services show <id>
 ```
 
-Create a service:
+#### 创建服务
+
 ```bash
-openaaas-admin services create --name "code-agent" --description "Code review agent" --usage "Submit PRs for review" --public
+openaaas-admin services create \
+  --name "code-agent" \
+  --description "代码审查 Agent" \
+  --usage "提交 PR 进行代码审查" \
+  --public
 ```
 
-Update a service:
+- `--public`：公开服务，所有用户默认可访问；不加则为受限服务
+- 创建成功后会输出注册 Token（`registration_token`），供 `agent-core` 注册时使用，请妥善保存
+
+#### 更新服务
+
 ```bash
+# 更新名称和描述
 openaaas-admin services update <id> --name "new-name" --description "new desc"
+
+# 设为公开
 openaaas-admin services update <id> --public
+
+# 设为受限
 openaaas-admin services update <id> --restricted
 ```
 
-Delete a service:
+支持部分更新，仅传入需要修改的字段。`--public` 和 `--restricted` 不能同时使用。
+
+#### 删除服务
+
+普通删除（含 `y/N` 确认）：
+
 ```bash
 openaaas-admin services delete <id>
 ```
 
-Force delete (cancels active tasks):
+强制删除（取消活跃任务，需输入服务 ID 二次确认）：
+
 ```bash
 openaaas-admin services delete <id> --force
 ```
 
-### Users
+强制删除成功后会显示被取消和保留的任务数量。
 
-List all users:
+### 用户管理
+
+#### 列出所有用户
+
 ```bash
 openaaas-admin users list
 ```
 
-Delete a user:
+输出中 API Key 会自动脱敏显示（前 8 位 + `***`）。
+
+#### 删除用户
+
 ```bash
 openaaas-admin users delete <id>
 ```
 
-### Permissions
+删除前会提示 `Are you sure you want to delete user <id>? [y/N]:`，输入 `y` 或 `yes` 确认。
 
-List user's permissions:
+### 权限管理
+
+#### 按用户查询权限
+
 ```bash
 openaaas-admin permissions list --user <user_id>
 ```
 
-Grant permission:
+#### 按服务查询授权用户
+
+```bash
+openaaas-admin permissions list --service <service_id>
+```
+
+如果目标服务为公开服务，会提示所有用户默认拥有访问权限。
+
+#### 授予权限
+
 ```bash
 openaaas-admin permissions grant --user <user_id> --service <service_id>
 ```
 
-Revoke permission:
+#### 撤销权限
+
 ```bash
 openaaas-admin permissions revoke --user <user_id> --service <service_id>
 ```
 
-### Stats
+### 任务统计
 
-Show task statistics:
 ```bash
 openaaas-admin stats
 ```
 
-## Authentication
-
-All admin endpoints require Bearer token authentication. The CLI automatically sends:
+拉取全部任务并按状态统计，输出示例：
 
 ```
-Authorization: Bearer <admin_api_key>
++-----------+-------+
+| Metric    | Count |
++-----------+-------+
+| Total     |  152  |
+| Pending   |   3   |
+| Running   |   7   |
+| Completed |  128  |
+| Failed    |   9   |
+| Cancelled |   4   |
+| Cancelling|   1   |
++-----------+-------+
 ```
 
-## Error Handling
-
-- HTTP 4xx/5xx errors display the server's `message`/`detail`/`error` field
-- Network errors suggest checking `--server-url`
-- All subcommands return non-zero exit codes on failure
-
-## Development
-
-Run tests:
-```bash
-cargo test
-```
-
-Run in debug mode:
-```bash
-cargo run -- --help
-```
-
-## Tech Stack
+## 技术栈
 
 - Rust 2024 edition
-- `clap` — command line parsing
-- `reqwest` — HTTP client
-- `tokio` — async runtime
-- `serde`/`serde_json` — serialization
-- `toml` — config persistence
-- `tabled` — table output
-- `colored` — colored terminal output
-- `thiserror` — error enums
-- `dirs` — config directory resolution
+- `clap` — 命令行解析
+- `reqwest` — HTTP 客户端
+- `tokio` — 异步运行时
+- `serde` / `serde_json` — 序列化
+- `toml` — 配置持久化
+- `tabled` — 表格输出
+- `colored` — 终端彩色输出
+- `thiserror` — 错误枚举
+- `dirs` — 配置目录解析
+- `rpassword` — 隐藏密码输入
+- `wiremock` — HTTP 测试模拟（dev）

--- a/admin-cli/README.md
+++ b/admin-cli/README.md
@@ -1,0 +1,180 @@
+# openaaas-admin
+
+OpenAaaS Server Admin CLI — A pure command-line, table-oriented administration tool for OpenAaaS Server.
+
+## Features
+
+- **Service Management**: list, show, create, update, delete (with force), services
+- **User Management**: list users, delete users
+- **Permission Management**: list, grant, revoke user service permissions
+- **Task Statistics**: overview of task counts by status
+- **Health Check**: verify server health and admin API key validity
+- **Configuration**: interactive or param-based config initialization
+
+## Requirements
+
+- Rust **1.85+** (required for the 2024 edition)
+
+## Installation
+
+```bash
+cd admin-cli
+cargo build --release
+```
+
+The binary will be at `target/release/openaaas-admin`.
+
+## Security Notice
+
+> ⚠️ **Avoid passing `--api-key` directly on the command line** — the value will be saved in your shell history. Prefer one of the following:
+> - Environment variable: `OPENAAAS_API_KEY`
+> - Config file: `openaaas-admin config init`
+
+## Configuration
+
+Config file location: `~/.config/openaaas-admin/config.toml`
+
+### Initialize config
+
+Interactive:
+```bash
+openaaas-admin config init
+```
+
+With parameters:
+```bash
+openaaas-admin config init --server-url http://localhost:8080 --api-key ak_admin_xxx
+```
+
+### Show config
+
+```bash
+openaaas-admin config show
+```
+
+### Priority
+
+Configuration is loaded with the following priority (highest first):
+
+1. CLI flags: `--server-url`, `--api-key`
+2. Environment variables: `OPENAAAS_SERVER_URL`, `OPENAAAS_API_KEY`
+3. Config file: `~/.config/openaaas-admin/config.toml`
+
+## Commands
+
+### Health Check
+
+```bash
+openaaas-admin health
+```
+
+Checks both the public `/health` endpoint and the admin `/api/v1/admin/users` endpoint.
+
+### Services
+
+List all services:
+```bash
+openaaas-admin services list
+```
+
+Show service details:
+```bash
+openaaas-admin services show <id>
+```
+
+Create a service:
+```bash
+openaaas-admin services create --name "code-agent" --description "Code review agent" --usage "Submit PRs for review" --public
+```
+
+Update a service:
+```bash
+openaaas-admin services update <id> --name "new-name" --description "new desc"
+openaaas-admin services update <id> --public
+openaaas-admin services update <id> --restricted
+```
+
+Delete a service:
+```bash
+openaaas-admin services delete <id>
+```
+
+Force delete (cancels active tasks):
+```bash
+openaaas-admin services delete <id> --force
+```
+
+### Users
+
+List all users:
+```bash
+openaaas-admin users list
+```
+
+Delete a user:
+```bash
+openaaas-admin users delete <id>
+```
+
+### Permissions
+
+List user's permissions:
+```bash
+openaaas-admin permissions list --user <user_id>
+```
+
+Grant permission:
+```bash
+openaaas-admin permissions grant --user <user_id> --service <service_id>
+```
+
+Revoke permission:
+```bash
+openaaas-admin permissions revoke --user <user_id> --service <service_id>
+```
+
+### Stats
+
+Show task statistics:
+```bash
+openaaas-admin stats
+```
+
+## Authentication
+
+All admin endpoints require Bearer token authentication. The CLI automatically sends:
+
+```
+Authorization: Bearer <admin_api_key>
+```
+
+## Error Handling
+
+- HTTP 4xx/5xx errors display the server's `message`/`detail`/`error` field
+- Network errors suggest checking `--server-url`
+- All subcommands return non-zero exit codes on failure
+
+## Development
+
+Run tests:
+```bash
+cargo test
+```
+
+Run in debug mode:
+```bash
+cargo run -- --help
+```
+
+## Tech Stack
+
+- Rust 2024 edition
+- `clap` — command line parsing
+- `reqwest` — HTTP client
+- `tokio` — async runtime
+- `serde`/`serde_json` — serialization
+- `toml` — config persistence
+- `tabled` — table output
+- `colored` — colored terminal output
+- `thiserror` — error enums
+- `dirs` — config directory resolution

--- a/admin-cli/src/cli.rs
+++ b/admin-cli/src/cli.rs
@@ -1,0 +1,161 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "openaaas-admin")]
+#[command(about = "OpenAaaS Server Admin CLI")]
+#[command(version)]
+pub struct Cli {
+    /// Override server URL
+    #[arg(long, global = true)]
+    pub server_url: Option<String>,
+
+    /// Override admin API key
+    #[arg(long, global = true)]
+    pub api_key: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Manage configuration
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
+    /// Check server health and admin privileges
+    Health,
+    /// Manage services
+    Services {
+        #[command(subcommand)]
+        command: ServicesCommands,
+    },
+    /// Manage users
+    Users {
+        #[command(subcommand)]
+        command: UsersCommands,
+    },
+    /// Manage permissions
+    Permissions {
+        #[command(subcommand)]
+        command: PermissionsCommands,
+    },
+    /// Show task statistics
+    Stats,
+}
+
+#[derive(Subcommand)]
+pub enum ConfigCommands {
+    /// Initialize configuration interactively or with parameters
+    Init {
+        /// Server URL
+        #[arg(long)]
+        server_url: Option<String>,
+        /// Admin API key
+        #[arg(long)]
+        api_key: Option<String>,
+    },
+    /// Show current configuration
+    Show,
+}
+
+#[derive(Subcommand)]
+pub enum ServicesCommands {
+    /// List all services
+    List,
+    /// Show service details
+    Show {
+        /// Service ID
+        id: String,
+    },
+    /// Create a new service
+    Create {
+        /// Service name
+        #[arg(long)]
+        name: String,
+        /// Service description
+        #[arg(long)]
+        description: String,
+        /// Service usage instructions
+        #[arg(long)]
+        usage: String,
+        /// Make service public (default is restricted)
+        #[arg(long)]
+        public: bool,
+    },
+    /// Update a service
+    Update {
+        /// Service ID
+        id: String,
+        /// New name
+        #[arg(long)]
+        name: Option<String>,
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+        /// New usage instructions
+        #[arg(long)]
+        usage: Option<String>,
+        /// Make service public
+        #[arg(long)]
+        public: bool,
+        /// Make service restricted
+        #[arg(long)]
+        restricted: bool,
+    },
+    /// Delete a service
+    Delete {
+        /// Service ID
+        id: String,
+        /// Force delete even if tasks exist
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UsersCommands {
+    /// List all users
+    List,
+    /// Delete a user
+    Delete {
+        /// User ID
+        id: String,
+    },
+}
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+pub struct ListPermissionsArgs {
+    /// User ID
+    #[arg(long)]
+    pub user: Option<String>,
+    /// Service ID
+    #[arg(long)]
+    pub service: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub enum PermissionsCommands {
+    /// List user's service permissions or service's authorized users
+    List(ListPermissionsArgs),
+    /// Grant permission to a restricted service
+    Grant {
+        /// User ID
+        #[arg(long)]
+        user: String,
+        /// Service ID
+        #[arg(long)]
+        service: String,
+    },
+    /// Revoke permission from a restricted service
+    Revoke {
+        /// User ID
+        #[arg(long)]
+        user: String,
+        /// Service ID
+        #[arg(long)]
+        service: String,
+    },
+}

--- a/admin-cli/src/client.rs
+++ b/admin-cli/src/client.rs
@@ -1,0 +1,922 @@
+use std::time::Duration;
+
+use reqwest::{Client, Response};
+
+use crate::config::Config;
+use crate::error::{AppError, Result};
+use crate::models::*;
+
+pub struct ApiClient {
+    client: Client,
+    base_url: String,
+    api_key: String,
+}
+
+impl ApiClient {
+    pub fn new(config: &Config) -> Result<Self> {
+        let base_url = config.require_server_url()?;
+        let api_key = config.require_api_key()?;
+        Ok(Self {
+            client: Client::builder().timeout(Duration::from_secs(30)).build()?,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+        })
+    }
+
+    pub fn new_without_auth(config: &Config) -> Result<Self> {
+        let base_url = config.require_server_url()?;
+        Ok(Self {
+            client: Client::builder().timeout(Duration::from_secs(30)).build()?,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: String::new(),
+        })
+    }
+
+    fn auth_header(&self) -> Option<(&str, String)> {
+        if self.api_key.is_empty() {
+            None
+        } else {
+            Some(("Authorization", format!("Bearer {}", self.api_key)))
+        }
+    }
+
+    async fn handle_response<T: serde::de::DeserializeOwned>(res: Response) -> Result<T> {
+        let status = res.status();
+        if status.is_success() {
+            let body = res.json::<T>().await?;
+            Ok(body)
+        } else {
+            let body_text = res.text().await.unwrap_or_default();
+            Err(AppError::extract_api_error(status.as_u16(), &body_text))
+        }
+    }
+
+    async fn handle_empty_response(res: Response) -> Result<()> {
+        let status = res.status();
+        if status.is_success() {
+            Ok(())
+        } else {
+            let body_text = res.text().await.unwrap_or_default();
+            Err(AppError::extract_api_error(status.as_u16(), &body_text))
+        }
+    }
+
+    // ========================================================================
+    // Health (no auth)
+    // ========================================================================
+
+    pub async fn health_check(&self) -> Result<HealthResponse> {
+        let url = format!("{}/health", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        Self::handle_response(res).await
+    }
+
+    // ========================================================================
+    // Services
+    // ========================================================================
+
+    pub async fn list_services(&self) -> Result<Vec<ServiceListItem>> {
+        let url = format!("{}/api/v1/services", self.base_url);
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn get_service(&self, id: &str) -> Result<ServiceResponse> {
+        let url = format!("{}/api/v1/services/{}", self.base_url, id);
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn get_service_usage(&self, id: &str) -> Result<ServiceUsageResponse> {
+        let url = format!("{}/api/v1/client/services/{}/usage", self.base_url, id);
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn create_service(
+        &self,
+        req_body: &CreateServiceRequest,
+    ) -> Result<CreateServiceResponse> {
+        let url = format!("{}/api/v1/services", self.base_url);
+        let mut req = self.client.post(&url).json(req_body);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn update_service(
+        &self,
+        id: &str,
+        req_body: &UpdateServiceRequest,
+    ) -> Result<ServiceResponse> {
+        let url = format!("{}/api/v1/services/{}", self.base_url, id);
+        let mut req = self.client.put(&url).json(req_body);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn delete_service(&self, id: &str, force: bool) -> Result<DeleteServiceResponse> {
+        let url = format!("{}/api/v1/services/{}", self.base_url, id);
+        let mut req = self.client.delete(&url);
+        if force {
+            req = req.query(&[("force", "true")]);
+        }
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    // ========================================================================
+    // Users
+    // ========================================================================
+
+    pub async fn list_users(&self) -> Result<Vec<UserResponse>> {
+        let url = format!("{}/api/v1/admin/users", self.base_url);
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn delete_user(&self, id: &str) -> Result<()> {
+        let url = format!("{}/api/v1/admin/users/{}", self.base_url, id);
+        let mut req = self.client.delete(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_empty_response(res).await
+    }
+
+    // ========================================================================
+    // Permissions
+    // ========================================================================
+
+    pub async fn list_service_users(&self, service_id: &str) -> Result<ServiceUsersList> {
+        let url = format!(
+            "{}/api/v1/admin/services/{}/users",
+            self.base_url, service_id
+        );
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    pub async fn list_user_permissions(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserPermissionResponse>> {
+        let url = format!(
+            "{}/api/v1/admin/users/{}/permissions",
+            self.base_url, user_id
+        );
+        let mut req = self.client.get(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+
+    /// Note: This endpoint uses `/api/v1/client/...` prefix by design,
+    /// matching the Python SDK `OaaSClient.grant_service_permission` behavior.
+    pub async fn grant_permission(&self, service_id: &str, user_id: &str) -> Result<()> {
+        let url = format!(
+            "{}/api/v1/client/services/{}/grant",
+            self.base_url, service_id
+        );
+        let body = GrantPermissionRequest {
+            user_id: user_id.to_string(),
+        };
+        let mut req = self.client.post(&url).json(&body);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_empty_response(res).await
+    }
+
+    pub async fn revoke_permission(&self, service_id: &str, user_id: &str) -> Result<()> {
+        let url = format!(
+            "{}/api/v1/admin/services/{}/users/{}",
+            self.base_url, service_id, user_id
+        );
+        let mut req = self.client.delete(&url);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_empty_response(res).await
+    }
+
+    pub async fn check_admin(&self) -> Result<()> {
+        let url = format!("{}/api/v1/admin/users", self.base_url);
+        let mut req = self.client.get(&url).query(&[("limit", "1")]);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        let status = res.status();
+        if status.is_success() {
+            Ok(())
+        } else {
+            let body_text = res.text().await.unwrap_or_default();
+            Err(AppError::extract_api_error(status.as_u16(), &body_text))
+        }
+    }
+
+    // ========================================================================
+    // Tasks / Stats
+    // ========================================================================
+
+    pub async fn list_admin_tasks(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<AdminTaskResponse>> {
+        let url = format!("{}/api/v1/admin/tasks", self.base_url);
+        let mut req = self
+            .client
+            .get(&url)
+            .query(&[("limit", limit.to_string()), ("offset", offset.to_string())]);
+        if let Some((k, v)) = self.auth_header() {
+            req = req.header(k, v);
+        }
+        let res = req.send().await?;
+        Self::handle_response(res).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_json, header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config(url: &str) -> Config {
+        Config {
+            server_url: Some(url.to_string()),
+            api_key: Some("test_key".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "version": "0.1.0",
+                "timestamp": "2024-01-01T00:00:00Z"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new_without_auth(&config).unwrap();
+        let health = client.health_check().await.unwrap();
+        assert_eq!(health.status, "ok");
+    }
+
+    #[tokio::test]
+    async fn test_list_services() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "svc-1",
+                    "name": "Test Service",
+                    "description": "Desc",
+                    "agent_status": "online",
+                    "registration_status": "active",
+                    "access_type": "public",
+                    "has_permission": true
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let services = client.list_services().await.unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].id, "svc-1");
+    }
+
+    #[tokio::test]
+    async fn test_api_error_extraction() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "message": "bad request"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.list_services().await.unwrap_err();
+        match err {
+            AppError::ApiError { status, message } => {
+                assert_eq!(status, 400);
+                assert_eq!(message, "bad request");
+            }
+            _ => panic!("Expected ApiError, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_service() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .and(body_json(serde_json::json!({
+                "name": "New Service",
+                "description": "A new service",
+                "usage": "Usage info",
+                "is_public": true
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "svc-new",
+                "name": "New Service",
+                "description": "A new service",
+                "usage": "Usage info",
+                "registration_status": "pending",
+                "registration_token": "rt_abc123",
+                "created_at": "2024-01-01T00:00:00Z"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let req = CreateServiceRequest {
+            name: "New Service".to_string(),
+            description: "A new service".to_string(),
+            usage: "Usage info".to_string(),
+            is_public: true,
+        };
+        let resp = client.create_service(&req).await.unwrap();
+        assert_eq!(resp.id, "svc-new");
+        assert_eq!(resp.registration_token, "rt_abc123");
+    }
+
+    #[tokio::test]
+    async fn test_delete_user_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/admin/users/u1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "不能删除当前登录的管理员账户"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.delete_user("u1").await.unwrap_err();
+        match err {
+            AppError::ApiError { status, message } => {
+                assert_eq!(status, 403);
+                assert!(message.contains("不能删除"));
+            }
+            _ => panic!("Expected ApiError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_service() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services/svc-1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "svc-1",
+                "name": "Test Service",
+                "description": "Desc",
+                "usage": "Usage info",
+                "agent_status": "online",
+                "registration_status": "active",
+                "agent_capacity": 10,
+                "agent_current_load": 2,
+                "is_public": true,
+                "created_at": "2024-01-01T00:00:00Z"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let svc = client.get_service("svc-1").await.unwrap();
+        assert_eq!(svc.id, "svc-1");
+        assert_eq!(svc.name, "Test Service");
+        assert_eq!(svc.agent_capacity, 10);
+        assert_eq!(svc.agent_current_load, 2);
+        assert!(svc.is_public);
+    }
+
+    #[tokio::test]
+    async fn test_update_service() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/services/svc-1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .and(body_json(serde_json::json!({
+                "name": "Updated Service",
+                "description": "Updated desc"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "svc-1",
+                "name": "Updated Service",
+                "description": "Updated desc",
+                "usage": "Usage info",
+                "agent_status": "online",
+                "registration_status": "active",
+                "agent_capacity": 10,
+                "agent_current_load": 2,
+                "is_public": true,
+                "created_at": "2024-01-01T00:00:00Z"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let req = UpdateServiceRequest {
+            name: Some("Updated Service".to_string()),
+            description: Some("Updated desc".to_string()),
+            usage: None,
+            is_public: None,
+        };
+        let svc = client.update_service("svc-1", &req).await.unwrap();
+        assert_eq!(svc.name, "Updated Service");
+        assert_eq!(svc.description, "Updated desc");
+    }
+
+    #[tokio::test]
+    async fn test_delete_service() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/services/svc-1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "deleted": true,
+                "tasks_cancelled": 0,
+                "tasks_retained": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let resp = client.delete_service("svc-1", false).await.unwrap();
+        assert!(resp.deleted);
+        assert_eq!(resp.tasks_cancelled, 0);
+        assert_eq!(resp.tasks_retained, 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_service_force() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/services/svc-1"))
+            .and(query_param("force", "true"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "deleted": true,
+                "tasks_cancelled": 3,
+                "tasks_retained": 1
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let resp = client.delete_service("svc-1", true).await.unwrap();
+        assert!(resp.deleted);
+        assert_eq!(resp.tasks_cancelled, 3);
+        assert_eq!(resp.tasks_retained, 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_users() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/users"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "u1",
+                    "name": "Alice",
+                    "api_key": "ak_abc",
+                    "role": "admin",
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let users = client.list_users().await.unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].id, "u1");
+        assert_eq!(users[0].name, "Alice");
+        assert_eq!(users[0].role, "admin");
+    }
+
+    #[tokio::test]
+    async fn test_delete_user() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/admin/users/u1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        client.delete_user("u1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_check_admin() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/users"))
+            .and(query_param("limit", "1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                { "id": "u1" }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        client.check_admin().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_check_admin_failure() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/users"))
+            .and(query_param("limit", "1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "Forbidden"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.check_admin().await.unwrap_err();
+        match err {
+            AppError::ApiError { status, message } => {
+                assert_eq!(status, 403);
+                assert_eq!(message, "Forbidden");
+            }
+            _ => panic!("Expected ApiError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grant_permission() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/client/services/svc-1/grant"))
+            .and(header("Authorization", "Bearer test_key"))
+            .and(body_json(serde_json::json!({
+                "user_id": "u1"
+            })))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        client.grant_permission("svc-1", "u1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_revoke_permission() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/admin/services/svc-1/users/u1"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        client.revoke_permission("svc-1", "u1").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_user_permissions() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/users/u1/permissions"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "service_id": "svc-1",
+                    "service_name": "Test Service",
+                    "granted_at": "2024-01-01T00:00:00Z"
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let perms = client.list_user_permissions("u1").await.unwrap();
+        assert_eq!(perms.len(), 1);
+        assert_eq!(perms[0].service_id, "svc-1");
+        assert_eq!(perms[0].service_name, "Test Service");
+    }
+
+    #[tokio::test]
+    async fn test_list_service_users() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/services/svc-1/users"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "is_public": false,
+                "users": [
+                    {
+                        "user_id": "u1",
+                        "user_name": "Alice",
+                        "role": "user",
+                        "granted_at": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let result = client.list_service_users("svc-1").await.unwrap();
+        assert!(!result.is_public);
+        assert_eq!(result.users.len(), 1);
+        assert_eq!(result.users[0].user_id, "u1");
+        assert_eq!(result.users[0].user_name, Some("Alice".to_string()));
+        assert_eq!(result.users[0].role, "user");
+    }
+
+    #[tokio::test]
+    async fn test_list_service_users_empty() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/services/svc-1/users"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "is_public": false,
+                "users": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let result = client.list_service_users("svc-1").await.unwrap();
+        assert!(!result.is_public);
+        assert!(result.users.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_service_users_not_found() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/services/svc-99/users"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "Service not found"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.list_service_users("svc-99").await.unwrap_err();
+        match err {
+            AppError::ApiError { status, message } => {
+                assert_eq!(status, 404);
+                assert_eq!(message, "Service not found");
+            }
+            _ => panic!("Expected ApiError, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_admin_tasks() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/tasks"))
+            .and(query_param("limit", "10"))
+            .and(query_param("offset", "0"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "task-1",
+                    "user_id": "u1",
+                    "user_name": "Alice",
+                    "service_id": "svc-1",
+                    "status": "running",
+                    "input": null,
+                    "output": null,
+                    "error_message": null,
+                    "session_id": "sess-1",
+                    "retry_count": 0,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "assigned_at": null,
+                    "started_at": null,
+                    "completed_at": null
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let tasks = client.list_admin_tasks(10, 0).await.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "task-1");
+        assert_eq!(tasks[0].status, crate::models::TaskStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn test_list_services_empty() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let services = client.list_services().await.unwrap();
+        assert!(services.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_users_empty() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/users"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let users = client.list_users().await.unwrap();
+        assert!(users.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_server_error_500() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "message": "internal server error"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.list_services().await.unwrap_err();
+        match err {
+            AppError::ApiError { status, .. } => {
+                assert_eq!(status, 500);
+            }
+            _ => panic!("Expected ApiError, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_malformed_json() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/services"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.list_services().await.unwrap_err();
+        match err {
+            AppError::Parse(_) | AppError::Network(_) => {}
+            _ => panic!("Expected Parse or Network error, got {:?}", err),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_service_usage() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/client/services/svc-1/usage"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "svc-1",
+                "name": "Test Service",
+                "usage": "Usage info"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let usage = client.get_service_usage("svc-1").await.unwrap();
+        assert_eq!(usage.id, "svc-1");
+        assert_eq!(usage.name, "Test Service");
+        assert_eq!(usage.usage, "Usage info");
+    }
+
+    #[tokio::test]
+    async fn test_list_admin_tasks_empty() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/admin/tasks"))
+            .and(query_param("limit", "10"))
+            .and(query_param("offset", "0"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let tasks = client.list_admin_tasks(10, 0).await.unwrap();
+        assert!(tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete_user_not_found() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/admin/users/u99"))
+            .and(header("Authorization", "Bearer test_key"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "User not found"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = test_config(&mock_server.uri());
+        let client = ApiClient::new(&config).unwrap();
+        let err = client.delete_user("u99").await.unwrap_err();
+        match err {
+            AppError::ApiError { status, message } => {
+                assert_eq!(status, 404);
+                assert_eq!(message, "User not found");
+            }
+            _ => panic!("Expected ApiError, got {:?}", err),
+        }
+    }
+}

--- a/admin-cli/src/commands/config.rs
+++ b/admin-cli/src/commands/config.rs
@@ -1,0 +1,65 @@
+use crate::config::Config;
+use crate::error::Result;
+use crate::table::{build_table_from_rows, print_error, print_success};
+
+pub async fn init(server_url: Option<String>, api_key: Option<String>) -> Result<()> {
+    let mut config = Config::load().unwrap_or_default();
+
+    // Interactive or param-based init
+    let url = if let Some(u) = server_url {
+        u
+    } else {
+        loop {
+            println!("Enter server URL [http://localhost:8080]: ");
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            let trimmed = input.trim();
+            let url = if trimmed.is_empty() {
+                "http://localhost:8080".to_string()
+            } else {
+                trimmed.to_string()
+            };
+            if url.starts_with("http://") || url.starts_with("https://") {
+                break url;
+            }
+            print_error("Invalid URL. Must start with http:// or https://");
+        }
+    };
+
+    let key = if let Some(k) = api_key {
+        k
+    } else {
+        rpassword::prompt_password("Enter admin API key: ")?
+    };
+
+    if key.is_empty() {
+        return Err(crate::error::AppError::Config(
+            "API key cannot be empty".to_string(),
+        ));
+    }
+
+    config.server_url = Some(url);
+    config.api_key = Some(key);
+    config.save()?;
+    print_success(&format!(
+        "Configuration saved to {}",
+        Config::config_path().display()
+    ));
+    Ok(())
+}
+
+pub fn show() -> Result<()> {
+    let config = Config::load()?;
+    let rows = vec![
+        vec![
+            "server_url".to_string(),
+            config.server_url.clone().unwrap_or_default(),
+        ],
+        vec!["api_key".to_string(), config.masked_api_key()],
+    ];
+    println!(
+        "{}",
+        build_table_from_rows(vec!["Key".to_string(), "Value".to_string()], rows)
+    );
+    Ok(())
+}

--- a/admin-cli/src/commands/health.rs
+++ b/admin-cli/src/commands/health.rs
@@ -1,0 +1,48 @@
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::error::Result;
+use colored::Colorize;
+
+pub async fn check(cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let server_url = config.require_server_url()?;
+
+    // 1. Check public health endpoint
+    println!("Checking server health at {} ...", server_url);
+    let client = ApiClient::new_without_auth(&config)?;
+    match client.health_check().await {
+        Ok(health) => {
+            println!("  {} Health: {}", "●".green(), health.status.green().bold());
+            println!("  {} Version: {}", "●".green(), health.version);
+            println!("  {} Timestamp: {}", "●".green(), health.timestamp);
+        }
+        Err(e) => {
+            println!(
+                "  {} Health check failed: {}",
+                "●".red(),
+                e.to_string().red()
+            );
+            return Err(e);
+        }
+    }
+
+    // 2. Check admin privileges
+    println!("\nChecking admin API key ...");
+    let auth_client = ApiClient::new(&config)?;
+    match auth_client.check_admin().await {
+        Ok(()) => {
+            println!("  {} Admin API key is valid", "●".green());
+        }
+        Err(e) => {
+            println!(
+                "  {} Admin check failed: {}",
+                "●".red(),
+                e.to_string().red()
+            );
+            return Err(e);
+        }
+    }
+
+    println!("\n{}", "✓ All checks passed".green().bold());
+    Ok(())
+}

--- a/admin-cli/src/commands/mod.rs
+++ b/admin-cli/src/commands/mod.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod health;
+pub mod permissions;
+pub mod services;
+pub mod stats;
+pub mod users;

--- a/admin-cli/src/commands/permissions.rs
+++ b/admin-cli/src/commands/permissions.rs
@@ -1,0 +1,124 @@
+use tabled::Tabled;
+
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::error::{AppError, Result};
+use crate::table::{build_table, print_success, print_warning};
+
+#[derive(Tabled)]
+struct PermissionRow {
+    #[tabled(rename = "Service ID")]
+    service_id: String,
+    #[tabled(rename = "Service Name")]
+    service_name: String,
+    #[tabled(rename = "Granted At")]
+    granted_at: String,
+}
+
+#[derive(Tabled)]
+struct ServiceUserRow {
+    #[tabled(rename = "User ID")]
+    user_id: String,
+    #[tabled(rename = "User Name")]
+    user_name: String,
+    #[tabled(rename = "Role")]
+    role: String,
+    #[tabled(rename = "Granted At")]
+    granted_at: String,
+}
+
+pub async fn list(
+    user_id: Option<&str>,
+    service_id: Option<&str>,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    match (user_id, service_id) {
+        (Some(user_id), _) => {
+            let permissions = client.list_user_permissions(user_id).await?;
+
+            let rows: Vec<PermissionRow> = permissions
+                .into_iter()
+                .map(|p| PermissionRow {
+                    service_id: p.service_id,
+                    service_name: p.service_name,
+                    granted_at: p.granted_at.to_rfc3339(),
+                })
+                .collect();
+
+            println!("{}", build_table(&rows));
+        }
+        (None, Some(service_id)) => {
+            let result = client.list_service_users(service_id).await?;
+
+            if result.is_public {
+                print_warning(&format!(
+                    "Service '{}' is public. All users have access by default.",
+                    service_id
+                ));
+                if result.users.is_empty() {
+                    println!("No explicit permission records (all users have access by default).");
+                }
+            } else if result.users.is_empty() {
+                println!("No explicit permissions granted.");
+            }
+
+            if !result.users.is_empty() {
+                let rows: Vec<ServiceUserRow> = result
+                    .users
+                    .into_iter()
+                    .map(|u| ServiceUserRow {
+                        user_id: u.user_id,
+                        user_name: u.user_name.as_deref().unwrap_or("-").to_string(),
+                        role: u.role,
+                        granted_at: u.granted_at.to_rfc3339(),
+                    })
+                    .collect();
+
+                println!("{}", build_table(&rows));
+            }
+        }
+        (None, None) => {
+            return Err(AppError::Other(
+                "Must specify either --user or --service".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn grant(
+    user_id: &str,
+    service_id: &str,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+    client.grant_permission(service_id, user_id).await?;
+    print_success(&format!(
+        "Granted user {} permission to service {}",
+        user_id, service_id
+    ));
+    Ok(())
+}
+
+pub async fn revoke(
+    user_id: &str,
+    service_id: &str,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+    client.revoke_permission(service_id, user_id).await?;
+    print_success(&format!(
+        "Revoked user {} permission to service {}",
+        user_id, service_id
+    ));
+    Ok(())
+}

--- a/admin-cli/src/commands/services.rs
+++ b/admin-cli/src/commands/services.rs
@@ -1,0 +1,242 @@
+use std::io::Write;
+
+use tabled::Tabled;
+
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::error::Result;
+use crate::models::{CreateServiceRequest, UpdateServiceRequest};
+use crate::table::{build_table, print_error, print_highlight, print_success, print_warning};
+
+#[derive(Tabled)]
+struct ServiceListRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Agent Status")]
+    agent_status: String,
+    #[tabled(rename = "Registration")]
+    registration_status: String,
+    #[tabled(rename = "Access")]
+    access_type: String,
+}
+
+#[derive(Tabled)]
+struct ServiceDetailRow {
+    #[tabled(rename = "Field")]
+    field: String,
+    #[tabled(rename = "Value")]
+    value: String,
+}
+
+pub async fn list(cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+    let services = client.list_services().await?;
+
+    let rows: Vec<ServiceListRow> = services
+        .into_iter()
+        .map(|s| ServiceListRow {
+            id: s.id,
+            name: s.name,
+            agent_status: s.agent_status,
+            registration_status: s.registration_status,
+            access_type: s.access_type,
+        })
+        .collect();
+
+    println!("{}", build_table(&rows));
+    Ok(())
+}
+
+pub async fn show(id: &str, cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    let service = client.get_service(id).await?;
+    let usage = client.get_service_usage(id).await;
+
+    let mut rows = vec![
+        ServiceDetailRow {
+            field: "ID".to_string(),
+            value: service.id,
+        },
+        ServiceDetailRow {
+            field: "Name".to_string(),
+            value: service.name,
+        },
+        ServiceDetailRow {
+            field: "Description".to_string(),
+            value: service.description,
+        },
+        ServiceDetailRow {
+            field: "Agent Status".to_string(),
+            value: service.agent_status,
+        },
+        ServiceDetailRow {
+            field: "Registration".to_string(),
+            value: service.registration_status,
+        },
+        ServiceDetailRow {
+            field: "Capacity".to_string(),
+            value: format!("{}/{}", service.agent_current_load, service.agent_capacity),
+        },
+        ServiceDetailRow {
+            field: "Public".to_string(),
+            value: if service.is_public {
+                "Yes".to_string()
+            } else {
+                "No".to_string()
+            },
+        },
+        ServiceDetailRow {
+            field: "Created At".to_string(),
+            value: service.created_at.to_rfc3339(),
+        },
+    ];
+
+    if let Ok(u) = usage {
+        rows.push(ServiceDetailRow {
+            field: "Usage".to_string(),
+            value: u.usage,
+        });
+    }
+
+    println!("{}", build_table(&rows));
+    Ok(())
+}
+
+pub async fn create(
+    name: String,
+    description: String,
+    usage: String,
+    public: bool,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    let req = CreateServiceRequest {
+        name,
+        description,
+        usage,
+        is_public: public,
+    };
+
+    let resp = client.create_service(&req).await?;
+
+    let rows = vec![
+        ServiceDetailRow {
+            field: "ID".to_string(),
+            value: resp.id.clone(),
+        },
+        ServiceDetailRow {
+            field: "Name".to_string(),
+            value: resp.name,
+        },
+        ServiceDetailRow {
+            field: "Registration Status".to_string(),
+            value: resp.registration_status,
+        },
+        ServiceDetailRow {
+            field: "Created At".to_string(),
+            value: resp.created_at.to_rfc3339(),
+        },
+    ];
+    println!("{}", build_table(&rows));
+    println!();
+    print_highlight(
+        "Registration Token (save this for agent-core)",
+        &resp.registration_token,
+    );
+
+    Ok(())
+}
+
+pub async fn update(
+    id: &str,
+    name: Option<String>,
+    description: Option<String>,
+    usage: Option<String>,
+    access: Option<bool>,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    let req = UpdateServiceRequest {
+        name,
+        description,
+        usage,
+        is_public: access,
+    };
+
+    if req.name.is_none()
+        && req.description.is_none()
+        && req.usage.is_none()
+        && req.is_public.is_none()
+    {
+        print_warning("No fields to update");
+        return Ok(());
+    }
+
+    let _resp = client.update_service(id, &req).await?;
+    print_success(&format!("Service {} updated successfully", id));
+    Ok(())
+}
+
+pub async fn delete(
+    id: &str,
+    force: bool,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    if force {
+        // Secondary confirmation for force delete
+        print_warning(&format!(
+            "You are about to FORCE delete service {}. This will cancel all active tasks.",
+            id
+        ));
+        print!("Type the service ID to confirm [{}]: ", id);
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let trimmed = input.trim();
+        if trimmed != id {
+            print_error("Confirmation failed. Service ID mismatch. Aborting.");
+            return Err(crate::error::AppError::Cancelled);
+        }
+    } else {
+        // Prompt y/N for normal delete
+        print!("Are you sure you want to delete service {}? [y/N]: ", id);
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let trimmed = input.trim().to_lowercase();
+        if trimmed != "y" && trimmed != "yes" {
+            print_warning("Deletion cancelled");
+            return Ok(());
+        }
+    }
+
+    let resp = client.delete_service(id, force).await?;
+
+    if resp.deleted {
+        if force {
+            print_success(&format!(
+                "Service {} force deleted. {} tasks cancelled, {} tasks retained.",
+                id, resp.tasks_cancelled, resp.tasks_retained
+            ));
+        } else {
+            print_success(&format!("Service {} deleted successfully", id));
+        }
+    }
+
+    Ok(())
+}

--- a/admin-cli/src/commands/stats.rs
+++ b/admin-cli/src/commands/stats.rs
@@ -1,0 +1,91 @@
+use tabled::Tabled;
+
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::error::Result;
+use crate::models::TaskStatus;
+use crate::table::build_table;
+
+#[derive(Tabled)]
+struct StatsRow {
+    #[tabled(rename = "Metric")]
+    metric: String,
+    #[tabled(rename = "Count")]
+    count: usize,
+}
+
+pub async fn show(cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    let mut all_tasks = Vec::new();
+    let mut offset = 0i64;
+    loop {
+        let tasks = client.list_admin_tasks(100, offset).await?;
+        if tasks.is_empty() {
+            break;
+        }
+        all_tasks.extend(tasks);
+        offset += 100;
+    }
+
+    let total = all_tasks.len();
+    let pending = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Pending)
+        .count();
+    let running = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Running)
+        .count();
+    let completed = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Completed)
+        .count();
+    let failed = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Failed)
+        .count();
+    let cancelled = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Cancelled)
+        .count();
+    let cancelling = all_tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Cancelling)
+        .count();
+
+    let rows = vec![
+        StatsRow {
+            metric: "Total".to_string(),
+            count: total,
+        },
+        StatsRow {
+            metric: "Pending".to_string(),
+            count: pending,
+        },
+        StatsRow {
+            metric: "Running".to_string(),
+            count: running,
+        },
+        StatsRow {
+            metric: "Completed".to_string(),
+            count: completed,
+        },
+        StatsRow {
+            metric: "Failed".to_string(),
+            count: failed,
+        },
+        StatsRow {
+            metric: "Cancelled".to_string(),
+            count: cancelled,
+        },
+        StatsRow {
+            metric: "Cancelling".to_string(),
+            count: cancelling,
+        },
+    ];
+
+    println!("{}", build_table(&rows));
+    Ok(())
+}

--- a/admin-cli/src/commands/users.rs
+++ b/admin-cli/src/commands/users.rs
@@ -1,0 +1,73 @@
+use std::io::Write;
+
+use tabled::Tabled;
+
+use crate::client::ApiClient;
+use crate::config::Config;
+use crate::error::Result;
+use crate::table::{build_table, print_success, print_warning};
+
+#[derive(Tabled)]
+struct UserListRow {
+    #[tabled(rename = "ID")]
+    id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Role")]
+    role: String,
+    #[tabled(rename = "API Key")]
+    api_key: String,
+    #[tabled(rename = "Created At")]
+    created_at: String,
+}
+
+pub async fn list(cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+    let users = client.list_users().await?;
+
+    let rows: Vec<UserListRow> = users
+        .into_iter()
+        .map(|u| UserListRow {
+            id: u.id,
+            name: u.name,
+            role: u.role,
+            api_key: mask_api_key(&u.api_key),
+            created_at: u.created_at,
+        })
+        .collect();
+
+    println!("{}", build_table(&rows));
+    Ok(())
+}
+
+pub async fn delete(
+    id: &str,
+    cli_server_url: Option<&str>,
+    cli_api_key: Option<&str>,
+) -> Result<()> {
+    let config = Config::effective(cli_server_url, cli_api_key)?;
+    let client = ApiClient::new(&config)?;
+
+    print!("Are you sure you want to delete user {}? [y/N]: ", id);
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    let trimmed = input.trim().to_lowercase();
+    if trimmed != "y" && trimmed != "yes" {
+        print_warning("Cancelled.");
+        return Ok(());
+    }
+
+    client.delete_user(id).await?;
+    print_success(&format!("User {} deleted successfully", id));
+    Ok(())
+}
+
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 8 {
+        format!("{}***", &key[..8])
+    } else {
+        key.to_string()
+    }
+}

--- a/admin-cli/src/config.rs
+++ b/admin-cli/src/config.rs
@@ -1,0 +1,175 @@
+use std::fs::Permissions;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Config {
+    pub server_url: Option<String>,
+    pub api_key: Option<String>,
+}
+
+impl Config {
+    pub fn config_dir() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("openaaas-admin")
+    }
+
+    pub fn config_path() -> PathBuf {
+        Self::config_dir().join("config.toml")
+    }
+
+    pub fn load() -> Result<Self> {
+        let path = Self::config_path();
+        if !path.exists() {
+            return Err(AppError::ConfigNotFound);
+        }
+        let content = std::fs::read_to_string(&path)?;
+        let config: Config = toml::from_str(&content)?;
+        Ok(config)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let dir = Self::config_dir();
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)?;
+        }
+        let path = dir.join("config.toml");
+        let content = toml::to_string_pretty(self)?;
+        std::fs::write(&path, content)?;
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&path, Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    /// Build effective config with priority:
+    /// CLI args > Environment variables > Config file
+    pub fn effective(cli_server_url: Option<&str>, cli_api_key: Option<&str>) -> Result<Self> {
+        // Start with config file (or empty)
+        let mut config = Self::load().unwrap_or_default();
+
+        // Override with environment variables
+        if let Ok(url) = std::env::var("OPENAAAS_SERVER_URL") {
+            config.server_url = Some(url);
+        }
+        if let Ok(key) = std::env::var("OPENAAAS_API_KEY") {
+            config.api_key = Some(key);
+        }
+
+        // Override with CLI args
+        if let Some(url) = cli_server_url {
+            config.server_url = Some(url.to_string());
+        }
+        if let Some(key) = cli_api_key {
+            config.api_key = Some(key.to_string());
+        }
+
+        Ok(config)
+    }
+
+    pub fn require_server_url(&self) -> Result<String> {
+        self.server_url.clone().ok_or_else(|| {
+            AppError::Config(
+                "Server URL not configured. Use --server-url or run `config init`.".to_string(),
+            )
+        })
+    }
+
+    pub fn require_api_key(&self) -> Result<String> {
+        self.api_key.clone().ok_or_else(|| {
+            AppError::Config(
+                "API key not configured. Use --api-key or run `config init`.".to_string(),
+            )
+        })
+    }
+
+    pub fn masked_api_key(&self) -> String {
+        match &self.api_key {
+            Some(key) if key.len() > 8 => format!("{}***", &key[..8]),
+            Some(key) => key.clone(),
+            None => "(not set)".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_parse() {
+        let toml = r#"
+server_url = "http://localhost:8080"
+api_key = "ak_admin_12345678"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.server_url, Some("http://localhost:8080".to_string()));
+        assert_eq!(config.api_key, Some("ak_admin_12345678".to_string()));
+    }
+
+    #[test]
+    fn test_config_default() {
+        let config = Config::default();
+        assert!(config.server_url.is_none());
+        assert!(config.api_key.is_none());
+    }
+
+    #[test]
+    fn test_masked_api_key() {
+        let config = Config {
+            server_url: None,
+            api_key: Some("ak_admin_1234567890".to_string()),
+        };
+        assert_eq!(config.masked_api_key(), "ak_admin***");
+
+        let config_short = Config {
+            server_url: None,
+            api_key: Some("short".to_string()),
+        };
+        assert_eq!(config_short.masked_api_key(), "short");
+
+        let config_none = Config::default();
+        assert_eq!(config_none.masked_api_key(), "(not set)");
+    }
+
+    #[test]
+    fn test_effective_priority() {
+        // Set env var temporarily
+        unsafe {
+            std::env::set_var("OPENAAAS_SERVER_URL", "http://env:8080");
+            std::env::set_var("OPENAAAS_API_KEY", "env_key");
+        }
+
+        let config = Config::effective(Some("http://cli:8080"), Some("cli_key")).unwrap();
+        assert_eq!(config.server_url, Some("http://cli:8080".to_string()));
+        assert_eq!(config.api_key, Some("cli_key".to_string()));
+
+        let config2 = Config::effective(None, None).unwrap();
+        assert_eq!(config2.server_url, Some("http://env:8080".to_string()));
+        assert_eq!(config2.api_key, Some("env_key".to_string()));
+
+        unsafe {
+            std::env::remove_var("OPENAAAS_SERVER_URL");
+            std::env::remove_var("OPENAAAS_API_KEY");
+        }
+    }
+
+    #[test]
+    fn test_config_serialize_roundtrip() {
+        let config = Config {
+            server_url: Some("http://test:8080".to_string()),
+            api_key: Some("ak_test".to_string()),
+        };
+        let s = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&s).unwrap();
+        assert_eq!(config, parsed);
+    }
+}

--- a/admin-cli/src/error.rs
+++ b/admin-cli/src/error.rs
@@ -1,0 +1,81 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("HTTP error {status}: {message}")]
+    ApiError { status: u16, message: String },
+
+    #[error("Network error: {0}. Please check your --server-url or config.")]
+    Network(#[from] reqwest::Error),
+
+    #[error("Config file not found. Run `openaaas-admin config init` first.")]
+    ConfigNotFound,
+
+    #[error("Config error: {0}")]
+    Config(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Parse error: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("Toml error: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    #[error("Toml serialize error: {0}")]
+    TomlSerialize(#[from] toml::ser::Error),
+
+    #[error("User cancelled operation")]
+    Cancelled,
+
+    #[allow(dead_code)]
+    #[error("Not found")]
+    NotFound,
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, AppError>;
+
+impl AppError {
+    pub fn extract_api_error(status: u16, body: &str) -> Self {
+        let message = if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+            val.get("message")
+                .or_else(|| val.get("detail"))
+                .or_else(|| val.get("error"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(body)
+                .to_string()
+        } else {
+            body.to_string()
+        };
+        AppError::ApiError { status, message }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_error_display() {
+        let err = AppError::ApiError {
+            status: 404,
+            message: "Not found".to_string(),
+        };
+        let display = format!("{}", err);
+        assert!(display.contains("404"));
+        assert!(display.contains("Not found"));
+    }
+
+    #[test]
+    fn test_network_error_display() {
+        // Construct a reqwest::Error without creating a Client or performing I/O
+        let err = reqwest::Proxy::all("://invalid").unwrap_err();
+        let app_err = AppError::Network(err);
+        let display = format!("{}", app_err);
+        assert!(display.contains("Network error"));
+    }
+}

--- a/admin-cli/src/main.rs
+++ b/admin-cli/src/main.rs
@@ -1,0 +1,109 @@
+use clap::Parser;
+
+mod cli;
+mod client;
+mod commands;
+mod config;
+mod error;
+mod models;
+mod table;
+
+use cli::{Cli, Commands, ConfigCommands, PermissionsCommands, ServicesCommands, UsersCommands};
+use error::{AppError, Result};
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        table::print_error(&e.to_string());
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    let server_url = cli.server_url.as_deref();
+    let api_key = cli.api_key.as_deref();
+
+    match cli.command {
+        Commands::Config { command } => match command {
+            ConfigCommands::Init {
+                server_url,
+                api_key,
+            } => commands::config::init(server_url, api_key).await,
+            ConfigCommands::Show => commands::config::show(),
+        },
+        Commands::Health => commands::health::check(server_url, api_key).await,
+        Commands::Services { command } => match command {
+            ServicesCommands::List => commands::services::list(server_url, api_key).await,
+            ServicesCommands::Show { id } => {
+                commands::services::show(&id, server_url, api_key).await
+            }
+            ServicesCommands::Create {
+                name,
+                description,
+                usage,
+                public,
+            } => {
+                commands::services::create(name, description, usage, public, server_url, api_key)
+                    .await
+            }
+            ServicesCommands::Update {
+                id,
+                name,
+                description,
+                usage,
+                public,
+                restricted,
+            } => {
+                if public && restricted {
+                    return Err(AppError::Other(
+                        "Cannot specify both --public and --restricted".to_string(),
+                    ));
+                }
+                let access = if public {
+                    Some(true)
+                } else if restricted {
+                    Some(false)
+                } else {
+                    None
+                };
+                commands::services::update(
+                    &id,
+                    name,
+                    description,
+                    usage,
+                    access,
+                    server_url,
+                    api_key,
+                )
+                .await
+            }
+            ServicesCommands::Delete { id, force } => {
+                commands::services::delete(&id, force, server_url, api_key).await
+            }
+        },
+        Commands::Users { command } => match command {
+            UsersCommands::List => commands::users::list(server_url, api_key).await,
+            UsersCommands::Delete { id } => commands::users::delete(&id, server_url, api_key).await,
+        },
+        Commands::Permissions { command } => match command {
+            PermissionsCommands::List(args) => {
+                commands::permissions::list(
+                    args.user.as_deref(),
+                    args.service.as_deref(),
+                    server_url,
+                    api_key,
+                )
+                .await
+            }
+            PermissionsCommands::Grant { user, service } => {
+                commands::permissions::grant(&user, &service, server_url, api_key).await
+            }
+            PermissionsCommands::Revoke { user, service } => {
+                commands::permissions::revoke(&user, &service, server_url, api_key).await
+            }
+        },
+        Commands::Stats => commands::stats::show(server_url, api_key).await,
+    }
+}

--- a/admin-cli/src/models.rs
+++ b/admin-cli/src/models.rs
@@ -1,0 +1,322 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Service Models
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ServiceListItem {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub agent_status: String,
+    pub registration_status: String,
+    pub agent_last_heartbeat: Option<DateTime<Utc>>,
+    pub access_type: String,
+    pub has_permission: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct ServiceResponse {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub usage: String,
+    pub agent_status: String,
+    pub registration_status: String,
+    pub agent_capacity: i64,
+    pub agent_current_load: i64,
+    pub agent_last_heartbeat: Option<DateTime<Utc>>,
+    pub is_public: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ServiceUsageResponse {
+    pub id: String,
+    pub name: String,
+    pub usage: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateServiceRequest {
+    pub name: String,
+    pub description: String,
+    pub usage: String,
+    #[serde(default = "default_true")]
+    pub is_public: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct CreateServiceResponse {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub usage: String,
+    pub registration_status: String,
+    pub registration_token: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateServiceRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_public: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeleteServiceResponse {
+    pub deleted: bool,
+    pub tasks_cancelled: i64,
+    pub tasks_retained: i64,
+}
+
+#[allow(dead_code)]
+fn default_true() -> bool {
+    true
+}
+
+// ============================================================================
+// User Models
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserResponse {
+    pub id: String,
+    pub name: String,
+    #[serde(skip)]
+    pub api_key: String,
+    pub role: String,
+    pub created_at: String,
+}
+
+// ============================================================================
+// Permission Models
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserPermissionResponse {
+    pub service_id: String,
+    pub service_name: String,
+    pub granted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServiceUser {
+    pub user_id: String,
+    pub user_name: Option<String>,
+    pub role: String,
+    pub granted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServiceUsersList {
+    pub is_public: bool,
+    pub users: Vec<ServiceUser>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GrantPermissionRequest {
+    pub user_id: String,
+}
+
+// ============================================================================
+// Task Models
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct AdminTaskResponse {
+    pub id: String,
+    pub user_id: String,
+    pub user_name: Option<String>,
+    pub service_id: String,
+    pub status: TaskStatus,
+    pub input: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub error_message: Option<String>,
+    pub session_id: String,
+    pub retry_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub assigned_at: Option<DateTime<Utc>>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+// ============================================================================
+// Health Models
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub timestamp: String,
+}
+
+// ============================================================================
+// Generic API Error Response
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct ApiErrorResponse {
+    pub message: Option<String>,
+    pub detail: Option<String>,
+    pub error: Option<String>,
+}
+
+// ============================================================================
+// Task Status
+// ============================================================================
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaskStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    Cancelling,
+    Unknown(String),
+}
+
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TaskStatus::Pending => write!(f, "pending"),
+            TaskStatus::Running => write!(f, "running"),
+            TaskStatus::Completed => write!(f, "completed"),
+            TaskStatus::Failed => write!(f, "failed"),
+            TaskStatus::Cancelled => write!(f, "cancelled"),
+            TaskStatus::Cancelling => write!(f, "cancelling"),
+            TaskStatus::Unknown(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl Serialize for TaskStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "pending" => TaskStatus::Pending,
+            "running" => TaskStatus::Running,
+            "completed" => TaskStatus::Completed,
+            "failed" => TaskStatus::Failed,
+            "cancelled" => TaskStatus::Cancelled,
+            "cancelling" => TaskStatus::Cancelling,
+            _ => TaskStatus::Unknown(s),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_task_status_roundtrip() {
+        let cases = vec![
+            (TaskStatus::Pending, "pending"),
+            (TaskStatus::Running, "running"),
+            (TaskStatus::Completed, "completed"),
+            (TaskStatus::Failed, "failed"),
+            (TaskStatus::Cancelled, "cancelled"),
+            (TaskStatus::Cancelling, "cancelling"),
+        ];
+        for (variant, json_str) in cases {
+            let serialized = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", json_str));
+            let deserialized: TaskStatus = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, variant);
+        }
+    }
+
+    #[test]
+    fn test_task_status_unknown() {
+        let deserialized: TaskStatus = serde_json::from_str("\"retrying\"").unwrap();
+        assert_eq!(deserialized, TaskStatus::Unknown("retrying".to_string()));
+        assert_eq!(deserialized.to_string(), "retrying");
+    }
+
+    #[test]
+    fn test_task_status_display() {
+        assert_eq!(TaskStatus::Pending.to_string(), "pending");
+        assert_eq!(TaskStatus::Running.to_string(), "running");
+        assert_eq!(TaskStatus::Completed.to_string(), "completed");
+        assert_eq!(TaskStatus::Failed.to_string(), "failed");
+        assert_eq!(TaskStatus::Cancelled.to_string(), "cancelled");
+        assert_eq!(TaskStatus::Cancelling.to_string(), "cancelling");
+        assert_eq!(
+            TaskStatus::Unknown("retrying".to_string()).to_string(),
+            "retrying"
+        );
+    }
+
+    #[test]
+    fn test_user_roundtrip() {
+        let user = UserResponse {
+            id: "u1".to_string(),
+            name: "Alice".to_string(),
+            api_key: "ak_abc".to_string(),
+            role: "admin".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&user).unwrap();
+        assert!(!json.contains("ak_abc"));
+        let parsed: UserResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, user.id);
+        assert_eq!(parsed.name, user.name);
+        assert_eq!(parsed.role, user.role);
+        // api_key is skipped on serialize, so it will be empty after deserialize
+        assert_eq!(parsed.api_key, "");
+    }
+
+    #[test]
+    fn test_service_roundtrip() {
+        let svc = ServiceResponse {
+            id: "svc-1".to_string(),
+            name: "Test".to_string(),
+            description: "Desc".to_string(),
+            usage: "Usage".to_string(),
+            agent_status: "online".to_string(),
+            registration_status: "active".to_string(),
+            agent_capacity: 10,
+            agent_current_load: 2,
+            agent_last_heartbeat: None,
+            is_public: true,
+            created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+        };
+        let json = serde_json::to_string(&svc).unwrap();
+        let parsed: ServiceResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, svc.id);
+        assert_eq!(parsed.name, svc.name);
+        assert_eq!(parsed.agent_capacity, svc.agent_capacity);
+        assert!(parsed.is_public);
+    }
+}

--- a/admin-cli/src/table.rs
+++ b/admin-cli/src/table.rs
@@ -1,0 +1,53 @@
+use colored::Colorize;
+use tabled::{
+    Table, Tabled,
+    builder::Builder,
+    settings::{Alignment, Modify, Style, object::Columns},
+};
+
+pub fn build_table<T: Tabled>(data: &[T]) -> String {
+    if data.is_empty() {
+        return "(no data)".dimmed().to_string();
+    }
+    let mut table = Table::new(data);
+    table.with(Style::modern_rounded());
+    table.with(Modify::new(Columns::new(1..)).with(Alignment::left()));
+    table.to_string()
+}
+
+pub fn build_table_from_rows(headers: Vec<String>, rows: Vec<Vec<String>>) -> String {
+    if rows.is_empty() {
+        return "(no data)".dimmed().to_string();
+    }
+    let mut builder = Builder::default();
+    builder.push_record(headers);
+    for row in rows {
+        builder.push_record(row);
+    }
+    let mut table = builder.build();
+    table.with(Style::modern_rounded());
+    table.with(Modify::new(Columns::new(1..)).with(Alignment::left()));
+    // Optionally style first row as header (tabled handles first push_record as header in some styles)
+    table.to_string()
+}
+
+pub fn print_success(msg: &str) {
+    println!("{}", format!("✓ {}", msg).green().bold());
+}
+
+pub fn print_error(msg: &str) {
+    eprintln!("{}", format!("✗ {}", msg).red().bold());
+}
+
+pub fn print_warning(msg: &str) {
+    println!("{}", format!("⚠ {}", msg).yellow());
+}
+
+#[allow(dead_code)]
+pub fn print_info(msg: &str) {
+    println!("{}", format!("ℹ {}", msg).blue());
+}
+
+pub fn print_highlight(label: &str, value: &str) {
+    println!("{}: {}", label.bold(), value.bright_yellow().bold());
+}

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-06
+
+### Added
+- 新增 `GET /api/v1/admin/services/{id}/users` 接口，支持管理员查询某服务的授权用户清单
+- 返回 `is_public` 标志和授权用户列表（user_id, user_name, role, granted_at）
+- 包含集成测试覆盖：服务不存在（404）、公开服务无显式授权、受限服务有授权用户
+
+### Changed
+- 代码格式化（cargo fmt）
+
+### Added
+- 后台清理任务测试补充（仅删除文件，保留数据库记录）
+
 ## [0.8.0] - 2026-06-01
 
 ### Changed
@@ -88,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[0.8.0]: https://github.com/Wolido/OpenAaaS/compare/v0.7.1...v0.8.0
+[0.9.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.8.0...server-v0.9.0
+[0.8.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.7.1...server-v0.8.0
 [0.7.1]: https://github.com/Wolido/OpenAaaS/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Wolido/OpenAaaS/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Wolido/OpenAaaS/compare/v0.6.0...v0.6.1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Add `openaaas-admin`, a Rust-based admin CLI for OpenAaaS Server.

## Features

### Service Management
- `services list` — List all services in table format
- `services show <id>` — Show service details + usage
- `services create` — Create a new service (prints registration_token)
- `services update <id>` — Update service info
- `services delete <id>` — Delete with [y/N] confirmation
- `services delete <id> --force` — Force delete with ID confirmation

### User Management
- `users list` — List all users (API key masked)
- `users delete <id>` — Delete with [y/N] confirmation

### Permission Management
- `permissions list --user <id>` — List user's service permissions
- `permissions list --service <id>` — List service's authorized users
- `permissions grant --user <id> --service <id>`
- `permissions revoke --user <id> --service <id>`

### System
- `config init` — Interactive configuration (API key input hidden via rpassword)
- `config show` — Show current config (API key masked)
- `health` — Check server health and admin API key validity
- `stats` — Task statistics overview

## Technical Stack
- Rust 2024 edition
- clap (derive macros) for CLI parsing
- reqwest + tokio for async HTTP
- tabled + colored for formatted output
- rpassword for secure password input
- dirs for config directory resolution

## Tests
- 39 tests covering config, models, error handling, and all API client methods
- Wiremock-based integration tests for HTTP client

## Security
- Config file permissions set to 0o600 (Unix)
- API key masked in display and logs
- Delete operations require interactive confirmation
- Sensitive args warned against shell history leakage