### PR TITLE
feat(mcp-adapter): add poll_task tool and bump to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,15 @@ paths = client.download_all_files(task.id)
   "mcpServers": {
     "openaaas": {
       "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
+      "args": ["openaaas-mcp-adapter"],
+      "toolTimeoutMs": 600000
     }
   }
 }
 ```
+
+- `toolTimeoutMs` 设置 MCP 工具调用的最大等待时间（毫秒），适合长任务轮询场景。
+- ⚠️ 该参数由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制，导致该参数不生效。
 
 配置后重启客户端，即可在对话中调用全部能力。
 

--- a/client-extension/openaaas-mcp-adapter/CHANGELOG.md
+++ b/client-extension/openaaas-mcp-adapter/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-06-16
+
+### Added
+
+- 新增 `poll_task` 工具：轮询任务直到获得最终结果，每 20 秒查询一次，默认无超时，支持 `timeout_seconds` 参数限制最大轮询时长。
+- 新增 `CHANGELOG.md`，用于记录版本变更。
+
+### Changed
+
+- `poll_task` 工具描述中明确说明：不建议 Agent 主动调用，应在用户明确提出需要等待/轮询任务结果时再使用。
+- 更新 MCP 客户端配置示例，新增 `toolTimeoutMs` 字段说明，用于长任务轮询场景。
+- 在主项目 `README.md`、MCP 适配器中文和英文 `README.md` 中补充 `toolTimeoutMs` 配置示例及生效提示。
+- 在 MCP 适配器中文和英文 `README.md` 的工具列表、参数表和标准使用流程中加入 `poll_task` 说明。
+
+### Notes
+
+- `toolTimeoutMs` 由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制。

--- a/client-extension/openaaas-mcp-adapter/Dockerfile
+++ b/client-extension/openaaas-mcp-adapter/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install package, create non-root user, fix permissions in one layer
-RUN pip install --no-cache-dir openaaas-mcp-adapter==0.2.0 && \
+RUN pip install --no-cache-dir openaaas-mcp-adapter==0.3.0 && \
     useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
 

--- a/client-extension/openaaas-mcp-adapter/README.en.md
+++ b/client-extension/openaaas-mcp-adapter/README.en.md
@@ -33,11 +33,15 @@ Configure Claude Desktop, Cursor, or Cline:
   "mcpServers": {
     "openaaas": {
       "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
+      "args": ["openaaas-mcp-adapter"],
+      "toolTimeoutMs": 600000
     }
   }
 }
 ```
+
+- `toolTimeoutMs` sets the maximum wait time for an MCP tool call (milliseconds), suitable for long-running task polling.
+- ⚠️ This parameter is parsed by the MCP client; actual behavior depends on the specific client implementation. Some clients or the Agent tool itself may have independent timeout limits, causing this parameter to not take effect.
 
 After modifying the configuration, restart the client for it to take effect.
 
@@ -175,6 +179,7 @@ list_servers()
 | `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
 | `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
 | `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
+| `poll_task` | Poll a task until a final result is obtained. Queries every 20 seconds, no timeout by default; pass `timeout_seconds` to limit maximum polling duration. Not recommended for Agent-initiated use; only use when the user explicitly asks to wait for or poll a task result |
 | `cancel_task` | Cancel a running task |
 | `list_files` | List result files for the task |
 | `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
@@ -204,6 +209,9 @@ list_servers()
 | | `server` | ❌ | Server alias, default `"default"` |
 | `get_task` | `task_id` | ✅ | Task ID |
 | | `server` | ❌ | Server alias, default `"default"` |
+| `poll_task` | `task_id` | ✅ | Task ID |
+| | `timeout_seconds` | ❌ | Maximum polling duration (seconds), no limit by default |
+| | `server` | ❌ | Server alias, default `"default"` |
 | `cancel_task` | `task_id` | ✅ | Task ID |
 | | `server` | ❌ | Server alias, default `"default"` |
 | `list_files` | `task_id` | ✅ | Task ID |
@@ -231,7 +239,8 @@ This adapter follows the principle of "progressive information disclosure": do n
 5. Based on usage content, construct correct `task_prompt` and `output_prompt`
 6. `submit_task` — Submit task (with optional files), save returned `task_id`
 7. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
