### PR TITLE
fix(client-app): unify task status display and hide internal service registration status

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - 任务列表改为展示排队中、进行中、已完成和失败四种真实任务状态，并移除无法由客户端验证的百分比进度展示。
+- 服务市场卡片和服务详情页不再向普通用户展示内部注册状态。
 
 ## [0.6.0] - 2026-06-06
 

--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 任务列表改为展示排队中、进行中、已完成和失败四种真实任务状态，并移除无法由客户端验证的百分比进度展示。
+
 ## [0.6.0] - 2026-06-06
 
 ### Added

--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-09
+
 ### Changed
 - 任务列表改为展示排队中、进行中、已完成和失败四种真实任务状态，并移除无法由客户端验证的百分比进度展示。
 - 服务市场卡片和服务详情页不再向普通用户展示内部注册状态。

--- a/client-app/docs/beautification-workflow.md
+++ b/client-app/docs/beautification-workflow.md
@@ -156,6 +156,8 @@ Make the form feel like a guided workflow:
 
 Make state and chronology easy to scan:
 
+- Use the four production task states in the list: queued, running, completed, and failed.
+- Do not show percentage progress unless the backend provides a real progress field.
 - Filter controls should look like segmented controls.
 - Task rows should show title, service, status, creation time, and completion time cleanly.
 - Empty states should include a useful next action when appropriate.

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2021"

