### PR TITLE
fix(mcp-adapter): prevent auto-polling and fix download paths

### DIFF
--- a/client-extension/openaaas-mcp-adapter/CHANGELOG.md
+++ b/client-extension/openaaas-mcp-adapter/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-17
+
+### Fixed
+
+- 防止 Agent 在 `submit_task` 后自动轮询：
+  - `poll_task` 工具描述明确：Agent 禁止主动调用，仅在用户明确说"帮我等结果"/"轮询任务"时才使用。
+  - `get_task` 工具描述明确：仅在用户明确要求查询任务状态时调用，不要主动轮询。
+  - `submit_task` 返回信息提示：提交后应询问用户是否需要等待结果，未明确授权不要调用 `poll_task` 或 `get_task`。
+- 修复 `download_result` 返回路径不清晰问题：返回结果中明确列出每个文件的完整路径，并提示读取文件时不要推测子目录。
+
+### Changed
+
+- 同步更新中英文 README 中 `poll_task`、`get_task`、`submit_task` 和 `download_result` 的工具描述及使用流程。
+
 ## [0.3.0] - 2026-06-16
 
 ### Added
@@ -16,9 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `poll_task` 工具描述中明确说明：Agent 禁止主动调用，仅在用户明确说"帮我等结果"/"轮询任务"时才使用。
-- `get_task` 工具描述中补充：仅在用户明确要求查询任务状态时调用，不要主动轮询。
-- `submit_task` 返回信息中补充：提交后应询问用户是否需要等待结果，不要主动调用 `poll_task` 或 `get_task`。
 - 更新 MCP 客户端配置示例，新增 `toolTimeoutMs` 字段说明，用于长任务轮询场景。
 - 在主项目 `README.md`、MCP 适配器中文和英文 `README.md` 中补充 `toolTimeoutMs` 配置示例及生效提示。
 - 在 MCP 适配器中文和英文 `README.md` 的工具列表、参数表和标准使用流程中加入 `poll_task` 说明。

--- a/client-extension/openaaas-mcp-adapter/CHANGELOG.md
+++ b/client-extension/openaaas-mcp-adapter/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `poll_task` 工具描述中明确说明：不建议 Agent 主动调用，应在用户明确提出需要等待/轮询任务结果时再使用。
+- `poll_task` 工具描述中明确说明：Agent 禁止主动调用，仅在用户明确说"帮我等结果"/"轮询任务"时才使用。
+- `get_task` 工具描述中补充：仅在用户明确要求查询任务状态时调用，不要主动轮询。
+- `submit_task` 返回信息中补充：提交后应询问用户是否需要等待结果，不要主动调用 `poll_task` 或 `get_task`。
 - 更新 MCP 客户端配置示例，新增 `toolTimeoutMs` 字段说明，用于长任务轮询场景。
 - 在主项目 `README.md`、MCP 适配器中文和英文 `README.md` 中补充 `toolTimeoutMs` 配置示例及生效提示。
 - 在 MCP 适配器中文和英文 `README.md` 的工具列表、参数表和标准使用流程中加入 `poll_task` 说明。

--- a/client-extension/openaaas-mcp-adapter/Dockerfile
+++ b/client-extension/openaaas-mcp-adapter/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install package, create non-root user, fix permissions in one layer
-RUN pip install --no-cache-dir openaaas-mcp-adapter==0.3.0 && \
+RUN pip install --no-cache-dir openaaas-mcp-adapter==0.3.1 && \
     useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
 

--- a/client-extension/openaaas-mcp-adapter/README.en.md
+++ b/client-extension/openaaas-mcp-adapter/README.en.md
@@ -178,8 +178,8 @@ list_servers()
 | `list_services` | List available services (returns lightweight summary: id/name/description/agent_status/access_type/has_permission/registration_status, without usage long text) |
 | `get_service_usage` | Get detailed usage for the specified service (capabilities, calling conventions, return format, constraints) |
 | `submit_task` | Submit task to remote Agent (supports file upload, supports `session_id` for conversation context) |
