### PR TITLE
docs(client-app): document contribution attribution check

### DIFF
--- a/client-app/docs/beautification-workflow.md
+++ b/client-app/docs/beautification-workflow.md
@@ -94,6 +94,17 @@ Guidelines:
 
    Then inspect the running app in a browser or Tauri window at a 1280x720 desktop viewport.
 
+6. Confirm GitHub contribution attribution before opening a PR.
+   Make sure the local Git author name and email resolve to the intended GitHub account. Prefer the account's GitHub-provided noreply address when a private email should not be exposed:
+
+   ```bash
+   git config user.name
+   git config user.email
+   git log -1 --format='%an <%ae>'
+   ```
+
+   Avoid generic machine-local author emails such as `user@MacBook.local`; GitHub cannot associate those commits with a contributor profile.
+
 ## Page-Specific Notes
 
 ### Service Marketplace


### PR DESCRIPTION
## Description

### Summary
- Add a PR-time Git author attribution check to the client app beautification workflow.
- Document using a GitHub-linked noreply email to avoid machine-local author emails that cannot be associated with contributor profiles.

### Validation
- npm test
- npm run build

## Checklist

- [x] 代码改动已测试通过
- [x] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
