### PR TITLE
docs(agent-core): improve Windows deployment guide

### DIFF
--- a/agent-core/README.en.md
+++ b/agent-core/README.en.md
@@ -4,6 +4,15 @@
 
 The Agent scheduler for OpenAaaS, responsible for registering with the Server, polling for tasks, and executing tasks in isolated Docker containers.
 
+## Prerequisites
+
+| Platform | Requirements |
+|----------|--------------|
+| All platforms | Rust toolchain 1.85+, Docker |
+| Windows | Docker Desktop (WSL2 backend recommended), Windows 10 19041+ or Windows 11 |
+
+> Windows users unfamiliar with Docker Desktop should refer to the [Windows Deployment](#windows-deployment) section below.
+
 ## Build & Install
 
 Requires Rust toolchain (1.85+) and Docker:
@@ -13,7 +22,7 @@ cd agent-core
 cargo build --release
 ```
 
-The compiled binary is located at `target/release/agent-core`.
+The compiled binary is located at `target/release/agent-core` (Windows: `target/release/agent-core.exe`).
 
 ## Executor Image
 
@@ -63,6 +72,35 @@ agent-core [OPTIONS] <COMMAND>
 | `stop` | Stop the background scheduler |
 | `status` | Check the scheduler status |
 
+## Windows Deployment
+
+### Recommended: Run inside WSL2
+
+Running inside WSL2 Ubuntu provides a native Linux experience:
+
+1. Install [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) and launch an Ubuntu distribution.
+2. In Docker Desktop, enable **Settings → Resources → WSL Integration → Enable integration with my default WSL distro**.
+3. Inside the WSL2 terminal, clone the code and follow the build and run steps below (`cargo build --release`, build the image, etc.).
+
+> **WSL2 path tip:** When editing `config.toml` inside a WSL2 terminal, the `host` path in `[[paths.mounts]]` must use Linux format (e.g. `/mnt/c/Users/xxx/share` or `/home/xxx/share`), not Windows format `C:\...`, or the mount will fail.
+
+### Alternative: Native Windows + Docker Desktop
+
+If WSL2 is not convenient, you can also run directly in PowerShell / CMD:
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+2. In Docker Desktop settings, enable **Use the WSL 2 based engine** (better performance).
+3. Build the executor image (use `./` as the path separator in PowerShell):
+   ```powershell
+   cd executor-example
+   docker build -t open-aaas-executor:latest .
+   ```
+4. For subsequent commands, use `.\agent-core.exe` instead of `./agent-core`.
+
+> On native Windows, the `host` path in `config.toml` can use `C:/path/to/dir` (recommended), `C:\\path\\to\\dir`, or `./relative/path`; Docker Desktop can mount all of them correctly.
+
+---
+
 ## First-Time Setup
 
 ### 1. Initialize Configuration
@@ -70,6 +108,8 @@ agent-core [OPTIONS] <COMMAND>
 ```bash
 ./agent-core init
 ```
+
+> **Windows (native):** `.\agent-core.exe init` (PowerShell recommended; in CMD you can run `agent-core.exe init` directly)
 
 Generates a default `config.toml` in the current directory.
 
@@ -82,6 +122,8 @@ Open `config.toml` and modify the Server address:
 base_url = "http://127.0.0.1:8080"  # Change to your Server address
 ```
 
+> **Windows path tip:** On native Windows, the `host` path in `[[paths.mounts]]` can be `C:/path/to/dir` (recommended), `C:\\path\\to\\dir`, or `./relative/path`; Docker Desktop can mount all of them correctly.
+
 ### 3. Register
 
 Obtain a registration token from the Server, then run:
@@ -89,6 +131,8 @@ Obtain a registration token from the Server, then run:
 ```bash
 ./agent-core register --token rt_xxx --name my-agent
 ```
+
+> **Windows (native):** `.\agent-core.exe register --token rt_xxx --name my-agent`
 
 After successful registration, `service_id` and `api_key` will be automatically written to `config.toml`.
 
@@ -100,6 +144,8 @@ Run in the foreground:
 ./agent-core run
 ```
 
+> **Windows (native):** `.\agent-core.exe run`
+
 On the first startup, it will interactively confirm the Server URL and data directory (default `./data`), then start polling for tasks.
 
 If the current directory already has a complete configuration and is registered, it will start directly without prompting.
@@ -109,6 +155,8 @@ If the current directory already has a complete configuration and is registered,
 ```bash
 ./agent-core run
 ```
+
+> **Windows (native):** `.\agent-core.exe run`
 
 After starting, it polls the Server for tasks, sends heartbeats, and runs tasks through the Docker executor. Press `Ctrl+C` or send `SIGTERM` for graceful shutdown.
 
@@ -127,13 +175,17 @@ If not yet registered and with `--interactive`, it will interactively ask for th
 - Linux/macOS: Runs in the background via `nohup`, logs output to `{data_dir}/agent.log`
 - Windows: Runs in the background via `cmd /C start /B`
 
-After background startup, a pidfile is written for subsequent management and status queries.
+> **Windows (native):** `.\agent-core.exe run-detached`
+
+After background startup, a pidfile is written for subsequent management and status checks.
 
 ## Check Status
 
 ```bash
 ./agent-core status
 ```
+
+> **Windows (native):** `.\agent-core.exe status`
 
 Example output:
 
@@ -161,6 +213,8 @@ Executor configuration:
 ```bash
 ./agent-core stop
 ```
+
+> **Windows (native):** `.\agent-core.exe stop`
 
 Sends `SIGTERM` to the background process, waiting up to 5 seconds for graceful exit; if timed out, sends `SIGKILL` to force termination and cleans up the pidfile.
 

--- a/agent-core/README.md
+++ b/agent-core/README.md
@@ -4,16 +4,23 @@
 
 OpenAaaS 的 Agent 调度器，负责向 Server 注册、轮询获取任务，并通过 Docker 容器隔离执行任务。
 
-## 编译安装
+## 前置条件
 
-需要安装 Rust 工具链（1.85+）和 Docker：
+| 平台 | 要求 |
+|------|------|
+| 所有平台 | Rust 工具链 1.85+、Docker |
+| Windows | Docker Desktop（推荐 WSL2 后端）、Windows 10 19041+ 或 Windows 11 |
+
+> Windows 用户如不熟悉 Docker Desktop 配置，建议直接参考下方 [Windows 部署](#windows-部署) 小节。
+
+## 编译安装
 
 ```bash
 cd agent-core
 cargo build --release
 ```
 
-编译产物为 `target/release/agent-core`。
+编译产物为 `target/release/agent-core`（Windows 上为 `target/release/agent-core.exe`）。
 
 ## 执行器镜像
 
@@ -63,6 +70,35 @@ agent-core [OPTIONS] <COMMAND>
 | `stop` | 停止后台调度器 |
 | `status` | 查看调度器状态 |
 
+## Windows 部署
+
+### 推荐方式：WSL2 内运行（最顺畅）
+
+在 WSL2 Ubuntu 中操作可获得与 Linux 完全一致的原生体验：
+
+1. 安装 [WSL2](https://docs.microsoft.com/zh-cn/windows/wsl/install) 并启动 Ubuntu 发行版。
+2. 在 Docker Desktop 中启用 **Settings → Resources → WSL Integration → Enable integration with my default WSL distro**。
+3. 在 WSL2 终端内克隆代码，按本文后续 Linux 步骤执行即可（`cargo build --release`、构建镜像等）。
+>
+> **WSL2 路径提示：** 在 WSL2 终端内编辑 `config.toml` 时，`[[paths.mounts]]` 中的 `host` 路径必须使用 Linux 格式（如 `/mnt/c/Users/xxx/share` 或 WSL 内部路径 `/home/xxx/share`），不能使用 Windows 格式 `C:\...`，否则挂载会失败。
+
+### 备选方式：原生 Windows + Docker Desktop
+
+如不方便使用 WSL2，也可直接在 PowerShell / CMD 中运行：
+
+1. 安装 [Docker Desktop](https://www.docker.com/products/docker-desktop/)。
+2. 在 Docker Desktop 设置中启用 **Use the WSL 2 based engine**（性能更好）。
+3. 构建 executor 镜像（PowerShell 中路径分隔符用 `./` 即可）：
+   ```powershell
+   cd executor-example
+   docker build -t open-aaas-executor:latest .
+   ```
+4. 后续命令使用 `.\agent-core.exe` 替代 `./agent-core`。
+
+> 原生 Windows 下，`config.toml` 中的 `host` 路径可使用 `C:/path/to/dir`（推荐）或 `C:\\path\\to\\dir` 或 `./relative/path` 格式，Docker Desktop 均可正确解析。
+
+---
+
 ## 首次使用
 
 ### 1. 初始化配置
@@ -70,6 +106,8 @@ agent-core [OPTIONS] <COMMAND>
 ```bash
 ./agent-core init
 ```
+
+> **Windows（原生）：** 直接运行 `.\agent-core.exe init`（PowerShell 推荐，CMD 可直接用 `agent-core.exe init`）。
 
 在当前目录生成默认 `config.toml`。
 
@@ -82,6 +120,8 @@ agent-core [OPTIONS] <COMMAND>
 base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ```
 
+> **Windows 路径提示：** `[[paths.mounts]]` 中的 `host` 路径在 Windows 上可以是 `C:/path/to/dir`（推荐）或 `C:\\path\\to\\dir` 或 `./relative/path` 格式，Docker Desktop 都能正确挂载。
+
 ### 3. 注册
 
 从 Server 获取注册 token 后执行：
@@ -89,6 +129,8 @@ base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ```bash
 ./agent-core register --token rt_xxx --name my-agent
 ```
+
+> **Windows（原生）：** `.\agent-core.exe register --token rt_xxx --name my-agent`
 
 注册成功后，`service_id` 和 `api_key` 会自动写入 `config.toml`。
 
@@ -100,6 +142,8 @@ base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ./agent-core run
 ```
 
+> **Windows（原生）：** `.\agent-core.exe run`
+
 首次启动会交互式确认 Server URL 和数据目录（默认 `./data`），随后开始轮询任务。
 
 如果当前目录已有完整配置且已注册，会直接启动，不再询问。
@@ -109,6 +153,8 @@ base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ```bash
 ./agent-core run
 ```
+
+> **Windows（原生）：** 使用 `.\agent-core.exe run`。
 
 启动后向 Server 轮询获取任务、发送心跳，并通过 Docker 执行器运行任务。按 `Ctrl+C` 或发送 `SIGTERM` 可优雅关闭。
 
@@ -127,6 +173,8 @@ base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 - Linux/macOS：通过 `nohup` 后台运行，日志输出到 `{data_dir}/agent.log`
 - Windows：通过 `cmd /C start /B` 后台运行
 
+> **Windows（原生）：** 使用 `.\agent-core.exe run-detached`。
+
 后台启动后会写入 pidfile，用于后续管理和状态查询。
 
 ## 查看状态
@@ -134,6 +182,8 @@ base_url = "http://127.0.0.1:8080"  # 改成你的 Server 地址
 ```bash
 ./agent-core status
 ```
+
+> **Windows（原生）：** 使用 `.\agent-core.exe status`。
 
 输出示例：
 
@@ -161,6 +211,8 @@ Agent 名称: my-agent
 ```bash
 ./agent-core stop
 ```
+
+> **Windows（原生）：** 使用 `.\agent-core.exe stop`。
 
 向后台进程发送 `SIGTERM`，等待最多 5 秒优雅退出；超时则发送 `SIGKILL` 强制终止，并清理 pidfile。
 


### PR DESCRIPTION
## 变更

- 新增「前置条件 / Prerequisites」小节，明确列出所有平台及 Windows 额外要求
- 新增「Windows 部署 / Windows Deployment」章节，提供两条路径：
  - **推荐**：WSL2 内运行（最顺畅的 Linux 原生体验）
  - **备选**：原生 Windows + Docker Desktop（PowerShell 操作）
- 在全部 7 个命令节点旁补充 Windows 原生提示 .\agent-core.exe
- 补充 Windows 路径格式防踩坑提示：
  - TOML 正斜杠推荐（如 C:/path/to/dir）及双反斜杠转义说明（如 C:\\\\path\\\\to\\\\dir）
  - WSL2 内编辑 config.toml 时 host 路径必须用 Linux 格式（如 /mnt/c/Users/xxx/share）
- 同步更新中英文两个 README