-| `get_task` | Query task status and final result (only call when the user requests it, do not poll actively) |
-| `poll_task` | Poll a task until a final result is obtained. Queries every 20 seconds, no timeout by default; pass `timeout_seconds` to limit maximum polling duration. Not recommended for Agent-initiated use; only use when the user explicitly asks to wait for or poll a task result |
+| `get_task` | Query task status and final result (only call when the user explicitly requests it; do not poll actively) |
+| `poll_task` | Poll a task until a final result is obtained. Queries every 20 seconds, no timeout by default; pass `timeout_seconds` to limit maximum polling duration. Agent must NOT call this proactively; ONLY use when the user explicitly asks to wait for or poll a task result |
 | `cancel_task` | Cancel a running task |
 | `list_files` | List result files for the task |
 | `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
@@ -237,10 +237,10 @@ This adapter follows the principle of "progressive information disclosure": do n
 3. `list_services` — Get lightweight service list (id/name/description/agent_status/access_type/has_permission/registration_status), browse and filter candidate services
 4. `get_service_usage` — For filtered candidate services, get detailed usage on demand (capabilities, calling conventions, return format, constraints)
 5. Based on usage content, construct correct `task_prompt` and `output_prompt`
-6. `submit_task` — Submit task (with optional files), save returned `task_id`
-7. `get_task` — Only call when the user explicitly requests it, query task status and final result (do not poll actively)
-8. `poll_task` — If you need to wait for task completion, poll until the task finishes (every 20 seconds, no timeout by default)
-9. `download_result` — Download result files after task completion
+6. `submit_task` — Submit task (with optional files), save returned `task_id`. After submitting, ask the user whether to wait for the result; do not poll actively
+7. `get_task` — Only call when the user explicitly requests to query task status (do not poll actively)
+8. `poll_task` — Only use when the user explicitly says "wait for the result" or "poll the task"; queries every 20 seconds, no timeout by default
+9. `download_result` — Download result files after task completion, when the user asks for it
 
 ### Why This Design
 

--- a/client-extension/openaaas-mcp-adapter/README.en.md
+++ b/client-extension/openaaas-mcp-adapter/README.en.md
@@ -182,7 +182,7 @@ list_servers()
 | `poll_task` | Poll a task until a final result is obtained. Queries every 20 seconds, no timeout by default; pass `timeout_seconds` to limit maximum polling duration. Agent must NOT call this proactively; ONLY use when the user explicitly asks to wait for or poll a task result |
 | `cancel_task` | Cancel a running task |
 | `list_files` | List result files for the task |
-| `download_result` | Download task result files (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files |
+| `download_result` | Download task result files and return the full path of each file (supports single file via file_id or all files via download_all). When neither file_id is specified nor download_all is true, defaults to preferring .zip files, otherwise downloads the first file. Automatically detects and extracts .zip files. Use the full paths listed in the returned result; do not guess subdirectories |
 | `list_servers` | List all configured servers |
 | `set_default_server` | Switch default server |
 | `remove_server` | Delete configuration for the specified server (cannot delete the default server) |

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -182,7 +182,7 @@ list_servers()
 | `poll_task` | 轮询任务直到获得最终结果。每 20 秒查询一次，默认无超时，可传入 `timeout_seconds` 限制最大轮询时长。Agent 禁止主动调用，仅在用户明确说"帮我等结果"/"轮询任务"时才使用 |
 | `cancel_task` | 取消执行中的任务 |
 | `list_files` | 列出任务的结果文件列表 |
-| `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
+| `download_result` | 下载任务结果文件并返回每个文件的完整路径（支持 file_id 单选或 download_all 全选）。未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件。读取文件时请使用返回结果中列出的完整路径，不要推测子目录 |
 | `list_servers` | 列出所有已配置的服务器 |
 | `set_default_server` | 切换默认服务器 |
 | `remove_server` | 删除指定服务器的配置（不能删除默认服务器） |

