### PR TITLE
fix(ci): resolve frontend-tests failure by pinning time crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
           cd client-app
           npm ci
           npm run test
+      - name: Build frontend
+        run: |
+          cd client-app
+          npm run build
       - name: Run Tauri Rust tests
         run: |
           cd client-app/src-tauri

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -15,6 +15,10 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Pin time to avoid E0119 conflict with tauri-utils 2.9.2
+# See: https://github.com/Wolido/OpenAaaS/issues/123
+# Remove once tauri-utils fixes the trait conflict or tauri is upgraded.
+time = "=0.3.47"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]


### PR DESCRIPTION
## 修复内容

修复 frontend-tests CI 持续失败的问题。

## 变更

- 在 `client-app/src-tauri/Cargo.toml` 中 pin `time = "=0.3.47"` 以避免与 `tauri-utils 2.9.2` 的 `From` trait 冲突（E0119）
- 在 CI 的 `frontend-tests` job 中添加 `Build frontend` 步骤，确保 `tauri.conf.json` 中的 `frontendDist` 指向的 `dist/` 目录存在
- 详见相关讨论和日志分析
