### PR TITLE
docs(readme): remove ICP filing service status notice

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,3 @@
-> ⚠️ **Service Status Notice**: Due to domain name filing (ICP备案), the public service nodes at `api.open-aaas.com` and `www.open-aaas.com` are temporarily inaccessible. Service is expected to resume in approximately one week. In the meantime, you can continue using OpenAaaS via [local deployment](#deploy-your-own-node).
-
 <p align="right"><a href="./README.md">中文</a> | English</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> ⚠️ **服务状态提醒**：由于域名备案中，`api.open-aaas.com` 及 `www.open-aaas.com` 公开服务节点暂时无法访问，预计约一周恢复。在此期间，您可以通过 [本地部署](#部署自己的节点) 继续使用 OpenAaaS。
-
 <p align="right">中文 | <a href="./README.en.md">English</a></p>
 
 <p align="center">


### PR DESCRIPTION
## 变更

- 域名备案已完成，`api.open-aaas.com` 与 `www.open-aaas.com` 公开服务节点已恢复访问。
- 删除 `README.md` 与 `README.en.md` 顶部的临时服务状态提醒横幅。

## 检查项

- [x] 中文 README 备案提示已删除
- [x] 英文 README 备案提示已删除
- [x] 两段删除范围对称，未误删其他内容