--- a/client-extension/openaaas-mcp-adapter/README.md
+++ b/client-extension/openaaas-mcp-adapter/README.md
@@ -178,8 +178,8 @@ list_servers()
 | `list_services` | 列出可用服务（返回轻量摘要：id/name/description/agent_status/access_type/has_permission/registration_status，不含 usage 长文本） |
 | `get_service_usage` | 获取指定服务的详细 usage（能力范围、调用规范、返回格式、限制条件） |
 | `submit_task` | 提交任务到远程 Agent（支持文件上传，支持 `session_id` 保持对话上下文） |
-| `get_task` | 查询任务状态和最终结果（仅在用户要求时调用，不要主动轮询） |
-| `poll_task` | 轮询任务直到获得最终结果。每 20 秒查询一次，默认无超时，可传入 `timeout_seconds` 限制最大轮询时长。不建议 Agent 主动调用，应在用户明确提出需要等待/轮询任务结果时再使用 |
+| `get_task` | 查询任务状态和最终结果（仅在用户明确要求时调用，不要主动轮询） |
+| `poll_task` | 轮询任务直到获得最终结果。每 20 秒查询一次，默认无超时，可传入 `timeout_seconds` 限制最大轮询时长。Agent 禁止主动调用，仅在用户明确说"帮我等结果"/"轮询任务"时才使用 |
 | `cancel_task` | 取消执行中的任务 |
 | `list_files` | 列出任务的结果文件列表 |
 | `download_result` | 下载任务结果文件（支持 file_id 单选或 download_all 全选），未指定 file_id 且 download_all=false 时默认优先下载 .zip 文件，否则下载第一个文件。自动检测并解压 .zip 文件 |
@@ -237,10 +237,10 @@ list_servers()
 3. `list_services` — 获取轻量服务列表（id/name/description/agent_status/access_type/has_permission/registration_status），浏览并筛选候选服务
 4. `get_service_usage` — 对筛选出的候选服务，按需获取详细 usage（能力范围、调用规范、返回格式、限制条件）
 5. 根据 usage 内容，构造正确的 `task_prompt` 和 `output_prompt`
