### PR TITLE
fix(agent-core): remove partial API key stdout and add bounds check in register.rs

### DIFF
--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 修复 `spawn_task` 中的静默失败：所有 `let _ = ...` 改为显式 `error!` 日志
 - `upsert_task` 失败后立即上报 Failed 并终止任务执行，不再无状态记录地继续运行
-- 移除 `register.rs` 中 API Key 的 stdout 输出及不安全切片 (#137)
+- 移除 `register.rs` 中 API Key 的 stdout 输出及不安全切片，并增加 Service ID 为空的回退提示 (#137)
 
 ## [0.4.1] - 2026-06-04
 

--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 修复 `spawn_task` 中的静默失败：所有 `let _ = ...` 改为显式 `error!` 日志
 - `upsert_task` 失败后立即上报 Failed 并终止任务执行，不再无状态记录地继续运行
+- 移除 `register.rs` 中 API Key 的 stdout 输出及不安全切片 (#137)
 
 ## [0.4.1] - 2026-06-04
 

--- a/agent-core/src/cmd/register.rs
+++ b/agent-core/src/cmd/register.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use agent_core::{client::ApiClient, config::Config, main_support::*};
+use std::path::PathBuf;
 use tracing::{error, info};
 
 pub async fn register(
@@ -19,10 +19,13 @@ pub async fn register(
     // 检查是否已注册
     info!("步骤 2: 检查是否已注册...");
     if config.agent.has_credentials() {
-        println!(
-            "Agent 已注册: {}",
-            config.agent.service_id.as_ref().unwrap()
-        );
+        let service_id = config
+            .agent
+            .service_id
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .unwrap_or("未知");
+        println!("Agent 已注册: {}", service_id);
         println!("如需重新注册，请删除配置文件后重试");
         return Ok(());
     }
@@ -63,11 +66,15 @@ pub async fn register(
             config.save_to_path(&config_path).await?;
 
             println!("注册成功！");
-            println!("Service ID: {}", config.agent.service_id.as_ref().unwrap());
-            println!(
-                "API Key: {}...",
-                &config.agent.api_key.as_ref().unwrap()[..20]
-            );
+            match config
+                .agent
+                .service_id
+                .as_deref()
+                .filter(|id| !id.trim().is_empty())
+            {
+                Some(service_id) => println!("Service ID: {}", service_id),
+                None => eprintln!("警告：注册成功但 Service ID 为空，请检查服务端响应"),
+            }
             println!("配置已保存");
         }
         Err(e) => {


### PR DESCRIPTION
修复 register.rs 中注册成功时向 stdout 打印 API Key 前缀片段的问题，并替换对 service_id 和 API key 的 unwrap/切片操作为更安全的 as_deref/filter 处理，避免空值或长度不足时 panic。

Fixes #136