-8. `download_result` — Download result files after task completion
+8. `poll_task` — If you need to wait for task completion, poll until the task finishes (every 20 seconds, no timeout by default)
+9. `download_result` — Download result files after task completion
 
 ### Why This Design
 

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -33,11 +33,15 @@ uvx openaaas-mcp-adapter
   "mcpServers": {
     "openaaas": {
       "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
+      "args": ["openaaas-mcp-adapter"],
+      "toolTimeoutMs": 600000
     }
   }
 }
 ```
+
+- `toolTimeoutMs` 设置 MCP 工具调用的最大等待时间（毫秒），适合长任务轮询场景。
+- ⚠️ 该参数由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制，导致该参数不生效。
 
 配置修改后，重启客户端即可生效。
 
@@ -175,6 +179,7 @@ list_servers()
 | `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
 | `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
 | `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
+| `poll_task` | 轮询任务直到获得最终结果。每 20 秒查询一次，默认无超时，可传入 `timeout_seconds` 限制最大轮询时长。不建议 Agent 主动调用，应在用户明确提出需要等待/轮询任务结果时再使用 |
 | `cancel_task` | 取消执行中的任务 |
 | `list_files` | 列出任务的结果文件列表 |
 | `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
@@ -204,6 +209,9 @@ list_servers()
 | | `server` | ❌ | 服务器别名，默认 `"default"` |
 | `get_task` | `task_id` | ✅ | 任务 ID |
 | | `server` | ❌ | 服务器别名，默认 `"default"` |
+| `poll_task` | `task_id` | ✅ | 任务 ID |
+| | `timeout_seconds` | ❌ | 最大轮询时长（秒），默认不限制 |
+| | `server` | ❌ | 服务器别名，默认 `"default"` |
 | `cancel_task` | `task_id` | ✅ | 任务 ID |
 | | `server` | ❌ | 服务器别名，默认 `"default"` |
 | `list_files` | `task_id` | ✅ | 任务 ID |
@@ -231,7 +239,8 @@ list_servers()
 5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
 6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
 7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-8. `download_result` — 任务完成后下载结果文件
+8. `poll_task` — 如需等待任务结束，可轮询直到任务完成（每 20 秒一次，默认无超时）
+9. `download_result` — 任务完成后下载结果文件
 
 ### 为什么这样设计
 

--- a/client-extension/openaaas-mcp-adapter/pyproject.toml
+++ b/client-extension/openaaas-mcp-adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openaaas-mcp-adapter"
-version = "0.2.0"
+version = "0.3.0"
 description = "OpenAaaS MCP adapter — connect Claude Desktop, Cursor, Cline to OpenAaaS Server"
 readme = "PYPI_README.md"
 requires-python = ">=3.10"

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/__init__.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/__init__.py
@@ -1,3 +1,3 @@
 """OpenAaaS MCP Adapter"""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
@@ -6,6 +6,7 @@ import mimetypes
 import os
 import re
 import shutil
+import time
 import unicodedata
 import zipfile
 from datetime import datetime, timezone
@@ -753,7 +754,100 @@ def register_tools(mcp: FastMCP) -> None:
         return "\n".join(lines)
 
     # ------------------------------------------------------------------
-    # 9. cancel_task
+    # 9. poll_task
+    # ------------------------------------------------------------------
+    @mcp.tool()
+    def poll_task(
+        task_id: str,
+        timeout_seconds: float | None = None,
+        server: str = "",
+    ) -> str:
+        """轮询任务直到获得最终结果
+
+        每 20 秒查询一次任务状态，直到任务进入 completed / failed / cancelled 状态。
+        默认不设置超时；传入 timeout_seconds 可限制最大轮询时长。
+
+        注意：不建议 Agent 主动调用此工具，应在用户明确提出需要等待/轮询任务结果时再使用。
+        """
+        if not task_id:
+            return "❌ 缺少必填参数: task_id"
+
+        try:
+            sc = get_server_config(server)
+            api_key = require_api_key(server)
+        except RuntimeError as e:
+            return f"❌ {e}"
+
+        server_url = strip_trailing_slash(sc.get("server_url", ""))
+        url = f"{server_url}/api/v1/client/tasks/{quote(task_id, safe='')}"
+
+        poll_interval = 20
+        start_time = time.monotonic()
+        iterations = 0
+
+        while True:
+            iterations += 1
+            try:
+                result = safe_request(
+                    "GET", url, headers={"Authorization": f"Bearer {api_key}"}
+                )
+            except OpenAaaSError as e:
+                return f"❌ 查询失败: {e}"
+
+            status = result.get("status", "unknown") if isinstance(result, dict) else "unknown"
+            if status in ("completed", "failed", "cancelled"):
+                elapsed = int(time.monotonic() - start_time)
+                status_desc = {
+                    "completed": "已完成",
+                    "failed": "失败",
+                    "cancelled": "已取消",
+                }.get(status, status)
+
+                tid = result.get("id") or result.get("task_id") or task_id
+                lines = [
+                    f"轮询结束，任务状态: {status_desc}",
+                    f"任务 ID: {tid}",
+                    f"轮询次数: {iterations}",
+                    f"总耗时: {elapsed} 秒",
+                ]
+
+                if status == "completed":
+                    lines.append("")
+                    lines.append("任务已完成，可以使用 download_result 下载结果文件。")
+                    result_data = result.get("result") if isinstance(result, dict) else None
+                    if isinstance(result_data, dict):
+                        lines.append("")
+                        lines.append("执行结果摘要:")
+                        if result_data.get("summary"):
+                            lines.append(str(result_data["summary"]))
+                        elif isinstance(result_data.get("output"), str):
+                            out = result_data["output"]
+                            lines.append(out[:500] + ("..." if len(out) > 500 else ""))
+                elif status == "failed":
+                    lines.append("")
+                    lines.append("❌ 任务执行失败")
+                    result_data = result.get("result") if isinstance(result, dict) else None
+                    if isinstance(result_data, dict):
+                        err_msg = result_data.get("error") or result_data.get("message")
+                        if err_msg:
+                            lines.append(f"错误信息: {err_msg}")
+
+                return "\n".join(lines)
+
+            if timeout_seconds is not None:
+                elapsed = time.monotonic() - start_time
+                if elapsed >= timeout_seconds:
+                    return (
+                        f"⏰ 轮询超时（已等待 {int(elapsed)} 秒，超过 {timeout_seconds} 秒）\n"
+                        f"任务 ID: {task_id}\n"
+                        f"当前状态: {status}\n"
+                        f"轮询次数: {iterations}"
+                    )
+
+            time.sleep(poll_interval)
+
+    # ------------------------------------------------------------------
+    # 10. cancel_task
     # ------------------------------------------------------------------
     @mcp.tool()
     def cancel_task(task_id: str, server: str = "") -> str:

--- a/client-extension/openaaas-mcp-adapter/tests/test_tools_mcp.py
+++ b/client-extension/openaaas-mcp-adapter/tests/test_tools_mcp.py
@@ -1,8 +1,7 @@
 """Tests for tools.py MCP tool functions."""
 
-import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -338,6 +337,112 @@ class TestGetTask:
                 }):
                     result = tools["get_task"]("task-1")
         assert "等待中" in result
+
+
+class TestPollTask:
+    """Tests for poll_task tool."""
+
+    def test_completed_immediately(self, tools):
+        with patch("openaaas_mcp_adapter.tools.get_server_config", return_value={
+            "alias": "default",
+            "server_url": "https://api.example.com",
+            "api_key": "key",
+        }):
+            with patch("openaaas_mcp_adapter.tools.require_api_key", return_value="key"):
+                with patch("openaaas_mcp_adapter.tools.safe_request", return_value={
+                    "id": "task-1",
+                    "status": "completed",
+                    "result": {"summary": "Done"},
+                }):
+                    with patch("openaaas_mcp_adapter.tools.time.sleep") as mock_sleep:
+                        result = tools["poll_task"]("task-1")
+        assert "轮询结束" in result
+        assert "已完成" in result
+        assert "Done" in result
+        mock_sleep.assert_not_called()
+
+    def test_polls_until_completed(self, tools):
+        responses = [
+            {"id": "task-1", "status": "pending"},
+            {"id": "task-1", "status": "running"},
+            {"id": "task-1", "status": "completed", "result": {"summary": "Done"}},
+        ]
+        with patch("openaaas_mcp_adapter.tools.get_server_config", return_value={
+            "alias": "default",
+            "server_url": "https://api.example.com",
+            "api_key": "key",
+        }):
+            with patch("openaaas_mcp_adapter.tools.require_api_key", return_value="key"):
+                with patch("openaaas_mcp_adapter.tools.safe_request", side_effect=responses):
+                    with patch("openaaas_mcp_adapter.tools.time.sleep") as mock_sleep:
+                        result = tools["poll_task"]("task-1")
+        assert "轮询结束" in result
+        assert "已完成" in result
+        assert "Done" in result
+        assert "轮询次数: 3" in result
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(20)
+
+    def test_timeout(self, tools):
+        with patch("openaaas_mcp_adapter.tools.get_server_config", return_value={
+            "alias": "default",
+            "server_url": "https://api.example.com",
+            "api_key": "key",
+        }):
+            with patch("openaaas_mcp_adapter.tools.require_api_key", return_value="key"):
+                with patch("openaaas_mcp_adapter.tools.safe_request", return_value={
+                    "id": "task-1",
+                    "status": "running",
+                }):
+                    with patch("openaaas_mcp_adapter.tools.time.sleep"):
+                        with patch(
+                            "openaaas_mcp_adapter.tools.time.monotonic",
+                            side_effect=[0.0, 5.0, 55.0],
+                        ):
+                            result = tools["poll_task"]("task-1", timeout_seconds=30)
+        assert "轮询超时" in result
+        assert "30 秒" in result
+        assert "running" in result
+
+    def test_failed_stops_polling(self, tools):
+        with patch("openaaas_mcp_adapter.tools.get_server_config", return_value={
+            "alias": "default",
+            "server_url": "https://api.example.com",
+            "api_key": "key",
+        }):
+            with patch("openaaas_mcp_adapter.tools.require_api_key", return_value="key"):
+                with patch("openaaas_mcp_adapter.tools.safe_request", return_value={
+                    "id": "task-1",
+                    "status": "failed",
+                    "result": {"error": "boom"},
+                }):
+                    with patch("openaaas_mcp_adapter.tools.time.sleep") as mock_sleep:
+                        result = tools["poll_task"]("task-1")
+        assert "轮询结束" in result
+        assert "失败" in result
+        assert "boom" in result
+        mock_sleep.assert_not_called()
+
+    def test_cancelled_stops_polling(self, tools):
+        with patch("openaaas_mcp_adapter.tools.get_server_config", return_value={
+            "alias": "default",
+            "server_url": "https://api.example.com",
+            "api_key": "key",
+        }):
+            with patch("openaaas_mcp_adapter.tools.require_api_key", return_value="key"):
+                with patch("openaaas_mcp_adapter.tools.safe_request", return_value={
+                    "id": "task-1",
+                    "status": "cancelled",
+                }):
+                    with patch("openaaas_mcp_adapter.tools.time.sleep") as mock_sleep:
+                        result = tools["poll_task"]("task-1")
+        assert "轮询结束" in result
+        assert "已取消" in result
+        mock_sleep.assert_not_called()
+
+    def test_empty_task_id(self, tools):
+        result = tools["poll_task"]("")
+        assert "缺少必填参数" in result
 
 
 class TestCancelTask:


### PR DESCRIPTION
## 变更

- 新增 "poll_task" 工具：每 20 秒轮询一次任务状态，直到任务进入 completed / failed / cancelled。
- "poll_task" 默认无超时，支持传入 "timeout_seconds" 参数限制最大轮询时长。
- 在 "poll_task" 工具描述中明确：不建议 Agent 主动调用，应在用户明确提出需要等待/轮询任务结果时再使用。
- 新增 "CHANGELOG.md" 记录版本变更。
- 更新主项目 README 及 MCP 适配器中英文 README：
  - 加入 "toolTimeoutMs" 配置示例及生效提示。
  - 在工具列表、参数表和使用流程中加入 "poll_task" 说明。
- 版本号从 0.2.0 提升至 0.3.0（pyproject.toml、__init__.py、Dockerfile）。

## 测试

- 本地测试全部通过：120 passed。