--- a/client-app/src-tauri/tauri.conf.json
+++ b/client-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenAaaS Client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.openaaas.client",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/client-app/src/components/ServiceCard.vue
+++ b/client-app/src/components/ServiceCard.vue
@@ -115,11 +115,10 @@ const loadMetrics = computed(() => {
       需要授权后查看负载
     </div>
 
-    <div class="mt-4 flex items-center justify-between border-t border-border pt-3 text-xs font-semibold text-text-muted">
-      <span>注册状态: {{ service.registrationStatus }}</span>
+    <div class="mt-4 flex items-center justify-end border-t border-border pt-3 text-xs font-semibold text-text-muted">
       <span
         v-if="!demo"
-        class="inline-flex items-center gap-1 text-accent opacity-0 transition-opacity group-hover:opacity-100"
+        class="inline-flex items-center gap-1 text-accent opacity-75 transition-opacity group-hover:opacity-100"
       >
         查看详情
         <ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />

--- a/client-app/src/stores/__tests__/task.spec.ts
+++ b/client-app/src/stores/__tests__/task.spec.ts
@@ -77,6 +77,8 @@ describe('useTaskStore', () => {
       createSampleTask({ id: 't1', status: 'pending' }),
       createSampleTask({ id: 't2', status: 'completed' }),
       createSampleTask({ id: 't3', status: 'running' }),
+      createSampleTask({ id: 't4', status: 'failed' }),
+      createSampleTask({ id: 't5', status: 'cancelling' }),
     ]
     expect(store.activeTasks).toHaveLength(2)
     expect(store.activeTaskCount).toBe(2)

--- a/client-app/src/stores/task.ts
+++ b/client-app/src/stores/task.ts
@@ -44,7 +44,7 @@ const POLL_INTERVAL_MS = 30000
 const MAX_POLL_FAIL = 20
 
 function isActiveStatus(status: TaskStatus): boolean {
-  return ['pending', 'running', 'cancelling'].includes(status)
+  return ['pending', 'running'].includes(status)
 }
 
 function isTerminalStatus(status: TaskStatus): boolean {

--- a/client-app/src/views/HomeView.vue
+++ b/client-app/src/views/HomeView.vue
@@ -40,7 +40,7 @@ const supplementalDemoServices: ServiceItem[] = [
   {
     id: 'demo-online-agent',
     name: '实时问答代理',
-    description: '在线 Agent 示例，展示 active 注册、公开访问和可用槽位状态。',
+    description: '在线 Agent 示例，可公开访问并提供多个可用任务槽位。',
     agentStatus: 'online',
     registrationStatus: 'active',
     accessType: 'public',
@@ -60,7 +60,7 @@ const supplementalDemoServices: ServiceItem[] = [
   {
     id: 'demo-restricted-granted',
     name: '受限合规审查',
-    description: '受限但已授权的服务示例，展示 restricted + hasPermission 的组合。',
+    description: '已授权访问的受限服务示例，适合合规审查和敏感内容处理。',
     agentStatus: 'online',
     registrationStatus: 'active',
     accessType: 'restricted',
@@ -69,8 +69,8 @@ const supplementalDemoServices: ServiceItem[] = [
   },
   {
     id: 'demo-revoked-agent',
-    name: '已吊销旧版代理',
-    description: 'revoked 注册状态示例，展示服务不可用但仍保留列表记录的视觉效果。',
+    name: '离线旧版代理',
+    description: '旧版 Agent 当前不可用，展示服务暂时无法使用时的视觉效果。',
     agentStatus: 'offline',
     registrationStatus: 'revoked',
     accessType: 'public',

--- a/client-app/src/views/ServiceDetailView.vue
+++ b/client-app/src/views/ServiceDetailView.vue
@@ -125,9 +125,6 @@ watch(() => route.params.id, () => {
         >
           {{ service.accessType === 'public' ? '公开访问' : '需要授权' }}
         </span>
-        <span class="text-xs text-text-muted">
-          注册状态: {{ service.registrationStatus }}
-        </span>
       </div>
 
       <div v-if="load !== undefined && load !== null" class="mt-4 p-3 bg-bg-primary border border-border rounded-md">

--- a/client-app/src/views/TaskDetailView.vue
+++ b/client-app/src/views/TaskDetailView.vue
@@ -28,21 +28,21 @@ const formattedCompletedAt = computed(() => formatTime(task.value?.completedAt))
 const duration = computed(() => durationText(task.value?.startedAt || task.value?.createdAt, task.value?.completedAt))
 
 const statusLabelMap: Record<string, string> = {
-  pending: '待处理',
-  running: '运行中',
+  pending: '排队中',
+  running: '进行中',
   completed: '已完成',
   failed: '失败',
-  cancelled: '已取消',
-  cancelling: '取消中',
+  cancelled: '失败',
+  cancelling: '失败',
 }
 
 const statusClassMap: Record<string, string> = {
   pending: 'bg-accent/10 text-accent',
-  running: 'bg-warning/10 text-warning',
+  running: 'bg-info-soft text-info',
   completed: 'bg-success/10 text-success',
   failed: 'bg-danger/10 text-danger',
-  cancelled: 'bg-text-muted/10 text-text-muted',
-  cancelling: 'bg-text-muted/10 text-text-muted',
+  cancelled: 'bg-danger/10 text-danger',
+  cancelling: 'bg-danger/10 text-danger',
 }
 
 function formatTime(iso?: string): string {
@@ -67,7 +67,7 @@ function durationText(startIso?: string, endIso?: string): string {
 
 const isTerminal = computed(() => {
   const s = task.value?.status
-  return s === 'completed' || s === 'failed' || s === 'cancelled'
+  return s === 'completed' || s === 'failed' || s === 'cancelled' || s === 'cancelling'
 })
 
 const canCancel = computed(() => {

--- a/client-app/src/views/TasksView.vue
+++ b/client-app/src/views/TasksView.vue
@@ -3,13 +3,10 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   AlertTriangle,
-  Ban,
   CheckCircle,
   Clock,
   FileText,
-  LoaderCircle,
   PlayCircle,
-  RotateCcw,
   Server,
   Sparkles,
   XCircle,
@@ -17,11 +14,11 @@ import {
 import { useTaskStore, type Task, type TaskStatus } from '@/stores/task'
 import StatusBadge from '@/components/StatusBadge.vue'
 
-type FilterKey = 'all' | 'active' | 'completed' | 'failed'
+type FilterKey = 'all' | 'queued' | 'running' | 'completed' | 'failed'
+type TaskDisplayState = 'queued' | 'running' | 'completed' | 'failed'
 type BadgeTone = InstanceType<typeof StatusBadge>['$props']['tone']
 type DisplayTask = Task & {
   isDemo?: boolean
-  progress?: number
   summary?: string
 }
 
@@ -30,24 +27,11 @@ const taskStore = useTaskStore()
 
 const filter = ref<FilterKey>('all')
 
+function isoMinutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60 * 1000).toISOString()
+}
+
 const demoTasks: DisplayTask[] = [
-  {
-    id: 'demo-running-image-batch',
-    serverAlias: 'local-dev',
-    serviceId: 'image-processing',
-    serviceName: '图像处理工作站',
-    title: '批量转换产品截图为 WebP',
-    taskPrompt: '将 28 张产品截图统一压缩为 1440px 宽度的 WebP 文件。',
-    outputPrompt: '输出处理后文件和压缩比统计。',
-    status: 'running',
-    createdAt: '2026-06-06T11:46:00Z',
-    startedAt: '2026-06-06T11:48:00Z',
-    files: [],
-    isPolling: true,
-    progress: 68,
-    summary: '正在处理第 19 / 28 个文件，预计数分钟内完成。',
-    isDemo: true,
-  },
   {
     id: 'demo-pending-data-report',
     serverAlias: 'local-dev',
@@ -57,11 +41,26 @@ const demoTasks: DisplayTask[] = [
     taskPrompt: '分析 CSV 数据并生成一页周报摘要。',
     outputPrompt: '结果写入 report.md，并附带关键指标表。',
     status: 'pending',
-    createdAt: '2026-06-06T11:55:00Z',
+    createdAt: isoMinutesAgo(7),
     files: [],
     isPolling: true,
-    progress: 12,
-    summary: '任务已入队，等待可用 Agent 槽位。',
+    summary: '任务已进入队列，等待服务接收并发送到执行端。',
+    isDemo: true,
+  },
+  {
+    id: 'demo-running-image-batch',
+    serverAlias: 'local-dev',
+    serviceId: 'image-processing',
+    serviceName: '图像处理工作站',
+    title: '批量转换产品截图为 WebP',
+    taskPrompt: '将 28 张产品截图统一压缩为 1440px 宽度的 WebP 文件。',
+    outputPrompt: '输出处理后文件和压缩比统计。',
+    status: 'running',
+    createdAt: isoMinutesAgo(23),
+    startedAt: isoMinutesAgo(21),
+    files: [],
+    isPolling: true,
+    summary: '任务已发送到服务器，正在等待服务端返回最终状态。',
     isDemo: true,
   },
   {
@@ -73,13 +72,12 @@ const demoTasks: DisplayTask[] = [
     taskPrompt: '检查中文 README 的术语一致性和表达清晰度。',
     outputPrompt: '列出修改建议并生成修订版 Markdown。',
     status: 'completed',
-    createdAt: '2026-06-06T09:10:00Z',
-    startedAt: '2026-06-06T09:12:00Z',
-    completedAt: '2026-06-06T09:24:00Z',
+    createdAt: isoMinutesAgo(78),
+    startedAt: isoMinutesAgo(76),
+    completedAt: isoMinutesAgo(64),
     result: '完成',
     files: [],
     isPolling: false,
-    progress: 100,
     summary: '已生成审校建议、术语统一表和修订版文档。',
     isDemo: true,
   },
@@ -92,49 +90,13 @@ const demoTasks: DisplayTask[] = [
     taskPrompt: '检查组件状态管理和可访问性问题。',
     outputPrompt: '输出问题列表和修复建议。',
     status: 'failed',
-    createdAt: '2026-06-06T08:40:00Z',
-    startedAt: '2026-06-06T08:42:00Z',
-    completedAt: '2026-06-06T08:45:00Z',
+    createdAt: isoMinutesAgo(96),
+    startedAt: isoMinutesAgo(94),
+    completedAt: isoMinutesAgo(91),
     files: [],
     errorMessage: '服务权限不足，无法读取上传附件。',
     isPolling: false,
-    progress: 38,
-    summary: '执行中断：附件读取权限不足。',
-    isDemo: true,
-  },
-  {
-    id: 'demo-cancelling-ocr',
-    serverAlias: 'local-dev',
-    serviceId: 'image-processing',
-    serviceName: '图像处理工作站',
-    title: '取消 OCR 批处理任务',
-    taskPrompt: '识别多语言截图中的文字。',
-    outputPrompt: '输出识别文本和置信度。',
-    status: 'cancelling',
-    createdAt: '2026-06-06T11:20:00Z',
-    startedAt: '2026-06-06T11:21:00Z',
-    files: [],
-    isPolling: true,
-    progress: 54,
-    summary: '正在通知 Agent 停止当前批处理。',
-    isDemo: true,
-  },
-  {
-    id: 'demo-cancelled-chart',
-    serverAlias: 'local-dev',
-    serviceId: 'data-analysis',
-    serviceName: '数据分析助手',
-    title: '取消季度趋势图生成',
-    taskPrompt: '根据 Excel 文件生成季度趋势图。',
-    outputPrompt: '输出图表和摘要。',
-    status: 'cancelled',
-    createdAt: '2026-06-06T07:30:00Z',
-    startedAt: '2026-06-06T07:33:00Z',
-    completedAt: '2026-06-06T07:36:00Z',
-    files: [],
-    isPolling: false,
-    progress: 22,
-    summary: '用户主动取消，未生成最终输出。',
+    summary: '服务端返回失败状态：附件读取权限不足。',
     isDemo: true,
   },
 ]
@@ -151,15 +113,7 @@ const sortedTasks = computed(() =>
 )
 
 const filteredTasks = computed(() => {
-  if (filter.value === 'active') {
-    return sortedTasks.value.filter((t) => ['pending', 'running', 'cancelling'].includes(t.status))
-  }
-  if (filter.value === 'completed') {
-    return sortedTasks.value.filter((t) => t.status === 'completed')
-  }
-  if (filter.value === 'failed') {
-    return sortedTasks.value.filter((t) => t.status === 'failed' || t.status === 'cancelled')
-  }
+  if (filter.value !== 'all') return sortedTasks.value.filter((t) => displayState(t.status) === filter.value)
   return sortedTasks.value
 })
 
@@ -167,73 +121,74 @@ const filterItems = computed(() => {
   const tasks = sortedTasks.value
   return [
     { key: 'all' as const, label: '全部', count: tasks.length },
-    { key: 'active' as const, label: '进行中', count: tasks.filter((t) => ['pending', 'running', 'cancelling'].includes(t.status)).length },
-    { key: 'completed' as const, label: '已完成', count: tasks.filter((t) => t.status === 'completed').length },
-    { key: 'failed' as const, label: '异常/取消', count: tasks.filter((t) => t.status === 'failed' || t.status === 'cancelled').length },
+    { key: 'queued' as const, label: '排队中', count: tasks.filter((t) => displayState(t.status) === 'queued').length },
+    { key: 'running' as const, label: '进行中', count: tasks.filter((t) => displayState(t.status) === 'running').length },
+    { key: 'completed' as const, label: '已完成', count: tasks.filter((t) => displayState(t.status) === 'completed').length },
+    { key: 'failed' as const, label: '失败', count: tasks.filter((t) => displayState(t.status) === 'failed').length },
   ]
 })
 
 const statusSummary = computed(() => ({
-  active: sortedTasks.value.filter((t) => ['pending', 'running', 'cancelling'].includes(t.status)).length,
-  completed: sortedTasks.value.filter((t) => t.status === 'completed').length,
-  problem: sortedTasks.value.filter((t) => t.status === 'failed' || t.status === 'cancelled').length,
+  queued: sortedTasks.value.filter((t) => displayState(t.status) === 'queued').length,
+  running: sortedTasks.value.filter((t) => displayState(t.status) === 'running').length,
+  completed: sortedTasks.value.filter((t) => displayState(t.status) === 'completed').length,
+  failed: sortedTasks.value.filter((t) => displayState(t.status) === 'failed').length,
 }))
 
-function statusMeta(status: TaskStatus): {
+function displayState(status: TaskStatus): TaskDisplayState {
+  if (status === 'pending') return 'queued'
+  if (status === 'running') return 'running'
+  if (status === 'completed') return 'completed'
+  return 'failed'
+}
+
+function statusMeta(status: TaskDisplayState): {
   label: string
   tone: BadgeTone
   icon: typeof Clock
   accentClass: string
-  progressClass: string
+  textClass: string
+  description: string
 } {
-  const map: Record<TaskStatus, {
+  const map: Record<TaskDisplayState, {
     label: string
     tone: BadgeTone
     icon: typeof Clock
     accentClass: string
-    progressClass: string
+    textClass: string
+    description: string
   }> = {
-    pending: {
-      label: '待处理',
+    queued: {
+      label: '排队中',
       tone: 'accent',
       icon: Clock,
       accentClass: 'bg-accent-soft text-accent border-accent/20',
-      progressClass: 'bg-accent',
+      textClass: 'text-accent',
+      description: '任务正在队列中等待服务接收。',
     },
     running: {
-      label: '运行中',
+      label: '进行中',
       tone: 'info',
       icon: PlayCircle,
       accentClass: 'bg-info-soft text-info border-info/20',
-      progressClass: 'bg-info',
+      textClass: 'text-info',
+      description: '任务已发送到服务器，正在等待最终结果。',
     },
     completed: {
       label: '已完成',
       tone: 'success',
       icon: CheckCircle,
       accentClass: 'bg-success/10 text-success border-success/20',
-      progressClass: 'bg-success',
+      textClass: 'text-success',
+      description: '服务端已返回完成状态，可以查看输出。',
     },
     failed: {
       label: '失败',
       tone: 'danger',
       icon: XCircle,
       accentClass: 'bg-danger/10 text-danger border-danger/20',
-      progressClass: 'bg-danger',
-    },
-    cancelled: {
-      label: '已取消',
-      tone: 'neutral',
-      icon: Ban,
-      accentClass: 'bg-bg-secondary text-text-muted border-border',
-      progressClass: 'bg-text-muted',
-    },
-    cancelling: {
-      label: '取消中',
-      tone: 'secondary',
-      icon: LoaderCircle,
-      accentClass: 'bg-secondary-soft text-secondary border-secondary/25',
-      progressClass: 'bg-secondary',
+      textClass: 'text-danger',
+      description: '服务端返回失败状态，或任务无法继续执行。',
     },
   }
   return map[status]
@@ -260,16 +215,6 @@ function durationText(task: DisplayTask): string {
   return `${h}小时${min % 60}分`
 }
 
-function progressValue(task: DisplayTask): number {
-  if (task.progress != null) return task.progress
-  if (task.status === 'completed') return 100
-  if (task.status === 'pending') return 10
-  if (task.status === 'running') return 62
-  if (task.status === 'cancelling') return 48
-  if (task.status === 'failed' || task.status === 'cancelled') return 36
-  return 0
-}
-
 function openTask(task: DisplayTask) {
   if (task.isDemo) return
   router.push(`/task/${task.id}`)
@@ -286,22 +231,26 @@ function openTask(task: DisplayTask) {
         </div>
         <h1 class="mt-1 text-3xl font-bold text-info">任务列表</h1>
         <p class="mt-2 text-sm text-text-secondary">
-          跟踪任务排队、运行、完成和异常状态，快速判断下一步操作。
+          按排队中、进行中、已完成和失败状态查看任务，快速判断下一步操作。
         </p>
       </div>
 
-      <div class="grid grid-cols-3 gap-2">
+      <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <div class="rounded-lg border border-border bg-bg-card px-4 py-3 shadow-sm">
+          <p class="text-[11px] font-semibold text-text-muted">排队中</p>
+          <p class="mt-1 text-xl font-bold text-accent">{{ statusSummary.queued }}</p>
+        </div>
         <div class="rounded-lg border border-border bg-bg-card px-4 py-3 shadow-sm">
           <p class="text-[11px] font-semibold text-text-muted">进行中</p>
-          <p class="mt-1 text-xl font-bold text-info">{{ statusSummary.active }}</p>
+          <p class="mt-1 text-xl font-bold text-info">{{ statusSummary.running }}</p>
         </div>
         <div class="rounded-lg border border-border bg-bg-card px-4 py-3 shadow-sm">
           <p class="text-[11px] font-semibold text-text-muted">已完成</p>
           <p class="mt-1 text-xl font-bold text-success">{{ statusSummary.completed }}</p>
         </div>
         <div class="rounded-lg border border-border bg-bg-card px-4 py-3 shadow-sm">
-          <p class="text-[11px] font-semibold text-text-muted">异常/取消</p>
-          <p class="mt-1 text-xl font-bold text-secondary">{{ statusSummary.problem }}</p>
+          <p class="text-[11px] font-semibold text-text-muted">失败</p>
+          <p class="mt-1 text-xl font-bold text-danger">{{ statusSummary.failed }}</p>
         </div>
       </div>
     </div>
@@ -342,7 +291,7 @@ function openTask(task: DisplayTask) {
         class="group w-full rounded-lg border border-border bg-bg-card p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-accent/35 hover:shadow-soft"
         :class="{
           'cursor-default hover:translate-y-0': task.isDemo,
-          'border-secondary/25 bg-secondary-soft/60': task.status === 'failed' || task.status === 'cancelling',
+          'border-danger/20 bg-danger/5': displayState(task.status) === 'failed',
         }"
         @click="openTask(task)"
       >
@@ -350,13 +299,12 @@ function openTask(task: DisplayTask) {
           <div class="flex min-w-0 flex-1 gap-3">
             <div
               class="flex flex-shrink-0 items-center justify-center rounded-lg border"
-              :class="statusMeta(task.status).accentClass"
+              :class="statusMeta(displayState(task.status)).accentClass"
               style="height: 44px; width: 44px;"
             >
               <component
-                :is="statusMeta(task.status).icon"
+                :is="statusMeta(displayState(task.status)).icon"
                 class="h-5 w-5"
-                :class="{ 'animate-spin': task.status === 'cancelling' }"
                 :stroke-width="2.25"
                 aria-hidden="true"
               />
@@ -366,8 +314,8 @@ function openTask(task: DisplayTask) {
               <div class="mb-2 flex flex-wrap items-center gap-2">
                 <h3 class="truncate text-base font-bold text-info">{{ task.title }}</h3>
                 <StatusBadge
-                  :label="statusMeta(task.status).label"
-                  :tone="statusMeta(task.status).tone"
+                  :label="statusMeta(displayState(task.status)).label"
+                  :tone="statusMeta(displayState(task.status)).tone"
                   compact
                   show-icon
                 />
@@ -396,18 +344,11 @@ function openTask(task: DisplayTask) {
         </div>
 
         <div class="mt-4 flex flex-wrap items-end justify-between gap-3">
-          <div class="min-w-[220px] flex-1">
-            <div class="mb-2 flex items-center justify-between text-xs font-semibold text-text-muted">
-              <span>进度</span>
-              <span>{{ progressValue(task) }}%</span>
-            </div>
-            <div class="h-2 overflow-hidden rounded-full bg-bg-tertiary">
-              <div
-                class="h-full rounded-full transition-all"
-                :class="statusMeta(task.status).progressClass"
-                :style="{ width: `${progressValue(task)}%` }"
-              />
-            </div>
+          <div class="min-w-[220px] flex-1 rounded-lg border border-border bg-bg-inset px-3 py-2">
+            <p class="text-[11px] font-semibold text-text-muted">当前状态</p>
+            <p class="mt-1 text-sm font-semibold" :class="statusMeta(displayState(task.status)).textClass">
+              {{ statusMeta(displayState(task.status)).description }}
+            </p>
           </div>
           <div class="flex items-center justify-end gap-2 text-xs font-semibold">
             <StatusBadge v-if="task.isDemo" label="Demo" tone="neutral" compact />
@@ -429,10 +370,10 @@ function openTask(task: DisplayTask) {
           {{ task.errorMessage || task.pollError }}
         </div>
         <div
-          v-else-if="task.status === 'pending' || task.status === 'running' || task.status === 'cancelling'"
+          v-else-if="displayState(task.status) === 'queued' || displayState(task.status) === 'running'"
           class="mt-3 flex items-center gap-2 rounded-lg border border-accent/15 bg-accent-soft px-3 py-2 text-xs font-semibold text-accent"
         >
-          <RotateCcw class="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <Clock class="h-4 w-4 flex-shrink-0" aria-hidden="true" />
           {{ task.isPolling ? '正在同步任务状态' : '等待下一次状态同步' }}
         </div>
       </button>


### PR DESCRIPTION
This PR combines the changes from #115 and #121 into a single unified fix for client-app status display issues.

### Included changes
- Align the client task list with the production task model: queued, running, completed, and failed.
- Remove unverified percentage progress from task cards.
- Hide internal service registration status from service market cards and service detail pages.
- Rewrite demo service copy so user-facing descriptions no longer expose internal enum or field names.
- Update task filters, task summary counts, demo task states, task detail status labels, and CHANGELOG.

Closes #115, closes #121