### PR TITLE
fix(client-app): align Rust edition with project (2024) (#104)

### DIFF
--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "openaaas-client"
 version = "0.6.1"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
-edition = "2021"
+edition = "2024"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
## 修复内容

将 client-app/src-tauri/Cargo.toml 的 Rust edition 从 2021 升级到 2024，与项目中其他 crate 保持一致。

## 变更

- client-app/src-tauri/Cargo.toml: edition = "2021" → edition = "2024"

Fixes #104
