### PR TITLE
fix(client-app): hide internal service registration status

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 服务市场卡片和服务详情页不再向普通用户展示内部注册状态。
+
 ## [0.6.0] - 2026-06-06
 
 ### Added

--- a/client-app/src/components/ServiceCard.vue
+++ b/client-app/src/components/ServiceCard.vue
@@ -115,11 +115,10 @@ const loadMetrics = computed(() => {
       需要授权后查看负载
     </div>
 
-    <div class="mt-4 flex items-center justify-between border-t border-border pt-3 text-xs font-semibold text-text-muted">
-      <span>注册状态: {{ service.registrationStatus }}</span>
+    <div class="mt-4 flex items-center justify-end border-t border-border pt-3 text-xs font-semibold text-text-muted">
       <span
         v-if="!demo"
-        class="inline-flex items-center gap-1 text-accent opacity-0 transition-opacity group-hover:opacity-100"
+        class="inline-flex items-center gap-1 text-accent opacity-75 transition-opacity group-hover:opacity-100"
       >
         查看详情
         <ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />

--- a/client-app/src/views/HomeView.vue
+++ b/client-app/src/views/HomeView.vue
@@ -40,7 +40,7 @@ const supplementalDemoServices: ServiceItem[] = [
   {
     id: 'demo-online-agent',
     name: '实时问答代理',
-    description: '在线 Agent 示例，展示 active 注册、公开访问和可用槽位状态。',
+    description: '在线 Agent 示例，可公开访问并提供多个可用任务槽位。',
     agentStatus: 'online',
     registrationStatus: 'active',
     accessType: 'public',
@@ -60,7 +60,7 @@ const supplementalDemoServices: ServiceItem[] = [
   {
     id: 'demo-restricted-granted',
     name: '受限合规审查',
-    description: '受限但已授权的服务示例，展示 restricted + hasPermission 的组合。',
+    description: '已授权访问的受限服务示例，适合合规审查和敏感内容处理。',
     agentStatus: 'online',
     registrationStatus: 'active',
     accessType: 'restricted',
@@ -69,8 +69,8 @@ const supplementalDemoServices: ServiceItem[] = [
   },
   {
     id: 'demo-revoked-agent',
-    name: '已吊销旧版代理',
-    description: 'revoked 注册状态示例，展示服务不可用但仍保留列表记录的视觉效果。',
+    name: '离线旧版代理',
+    description: '旧版 Agent 当前不可用，展示服务暂时无法使用时的视觉效果。',
     agentStatus: 'offline',
     registrationStatus: 'revoked',
     accessType: 'public',

--- a/client-app/src/views/ServiceDetailView.vue
+++ b/client-app/src/views/ServiceDetailView.vue
@@ -125,9 +125,6 @@ watch(() => route.params.id, () => {
         >
           {{ service.accessType === 'public' ? '公开访问' : '需要授权' }}
         </span>
-        <span class="text-xs text-text-muted">
-          注册状态: {{ service.registrationStatus }}
-        </span>
       </div>
 
       <div v-if="load !== undefined && load !== null" class="mt-4 p-3 bg-bg-primary border border-border rounded-md">


### PR DESCRIPTION
## Description

### Summary
- Hide internal service registration status from service market cards.
- Remove the same internal registration status from service detail pages.
- Rewrite demo service copy so user-facing descriptions no longer expose internal enum or field names.
- Update the client app changelog.

### Validation
- npm test
- npm run build

## Checklist

- [x] 代码改动已测试通过
- [x] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（`fix(client-app): hide internal service registration status`）