-6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`
-7. `get_task` — 仅在用户明确要求时调用，查询任务状态和最终结果（不要主动轮询）
-8. `poll_task` — 如需等待任务结束，可轮询直到任务完成（每 20 秒一次，默认无超时）
-9. `download_result` — 任务完成后下载结果文件
+6. `submit_task` — 提交任务（可附带文件），保存返回的 `task_id`。提交后应询问用户是否需要等待结果，不要主动轮询
+7. `get_task` — 仅在用户明确要求查询任务状态时调用（不要主动轮询）
+8. `poll_task` — 仅在用户明确说"帮我等结果"/"轮询任务"时使用，每 20 秒查询一次，默认无超时
+9. `download_result` — 任务完成后，用户要求下载结果文件时调用
 
 ### 为什么这样设计
 

--- a/client-extension/openaaas-mcp-adapter/pyproject.toml
+++ b/client-extension/openaaas-mcp-adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openaaas-mcp-adapter"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenAaaS MCP adapter — connect Claude Desktop, Cursor, Cline to OpenAaaS Server"
 readme = "PYPI_README.md"
 requires-python = ">=3.10"

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/__init__.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/__init__.py
@@ -1,3 +1,3 @@
 """OpenAaaS MCP Adapter"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
@@ -947,10 +947,12 @@ def register_tools(mcp: FastMCP) -> None:
         server: str = "",
     ) -> str:
         """
-        下载任务结果文件
+        下载任务结果文件并返回每个文件的完整路径
 
         - file_id: 指定要下载的文件 ID，不指定则默认下载第一个 zip 文件或第一个文件
         - download_all: 是否下载该任务的所有结果文件
+
+        返回结果中会明确列出每个文件的完整路径，读取文件时请直接使用这些路径，不要推测子目录。
         """
         if not task_id:
             return "❌ 缺少必填参数: task_id"
@@ -1099,6 +1101,10 @@ def register_tools(mcp: FastMCP) -> None:
             f"成功下载: {len(downloaded)} 个文件",
         ]
 
+        lines.append("文件列表（请使用下方列出的完整路径，不要推测子目录）:")
+        for item in downloaded:
+            lines.append(f"  - {item['filename']}: {item['path']}")
+
         if extracted_dirs:
             lines.append(f"自动解压目录: {len(extracted_dirs)} 个")
             for d in extracted_dirs:
@@ -1113,7 +1119,7 @@ def register_tools(mcp: FastMCP) -> None:
             for err in errors:
                 lines.append(f"  - {err}")
 
-        lines.append("\n💡 提示: 同一任务多次下载会覆盖到同一目录。")
+        lines.append("\n💡 提示: 同一任务多次下载会覆盖到同一目录；读取文件时请使用上面列出的完整路径。")
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
+++ b/client-extension/openaaas-mcp-adapter/src/openaaas_mcp_adapter/tools.py
@@ -676,8 +676,8 @@ def register_tools(mcp: FastMCP) -> None:
             f"✅ 任务提交成功！\n"
             f"任务 ID: {task_id}\n"
             f"状态: {status}\n\n"
-            "⏳ 任务正在后台执行，请稍后使用 get_task 查询结果。\n"
-            "请勿频繁轮询，建议等待一段时间后再查询。"
+            "⏳ 任务正在后台执行。请询问用户是否需要等待结果。\n"
+            "如果用户没有明确说'帮我等结果'或'轮询任务'，不要主动调用 poll_task 或 get_task。"
         )
 
     # ------------------------------------------------------------------
@@ -685,7 +685,10 @@ def register_tools(mcp: FastMCP) -> None:
     # ------------------------------------------------------------------
     @mcp.tool()
     def get_task(task_id: str, server: str = "") -> str:
-        """查询任务状态和最终结果"""
+        """查询任务状态和最终结果（仅在用户明确要求时调用）
+
+        ⚠️ 不要主动轮询。只有在用户明确要求查询任务状态时，才调用此工具。
+        """
         if not task_id:
             return "❌ 缺少必填参数: task_id"
 
@@ -762,12 +765,14 @@ def register_tools(mcp: FastMCP) -> None:
         timeout_seconds: float | None = None,
         server: str = "",
     ) -> str:
-        """轮询任务直到获得最终结果
+        """轮询任务直到获得最终结果（仅用户明确要求时使用）
 
         每 20 秒查询一次任务状态，直到任务进入 completed / failed / cancelled 状态。
         默认不设置超时；传入 timeout_seconds 可限制最大轮询时长。
 
-        注意：不建议 Agent 主动调用此工具，应在用户明确提出需要等待/轮询任务结果时再使用。
+        ⚠️ 重要：Agent 禁止主动调用此工具。ONLY use this tool when the user explicitly
+        asks to wait for or poll a task result (e.g. "帮我等结果"、"轮询一下任务").
+        如果用户没有明确表达等待意图，应询问用户而不是直接轮询。
         """
         if not task_id:
             return "❌ 缺少必填参数: task_id"


### PR DESCRIPTION
## 修复内容

本次 PR 是 #129 合并后的补充修复：

### 1. 防止 Agent 在 submit_task 后自动轮询

- 强化 "poll_task" 工具描述：Agent 禁止主动调用，仅在用户明确说"帮我等结果"、"轮询任务"时才使用。
- 强化 "get_task" 工具描述：仅在用户明确要求查询任务状态时调用，不要主动轮询。
- 调整 "submit_task" 返回信息：提交成功后提示 Agent 询问用户是否需要等待结果，未明确授权不要调用 poll_task/get_task。
- 同步更新中英文 README 的工具描述和使用流程。

### 2. 修复 download_result 返回路径不清晰问题

- 在返回结果中明确列出每个下载文件的完整路径。
- 增加提示：读取文件时请使用返回的完整路径，不要推测子目录。
- 更新 docstring 和 README，避免 Agent 出现类似  的路径幻觉。

## 测试

- 本地测试全部通过：120 passed。
