### PR TITLE
fix(admin-cli): add initialization guide to --help output

### DIFF
--- a/admin-cli/CHANGELOG.md
+++ b/admin-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-12
+
+### Fixed
+- admin-cli `--help` 输出增加初始化配置引导说明，提示首次使用执行 `config init`（Issue #123）
+
 ## [0.1.0] - 2026-06-06
 
 ### Added
@@ -20,4 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 39 个单元/集成测试（含 wiremock HTTP 测试）
 - 安全配置：文件权限 0o600、API Key 脱敏、删除确认
 
+[0.1.1]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.1
 [0.1.0]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.0

--- a/admin-cli/Cargo.toml
+++ b/admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-admin"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["OpenAaaS Contributors"]
 description = "OpenAaaS Server Admin CLI"

--- a/admin-cli/src/cli.rs
+++ b/admin-cli/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{Args, Parser, Subcommand};
 #[command(name = "openaaas-admin")]
 #[command(about = "OpenAaaS Server Admin CLI")]
 #[command(version)]
+#[command(after_help = "First time? Run 'openaaas-admin config init' to set up your server URL and API key.")]
 pub struct Cli {
     /// Override server URL
     #[arg(long, global = true)]
@@ -19,7 +20,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Manage configuration
+    /// Manage configuration (run 'config init' to initialize)
     Config {
         #[command(subcommand)]
         command: ConfigCommands,
@@ -47,7 +48,7 @@ pub enum Commands {
 
 #[derive(Subcommand)]
 pub enum ConfigCommands {
-    /// Initialize configuration interactively or with parameters
+    /// Initialize configuration (set server URL and API key interactively or via flags)
     Init {
         /// Server URL
         #[arg(long)]


### PR DESCRIPTION
## 修复内容

为 admin-cli 的 `--help` 输出增加初始化配置引导，解决 Issue #123 中用户反馈的下载后不知道如何初始化的问题。

## 变更

- 在顶层 `Cli` 上增加 `after_help`，提示首次使用执行 `config init`
- 将 `config` 子命令描述改为 `Manage configuration (run config init to initialize)`
- 将 `config init` 描述改为 `Initialize configuration (set server URL and API key interactively or via flags)`

Fixes #123
