### PR TITLE
fix(server): 按 API Key 限流与审计日志 (#133)

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -55,6 +55,9 @@ urlencoding = "2.1"
 # 流式 IO
 tokio-util = { version = "0.7", features = ["io"] }
 
+# 并发限流
+dashmap = "6.1"
+
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }

--- a/server/config.toml.example
+++ b/server/config.toml.example
@@ -13,6 +13,8 @@ addr = "0.0.0.0:8080"
 timeout_secs = 30
 # 最大请求体大小(字节)
 max_body_size = 10485760
+# 是否信任 X-Forwarded-For 获取来源 IP（默认 false，仅在受信任反向代理后开启）
+trust_x_forwarded_for = false
 
 [database]
 # 数据库连接URL (SQLite)

--- a/server/src/audit.rs
+++ b/server/src/audit.rs
@@ -1,0 +1,61 @@
+//! 审计日志模块
+//!
+//! 记录关键安全事件：注册请求、认证失败等。
+//! 来源 IP 默认使用连接 IP；当配置 `trust_x_forwarded_for = true` 时，
+//! 从 `X-Forwarded-For` 最左侧取值。
+
+use axum::extract::Request;
+use axum::extract::connect_info::ConnectInfo;
+use std::net::SocketAddr;
+
+/// 从请求中提取来源 IP
+pub fn extract_client_ip(req: &Request, trust_x_forwarded_for: bool) -> Option<String> {
+    if trust_x_forwarded_for
+        && let Some(value) = req.headers().get("X-Forwarded-For")
+        && let Ok(s) = value.to_str()
+        && let Some(first) = s.split(',').next()
+    {
+        let ip = first.trim();
+        if !ip.is_empty() {
+            return Some(ip.to_string());
+        }
+    }
+
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip().to_string())
+}
+
+/// 记录 Client 注册审计日志
+pub fn log_client_register(name: &str, ip: Option<&str>) {
+    tracing::info!(
+        audit_event = "client_register",
+        name = name,
+        client_ip = ip.unwrap_or("unknown"),
+        "Client 注册请求"
+    );
+}
+
+/// 记录 Agent 注册审计日志
+pub fn log_agent_register(service_name: &str, ip: Option<&str>) {
+    tracing::info!(
+        audit_event = "agent_register",
+        service_name = service_name,
+        client_ip = ip.unwrap_or("unknown"),
+        "Agent 注册请求"
+    );
+}
+
+/// 记录认证失败审计日志
+///
+/// `identifier` 应当是已脱敏的标识，例如 API Key 的 HMAC 前缀或服务 ID。
+pub fn log_auth_failure(kind: &str, identifier: &str, ip: Option<&str>, reason: &str) {
+    tracing::warn!(
+        audit_event = "auth_failure",
+        kind = kind,
+        identifier = identifier,
+        client_ip = ip.unwrap_or("unknown"),
+        reason = reason,
+        "认证失败"
+    );
+}

--- a/server/src/audit.rs
+++ b/server/src/audit.rs
@@ -36,15 +36,35 @@ pub fn log_client_register(name: &str, ip: Option<&str>) {
     );
 }
 
-/// 对敏感 token 进行前缀掩码，保留前 4 位和后 4 位，中间用 `...` 代替。
+/// 对敏感 token 进行字符级掩码，避免泄露完整 token。
+///
+/// 掩码策略按字符长度分级：
+/// - 长度 ≤ 2：仅保留首个字符，其余用 `...` 代替。
+/// - 长度 ≤ 8：保留首尾各 1 个字符，中间用 `...` 代替。
+/// - 长度 ≤ 12：保留首尾各 2 个字符，中间用 `...` 代替。
+/// - 长度 > 12：保留前 4 个字符和后 4 个字符，中间用 `...` 代替。
+///
+/// 使用字符边界切片，对多字节 UTF-8 字符安全，不会 panic。
 ///
 /// 例如 `rt_abc123def456` -> `rt_a...f456`。
 pub fn mask_token(token: &str) -> String {
-    let len = token.len();
-    if len <= 8 {
+    let chars: Vec<char> = token.chars().collect();
+    let len = chars.len();
+
+    if len == 0 {
         "...".to_string()
+    } else if len <= 2 {
+        format!("{}...", chars[0])
+    } else if len <= 8 {
+        format!("{}...{}", chars[0], chars[len - 1])
+    } else if len <= 12 {
+        let head: String = chars.iter().take(2).collect();
+        let tail: String = chars.iter().rev().take(2).rev().collect();
+        format!("{}...{}", head, tail)
     } else {
-        format!("{}...{}", &token[..4], &token[len - 4..])
+        let head: String = chars.iter().take(4).collect();
+        let tail: String = chars.iter().rev().take(4).rev().collect();
+        format!("{}...{}", head, tail)
     }
 }
 
@@ -72,4 +92,145 @@ pub fn log_auth_failure(kind: &str, identifier: &str, ip: Option<&str>, reason: 
         reason = reason,
         "认证失败"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::HeaderValue;
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    fn request_with_xff(xff: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().uri("/test");
+        if let Some(value) = xff {
+            builder = builder.header("X-Forwarded-For", value);
+        }
+        builder.body(Body::empty()).unwrap()
+    }
+
+    fn request_with_connect_info(ip: &str) -> Request<Body> {
+        let mut req = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        let addr = SocketAddr::new(ip.parse::<Ipv4Addr>().unwrap().into(), 8080);
+        req.extensions_mut().insert(ConnectInfo(addr));
+        req
+    }
+
+    fn request_with_both(xff: &str, ip: &str) -> Request<Body> {
+        let mut req = request_with_connect_info(ip);
+        req.headers_mut()
+            .insert("X-Forwarded-For", HeaderValue::from_str(xff).unwrap());
+        req
+    }
+
+    #[test]
+    fn test_extract_client_ip_no_xff_uses_connect_info() {
+        let req = request_with_connect_info("192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, false),
+            Some("192.168.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_distrust_xff_uses_connect_info() {
+        let req = request_with_both("10.0.0.1", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, false),
+            Some("192.168.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_trust_xff_single_ip() {
+        let req = request_with_both("10.0.0.1", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, true),
+            Some("10.0.0.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_trust_xff_multiple_ips_takes_leftmost() {
+        let req = request_with_both("203.0.113.1, 10.0.0.2, 10.0.0.3", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, true),
+            Some("203.0.113.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_trust_xff_trims_whitespace() {
+        let req = request_with_both("  203.0.113.1  ", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, true),
+            Some("203.0.113.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_xff_empty_falls_back_to_connect_info() {
+        let req = request_with_both("", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, true),
+            Some("192.168.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_xff_only_commas_falls_back_to_connect_info() {
+        let req = request_with_both(", ,", "192.168.1.1");
+        assert_eq!(
+            extract_client_ip(&req, true),
+            Some("192.168.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_client_ip_no_xff_no_connect_info() {
+        let req = request_with_xff(None);
+        assert_eq!(extract_client_ip(&req, false), None);
+    }
+
+    #[test]
+    fn test_mask_token_ascii() {
+        assert_eq!(mask_token("rt_abc123def456"), "rt_a...f456");
+    }
+
+    #[test]
+    fn test_mask_token_multibyte_utf8() {
+        // 前缀与后缀都是多字节 UTF-8 字符，长度 > 12，保留前 4 / 后 4 字符
+        let token = "测试令牌abc123xyz";
+        assert_eq!(mask_token(token), "测试令牌...3xyz");
+    }
+
+    #[test]
+    fn test_mask_token_empty() {
+        assert_eq!(mask_token(""), "...");
+    }
+
+    #[test]
+    fn test_mask_token_short_very_short() {
+        assert_eq!(mask_token("a"), "a...");
+        assert_eq!(mask_token("ab"), "a...");
+    }
+
+    #[test]
+    fn test_mask_token_short_up_to_8() {
+        assert_eq!(mask_token("abc"), "a...c");
+        assert_eq!(mask_token("abcdefgh"), "a...h");
+    }
+
+    #[test]
+    fn test_mask_token_short_up_to_12() {
+        assert_eq!(mask_token("abcdefghi"), "ab...hi");
+        assert_eq!(mask_token("abcdefghijkl"), "ab...kl");
+    }
+
+    #[test]
+    fn test_mask_token_multibyte_does_not_panic() {
+        // 验证字符级切片对多字节 UTF-8 安全，不会 panic。
+        let token = "中文字符测试令牌";
+        let _ = mask_token(token);
+    }
 }

--- a/server/src/audit.rs
+++ b/server/src/audit.rs
@@ -39,7 +39,7 @@ pub fn log_client_register(name: &str, ip: Option<&str>) {
 /// 对敏感 token 进行字符级掩码，避免泄露完整 token。
 ///
 /// 掩码策略按字符长度分级：
-/// - 长度 ≤ 2：仅保留首个字符，其余用 `...` 代替。
+/// - 长度 ≤ 2：统一返回 `...`，避免泄露 50%~100% 原始字符。
 /// - 长度 ≤ 8：保留首尾各 1 个字符，中间用 `...` 代替。
 /// - 长度 ≤ 12：保留首尾各 2 个字符，中间用 `...` 代替。
 /// - 长度 > 12：保留前 4 个字符和后 4 个字符，中间用 `...` 代替。
@@ -51,10 +51,8 @@ pub fn mask_token(token: &str) -> String {
     let chars: Vec<char> = token.chars().collect();
     let len = chars.len();
 
-    if len == 0 {
+    if len <= 2 {
         "...".to_string()
-    } else if len <= 2 {
-        format!("{}...", chars[0])
     } else if len <= 8 {
         format!("{}...{}", chars[0], chars[len - 1])
     } else if len <= 12 {
@@ -211,8 +209,8 @@ mod tests {
 
     #[test]
     fn test_mask_token_short_very_short() {
-        assert_eq!(mask_token("a"), "a...");
-        assert_eq!(mask_token("ab"), "a...");
+        assert_eq!(mask_token("a"), "...");
+        assert_eq!(mask_token("ab"), "...");
     }
 
     #[test]

--- a/server/src/audit.rs
+++ b/server/src/audit.rs
@@ -36,11 +36,25 @@ pub fn log_client_register(name: &str, ip: Option<&str>) {
     );
 }
 
+/// 对敏感 token 进行前缀掩码，保留前 4 位和后 4 位，中间用 `...` 代替。
+///
+/// 例如 `rt_abc123def456` -> `rt_a...f456`。
+pub fn mask_token(token: &str) -> String {
+    let len = token.len();
+    if len <= 8 {
+        "...".to_string()
+    } else {
+        format!("{}...{}", &token[..4], &token[len - 4..])
+    }
+}
+
 /// 记录 Agent 注册审计日志
-pub fn log_agent_register(service_name: &str, ip: Option<&str>) {
+///
+/// `registration_token` 在记录前会被掩码，避免完整 token 泄露。
+pub fn log_agent_register(registration_token: &str, ip: Option<&str>) {
     tracing::info!(
         audit_event = "agent_register",
-        service_name = service_name,
+        registration_token = mask_token(registration_token),
         client_ip = ip.unwrap_or("unknown"),
         "Agent 注册请求"
     );

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sqlx::SqlitePool;
 
+use crate::audit::{extract_client_ip, log_auth_failure};
 use crate::error::{AppError, Result};
 use crate::state::AppState;
 
@@ -68,8 +69,11 @@ pub async fn require_auth(
         .as_ref()
         .ok_or_else(|| AppError::Internal("Secret key not configured".to_string()))?;
 
+    let client_ip = extract_client_ip(&request, state.config.server.trust_x_forwarded_for);
+
     // 验证 api_key 并查询用户信息
-    let auth_user = verify_client_api_key(state.db.pool(), secret_key, &api_key).await?;
+    let auth_user =
+        verify_client_api_key(state.db.pool(), secret_key, &api_key, client_ip.as_deref()).await?;
 
     // 将用户信息附加到请求扩展
     request.extensions_mut().insert(auth_user);
@@ -95,7 +99,7 @@ pub async fn require_admin(
 }
 
 /// 从 Authorization header 提取 Bearer token
-fn extract_bearer_token(request: &Request) -> Result<String> {
+pub(crate) fn extract_bearer_token(request: &Request) -> Result<String> {
     let auth_header = request
         .headers()
         .get(header::AUTHORIZATION)
@@ -122,12 +126,13 @@ pub async fn verify_client_api_key(
     pool: &SqlitePool,
     secret_key: &str,
     api_key: &str,
+    client_ip: Option<&str>,
 ) -> Result<AuthUser> {
     let hashed_api_key = hash_api_key(secret_key, api_key);
     let row = sqlx::query_as::<_, (String, String, String)>(
         "SELECT id, api_key, role FROM users WHERE api_key = ?",
     )
-    .bind(hashed_api_key)
+    .bind(&hashed_api_key)
     .fetch_optional(pool)
     .await
     .map_err(AppError::Database)?;
@@ -138,7 +143,12 @@ pub async fn verify_client_api_key(
             api_key,
             role,
         }),
-        None => Err(AppError::Auth("无效的 API Key".to_string())),
+        None => {
+            // 使用 Key 哈希前 16 位作为脱敏标识
+            let identifier = &hashed_api_key[..hashed_api_key.len().min(16)];
+            log_auth_failure("client", identifier, client_ip, "无效的 API Key");
+            Err(AppError::Auth("无效的 API Key".to_string()))
+        }
     }
 }
 
@@ -153,6 +163,7 @@ pub async fn verify_agent_credentials(
     secret_key: &str,
     service_id: &str,
     api_key: &str,
+    client_ip: Option<&str>,
 ) -> Result<()> {
     let hashed_api_key = hash_api_key(secret_key, api_key);
     let row = sqlx::query_as::<_, (String, String)>(
@@ -168,10 +179,14 @@ pub async fn verify_agent_credentials(
             if stored_api_key == hashed_api_key {
                 Ok(())
             } else {
+                log_auth_failure("agent", service_id, client_ip, "API Key 无效");
                 Err(AppError::Auth("API Key 无效".to_string()))
             }
         }
-        None => Err(AppError::Auth("服务不存在".to_string())),
+        None => {
+            log_auth_failure("agent", service_id, client_ip, "服务不存在");
+            Err(AppError::Auth("服务不存在".to_string()))
+        }
     }
 }
 
@@ -264,13 +279,22 @@ pub async fn agent_auth_middleware(
         return Err(AppError::Auth("API Key 不能为空".to_string()));
     }
 
+    let client_ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
+
     // 验证 Agent 凭证
     let secret_key = state
         .config
         .secret_key
         .as_ref()
         .ok_or_else(|| AppError::Internal("Secret key not configured".to_string()))?;
-    verify_agent_credentials(state.db.pool(), secret_key, &service_id, &api_key).await?;
+    verify_agent_credentials(
+        state.db.pool(),
+        secret_key,
+        &service_id,
+        &api_key,
+        client_ip.as_deref(),
+    )
+    .await?;
 
     // 将 agent 信息附加到请求扩展
     req.extensions_mut().insert(AuthAgent {
@@ -556,7 +580,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = verify_client_api_key(&pool, secret_key, "ak_test_valid_key").await;
+        let result = verify_client_api_key(&pool, secret_key, "ak_test_valid_key", None).await;
         assert!(result.is_ok());
 
         let auth_user = result.unwrap();
@@ -569,7 +593,7 @@ mod tests {
         let pool = setup_test_db().await;
         let secret_key = "test-secret-key-for-unit-tests-only";
 
-        let result = verify_client_api_key(&pool, secret_key, "ak_nonexistent").await;
+        let result = verify_client_api_key(&pool, secret_key, "ak_nonexistent", None).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppError::Auth(msg) => assert!(msg.contains("无效")),
@@ -591,7 +615,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = verify_client_api_key(&pool, secret_key, "ak_admin_key").await;
+        let result = verify_client_api_key(&pool, secret_key, "ak_admin_key", None).await;
         assert!(result.is_ok());
 
         let auth_user = result.unwrap();
@@ -616,7 +640,8 @@ mod tests {
             .unwrap();
 
         let result =
-            verify_agent_credentials(&pool, secret_key, "service_123", "ak_agent_valid").await;
+            verify_agent_credentials(&pool, secret_key, "service_123", "ak_agent_valid", None)
+                .await;
         assert!(result.is_ok());
     }
 
@@ -635,7 +660,8 @@ mod tests {
             .await
             .unwrap();
 
-        let result = verify_agent_credentials(&pool, secret_key, "service_123", "wrong_key").await;
+        let result =
+            verify_agent_credentials(&pool, secret_key, "service_123", "wrong_key", None).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppError::Auth(msg) => assert!(msg.contains("无效")),
@@ -649,7 +675,8 @@ mod tests {
         let secret_key = "test-secret-key-for-unit-tests-only";
 
         let result =
-            verify_agent_credentials(&pool, secret_key, "nonexistent_service", "some_key").await;
+            verify_agent_credentials(&pool, secret_key, "nonexistent_service", "some_key", None)
+                .await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppError::Auth(msg) => assert!(msg.contains("不存在")),

--- a/server/src/cmd/run.rs
+++ b/server/src/cmd/run.rs
@@ -44,10 +44,11 @@ pub async fn run_foreground(config_path: PathBuf) -> anyhow::Result<()> {
 
     // 2. 加载配置
     tracing::info!(
-        "Server config: addr={}, timeout_secs={}, max_body_size={}",
+        "Server config: addr={}, timeout_secs={}, max_body_size={}, trust_x_forwarded_for={}",
         config.server.addr,
         config.server.timeout_secs,
-        config.server.max_body_size
+        config.server.max_body_size,
+        config.server.trust_x_forwarded_for
     );
     tracing::info!("Database config: {:?}", config.database);
 

--- a/server/src/cmd/run.rs
+++ b/server/src/cmd/run.rs
@@ -1,6 +1,7 @@
 use crate::cli;
 use axum::{Router, extract::DefaultBodyLimit};
 use open_aaas_server::{handlers, main_support::*, state::AppState};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -130,6 +131,13 @@ pub async fn run_foreground(config_path: PathBuf) -> anyhow::Result<()> {
     let _heartbeat_handle =
         crate::bg_tasks::spawn_heartbeat_task(state.clone(), shutdown_tx.clone());
 
+    // 7a. 启动限流器空 bucket 清理后台任务
+    let _rate_limit_prune_handle =
+        open_aaas_server::rate_limit::spawn_rate_limiter_prune_task(
+            state.clone(),
+            shutdown_tx.clone(),
+        );
+
     // 8. 启动后台任务清理任务
     let retention_days = config.task.result_retention_days;
     let (cleanup_shutdown_tx, _cleanup_shutdown_rx) = watch::channel(false);
@@ -144,7 +152,7 @@ pub async fn run_foreground(config_path: PathBuf) -> anyhow::Result<()> {
     tracing::info!("Server listening on {}", config.server_addr());
 
     // 优雅关闭
-    axum::serve(listener, app)
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
         .with_graceful_shutdown(async move {
             shutdown_signal().await;
             let _ = shutdown_tx.send(());

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -16,6 +16,9 @@ pub struct ServerConfig {
     /// 最大请求体大小(字节)
     #[serde(default = "default_max_body_size")]
     pub max_body_size: usize,
+    /// 是否信任 X-Forwarded-For 头部获取来源 IP（仅在受信任反向代理后开启）
+    #[serde(default = "default_trust_x_forwarded_for")]
+    pub trust_x_forwarded_for: bool,
 }
 
 impl Default for ServerConfig {
@@ -24,6 +27,7 @@ impl Default for ServerConfig {
             addr: default_server_addr(),
             timeout_secs: default_timeout_secs(),
             max_body_size: default_max_body_size(),
+            trust_x_forwarded_for: default_trust_x_forwarded_for(),
         }
     }
 }
@@ -197,6 +201,14 @@ impl AppConfig {
         lines.push(format!("timeout_secs = {}", self.server.timeout_secs));
         lines.push("# 最大请求体大小(字节)".to_string());
         lines.push(format!("max_body_size = {}", self.server.max_body_size));
+        lines.push(
+            "# 是否信任 X-Forwarded-For 获取来源 IP（默认 false，仅在受信任反向代理后开启）"
+                .to_string(),
+        );
+        lines.push(format!(
+            "trust_x_forwarded_for = {}",
+            self.server.trust_x_forwarded_for
+        ));
         lines.push("".to_string());
         lines.push("[database]".to_string());
         lines.push("# 数据库连接URL (SQLite)".to_string());
@@ -249,6 +261,10 @@ fn default_timeout_secs() -> u64 {
 
 fn default_max_body_size() -> usize {
     10 * 1024 * 1024 // 10MB
+}
+
+fn default_trust_x_forwarded_for() -> bool {
+    false
 }
 
 fn default_database_url() -> String {
@@ -341,6 +357,7 @@ mod tests {
         assert_eq!(config.addr.to_string(), "0.0.0.0:8080");
         assert_eq!(config.timeout_secs, 30);
         assert_eq!(config.max_body_size, 10 * 1024 * 1024);
+        assert!(!config.trust_x_forwarded_for);
     }
 
     #[test]

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     Json,
-    http::StatusCode,
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
@@ -93,11 +93,18 @@ impl IntoResponse for AppError {
                 // 对外统一返回“认证失败”，避免泄露内部细节（如 key 是否存在）
                 (StatusCode::UNAUTHORIZED, "Auth", "认证失败".to_string())
             }
-            AppError::RateLimited => (
-                StatusCode::TOO_MANY_REQUESTS,
-                "RateLimited",
-                "请求过于频繁，请稍后再试".to_string(),
-            ),
+            AppError::RateLimited => {
+                let body = Json(ErrorResponse {
+                    error: "RateLimited".to_string(),
+                    message: "请求过于频繁，请稍后再试".to_string(),
+                });
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(header::RETRY_AFTER, "60")],
+                    body,
+                )
+                    .into_response();
+            }
             AppError::Forbidden => (StatusCode::FORBIDDEN, "Forbidden", self.to_string()),
             AppError::Conflict(msg) => (StatusCode::CONFLICT, "Conflict", msg.clone()),
             AppError::Other(e) => {

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -50,6 +50,10 @@ pub enum AppError {
     #[error("资源冲突: {0}")]
     Conflict(String),
 
+    /// 请求过于频繁
+    #[error("请求过于频繁，请稍后再试")]
+    RateLimited,
+
     /// 其他错误
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -85,7 +89,15 @@ impl IntoResponse for AppError {
                 )
             }
             AppError::Config(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "Config", msg.clone()),
-            AppError::Auth(msg) => (StatusCode::UNAUTHORIZED, "Auth", msg.clone()),
+            AppError::Auth(_) => {
+                // 对外统一返回“认证失败”，避免泄露内部细节（如 key 是否存在）
+                (StatusCode::UNAUTHORIZED, "Auth", "认证失败".to_string())
+            }
+            AppError::RateLimited => (
+                StatusCode::TOO_MANY_REQUESTS,
+                "RateLimited",
+                "请求过于频繁，请稍后再试".to_string(),
+            ),
             AppError::Forbidden => (StatusCode::FORBIDDEN, "Forbidden", self.to_string()),
             AppError::Conflict(msg) => (StatusCode::CONFLICT, "Conflict", msg.clone()),
             AppError::Other(e) => {
@@ -282,6 +294,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rate_limited_into_response() {
+        let err = AppError::RateLimited;
+        let response = err.into_response();
+        let (status, error, message) = extract_response_info(response).await;
+
+        assert_eq!(status, 429);
+        assert_eq!(error, "RateLimited");
+        assert_eq!(message, "请求过于频繁，请稍后再试");
+    }
+
+    #[tokio::test]
     async fn test_other_into_response() {
         let err = AppError::Other(anyhow::anyhow!("未知异常"));
         let response = err.into_response();
@@ -341,6 +364,7 @@ mod tests {
         let _ = AppError::Auth("test".to_string());
         let _ = AppError::Forbidden;
         let _ = AppError::Conflict("test".to_string());
+        let _ = AppError::RateLimited;
         let _ = AppError::Other(anyhow::anyhow!("test"));
     }
 
@@ -390,6 +414,7 @@ mod tests {
             (AppError::Auth("".to_string()), 401),
             (AppError::Forbidden, 403),
             (AppError::Conflict("".to_string()), 409),
+            (AppError::RateLimited, 429),
             (AppError::Other(anyhow::anyhow!("")), 500),
         ];
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -312,6 +312,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rate_limited_includes_retry_after_header() {
+        let err = AppError::RateLimited;
+        let response = err.into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&header::HeaderValue::from_static("60")
+            )
+        );
+    }
+
+    #[tokio::test]
     async fn test_other_into_response() {
         let err = AppError::Other(anyhow::anyhow!("未知异常"));
         let response = err.into_response();

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -311,8 +311,8 @@ mod tests {
         assert_eq!(message, "请求过于频繁，请稍后再试");
     }
 
-    #[tokio::test]
-    async fn test_rate_limited_includes_retry_after_header() {
+    #[test]
+    fn test_rate_limited_includes_retry_after_header() {
         let err = AppError::RateLimited;
         let response = err.into_response();
 

--- a/server/src/handlers/admin.rs
+++ b/server/src/handlers/admin.rs
@@ -25,6 +25,7 @@ use crate::{
         service::UserPermissionResponse,
         user::{UpdateUserRoleRequest, User, UserResponse},
     },
+    rate_limit::client_rate_limit_middleware,
     state::AppState,
 };
 
@@ -84,8 +85,12 @@ pub fn routes(state: AppState) -> Router<AppState> {
         )
         .layer(middleware::from_fn(require_admin))
         .layer(middleware::from_fn_with_state(
-            state,
+            state.clone(),
             crate::auth::require_auth,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state,
+            client_rate_limit_middleware,
         ))
 }
 

--- a/server/src/handlers/agent.rs
+++ b/server/src/handlers/agent.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
 use crate::{
+    audit::{extract_client_ip, log_agent_register},
     auth::{AuthAgent, agent_auth_middleware},
     error::{AppError, Result},
     models::{
@@ -24,6 +25,7 @@ use crate::{
         service::{AgentStatus, Service},
         task::{Task, TaskInput, TaskStatus},
     },
+    rate_limit::agent_rate_limit_middleware,
     state::AppState,
 };
 use serde_json::json;
@@ -35,13 +37,20 @@ pub fn routes(state: AppState) -> Router<AppState> {
     // 公开路由
     let public_routes = Router::new().route("/register", post(register_service_agent));
 
-    // 需要认证的路由 - 使用 from_fn_with_state 添加 Agent 鉴权中间件
+    // 需要认证的路由 - 使用 from_fn_with_state 添加限流 + Agent 鉴权中间件
     let authenticated_routes = Router::new()
         .route("/{service_id}/poll", post(poll_handler))
         .route("/{service_id}/accept", post(accept_handler))
         .route("/{service_id}/complete", post(complete_handler))
         .route("/{service_id}/heartbeat", post(heartbeat_handler))
-        .layer(middleware::from_fn_with_state(state, agent_auth_middleware));
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            agent_auth_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state,
+            agent_rate_limit_middleware,
+        ));
 
     public_routes.merge(authenticated_routes)
 }
@@ -215,8 +224,19 @@ pub struct CompleteTaskResponse {
 /// 5. 更新服务为 active 状态，清除 registration_token
 pub async fn register_service_agent(
     State(state): State<AppState>,
-    Json(req): Json<RegisterAgentApiRequest>,
+    req: axum::extract::Request,
 ) -> Result<Json<RegisterAgentResponse>> {
+    let client_ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
+
+    // 解析 JSON body
+    let bytes = axum::body::to_bytes(req.into_body(), state.config.server.max_body_size)
+        .await
+        .map_err(|e| AppError::BadRequest(format!("读取请求体失败: {}", e)))?;
+    let req: RegisterAgentApiRequest = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::BadRequest(format!("JSON 解析失败: {}", e)))?;
+
+    log_agent_register(&req.registration_token, client_ip.as_deref());
+
     // 1. 查找服务（通过 registration_token）
     let service: Option<Service> =
         sqlx::query_as::<_, Service>("SELECT * FROM services WHERE registration_token = ?")
@@ -1079,7 +1099,10 @@ mod tests {
     }
 
     /// 创建指定容量的测试服务
-    async fn create_test_service_with_capacity(pool: &SqlitePool, capacity: i64) -> (String, String, String) {
+    async fn create_test_service_with_capacity(
+        pool: &SqlitePool,
+        capacity: i64,
+    ) -> (String, String, String) {
         let service_id = format!("test-service-{}", uuid::Uuid::new_v4());
         let registration_token = format!("rt_{}", uuid::Uuid::new_v4());
         let api_key = format!(

--- a/server/src/handlers/client.rs
+++ b/server/src/handlers/client.rs
@@ -915,7 +915,9 @@ async fn register(
     let req: CreateUserRequest = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::BadRequest(format!("JSON 解析失败: {}", e)))?;
 
-    log_client_register(&req.name, client_ip.as_deref());
+    // 审计日志中对用户提交的 name 做长度截断，避免超长内容写入日志
+    let audit_name: String = req.name.chars().take(64).collect();
+    log_client_register(&audit_name, client_ip.as_deref());
 
     // 0. 验证用户名格式
     let name = validate_username(&req.name)?;

--- a/server/src/handlers/client.rs
+++ b/server/src/handlers/client.rs
@@ -17,6 +17,7 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::{
+    audit::{extract_client_ip, log_client_register},
     auth::AuthUser,
     error::{AppError, Result},
     models::{
@@ -25,6 +26,7 @@ use crate::{
         task::{ListTasksQuery, Task, TaskResponse, TaskStatus},
         user::{CreateUserRequest, UserResponse},
     },
+    rate_limit::client_rate_limit_middleware,
     state::AppState,
 };
 
@@ -121,8 +123,12 @@ pub fn routes(state: AppState) -> Router<AppState> {
         // 用户资料管理
         .route("/profile", put(update_profile))
         .layer(middleware::from_fn_with_state(
-            state,
+            state.clone(),
             crate::auth::require_auth,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state,
+            client_rate_limit_middleware,
         ));
 
     // 公开路由
@@ -158,7 +164,13 @@ struct CreateTaskJsonBody {
 async fn parse_multipart_fields(
     mut multipart: Multipart,
     state: &AppState,
-) -> Result<(String, String, String, Option<String>, Vec<(std::path::PathBuf, String, Option<String>, usize)>)> {
+) -> Result<(
+    String,
+    String,
+    String,
+    Option<String>,
+    Vec<(std::path::PathBuf, String, Option<String>, usize)>,
+)> {
     let mut service_id: Option<String> = None;
     let mut task_prompt: Option<String> = None;
     let mut output_prompt: Option<String> = None;
@@ -285,7 +297,13 @@ async fn parse_multipart_fields(
     let output_prompt =
         output_prompt.ok_or_else(|| AppError::BadRequest("缺少 output_prompt 字段".to_string()))?;
 
-    Ok((service_id, task_prompt, output_prompt, session_id, uploaded_files))
+    Ok((
+        service_id,
+        task_prompt,
+        output_prompt,
+        session_id,
+        uploaded_files,
+    ))
 }
 
 async fn create_task_inner(
@@ -486,13 +504,15 @@ async fn create_task(
     Extension(auth_user): Extension<AuthUser>,
     req: axum::extract::Request,
 ) -> Result<Json<TaskResponse>> {
-    let content_type = req.headers()
+    let content_type = req
+        .headers()
         .get(axum::http::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok());
 
     let (service_id, task_prompt, output_prompt, session_id, uploaded_files) = match content_type {
         Some(ct) if ct.to_ascii_lowercase().starts_with("application/json") => {
-            let bytes = axum::body::to_bytes(req.into_body(), 1024 * 1024).await
+            let bytes = axum::body::to_bytes(req.into_body(), 1024 * 1024)
+                .await
                 .map_err(|e| AppError::BadRequest(format!("读取请求体失败: {}", e)))?;
             let body: CreateTaskJsonBody = serde_json::from_slice(&bytes)
                 .map_err(|e| AppError::BadRequest(format!("JSON 解析失败: {}", e)))?;
@@ -502,25 +522,46 @@ async fn create_task(
                     && !id.contains("..")
                     && !id.contains('/')
                     && id.len() <= 64
-                    && id.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+                    && id
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
                 {
                     Some(id)
                 } else {
-                    tracing::warn!("Invalid session_id '{}' from JSON body, generating new one", id);
+                    tracing::warn!(
+                        "Invalid session_id '{}' from JSON body, generating new one",
+                        id
+                    );
                     None
                 }
             });
 
-            (body.service_id, body.task_prompt, body.output_prompt, session_id, vec![])
+            (
+                body.service_id,
+                body.task_prompt,
+                body.output_prompt,
+                session_id,
+                vec![],
+            )
         }
         _ => {
-            let multipart = Multipart::from_request(req, &state).await
+            let multipart = Multipart::from_request(req, &state)
+                .await
                 .map_err(|e| AppError::BadRequest(format!("解析 multipart 失败: {}", e)))?;
             parse_multipart_fields(multipart, &state).await?
         }
     };
 
-    create_task_inner(&state, &auth_user, service_id, task_prompt, output_prompt, session_id, uploaded_files).await
+    create_task_inner(
+        &state,
+        &auth_user,
+        service_id,
+        task_prompt,
+        output_prompt,
+        session_id,
+        uploaded_files,
+    )
+    .await
 }
 
 /// 获取任务列表
@@ -863,8 +904,19 @@ pub async fn service_status(
 /// 用户注册
 async fn register(
     State(state): State<AppState>,
-    Json(req): Json<CreateUserRequest>,
+    req: axum::extract::Request,
 ) -> Result<Json<UserResponse>> {
+    let client_ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
+
+    // 解析 JSON body
+    let bytes = axum::body::to_bytes(req.into_body(), state.config.server.max_body_size)
+        .await
+        .map_err(|e| AppError::BadRequest(format!("读取请求体失败: {}", e)))?;
+    let req: CreateUserRequest = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::BadRequest(format!("JSON 解析失败: {}", e)))?;
+
+    log_client_register(&req.name, client_ip.as_deref());
+
     // 0. 验证用户名格式
     let name = validate_username(&req.name)?;
 

--- a/server/src/handlers/files.rs
+++ b/server/src/handlers/files.rs
@@ -20,6 +20,7 @@ use crate::{
         FileCreatedBy, FileInfoResponse, FileListResponse, TaskFile, UploadFileResponse,
     },
     models::task::Task,
+    rate_limit::{agent_rate_limit_middleware, client_rate_limit_middleware},
     state::AppState,
 };
 
@@ -30,7 +31,11 @@ pub fn client_routes(state: AppState) -> Router<AppState> {
         .route("/files/list/{task_id}", get(client_list_files))
         .route("/files/{id}/download", get(client_download_file))
         .route("/files/{id}", get(client_get_file_info))
-        .layer(middleware::from_fn_with_state(state, require_auth))
+        .layer(middleware::from_fn_with_state(state.clone(), require_auth))
+        .layer(middleware::from_fn_with_state(
+            state,
+            client_rate_limit_middleware,
+        ))
 }
 
 /// Agent 文件路由 - 需要 Agent 鉴权
@@ -44,7 +49,14 @@ pub fn agent_routes(state: AppState) -> Router<AppState> {
             get(agent_download_file),
         )
         .route("/{service_id}/files/{id}", get(agent_get_file_info))
-        .layer(middleware::from_fn_with_state(state, agent_auth_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            agent_auth_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state,
+            agent_rate_limit_middleware,
+        ))
 }
 
 // ============================================================================

--- a/server/src/handlers/services.rs
+++ b/server/src/handlers/services.rs
@@ -21,6 +21,7 @@ use crate::{
         CreateServiceRequest, CreateServiceResponse, DeleteServiceResponse, Service,
         ServiceListItem, ServiceResponse, UpdateServiceRequest,
     },
+    rate_limit::client_rate_limit_middleware,
     state::AppState,
 };
 
@@ -34,8 +35,12 @@ pub fn routes(state: AppState) -> Router<AppState> {
         )
         .layer(middleware::from_fn(require_admin))
         .layer(middleware::from_fn_with_state(
-            state,
+            state.clone(),
             crate::auth::require_auth,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state,
+            client_rate_limit_middleware,
         ))
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! 提供异步Agent服务的服务端实现 - 一对一服务模型
 
+pub mod audit;
 pub mod auth;
 pub mod config;
 pub mod db;
@@ -9,6 +10,7 @@ pub mod error;
 pub mod handlers;
 pub mod main_support;
 pub mod models;
+pub mod rate_limit;
 pub mod state;
 
 #[cfg(test)]

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -90,11 +90,27 @@ impl RateLimiter {
     /// 清理所有时间戳均已过期或为空的 bucket。
     ///
     /// 应由后台任务定期调用，防止空 bucket 无限累积导致内存泄漏。
-    pub fn prune(&self) {
-        self.buckets.retain(|_, timestamps| {
-            timestamps.retain(|t| t.elapsed() < WINDOW_SIZE);
-            !timestamps.is_empty()
-        });
+    ///
+    /// 返回本次清理掉的 bucket 数量，便于观测与调试。
+    pub fn prune(&self) -> usize {
+        let keys_to_remove: Vec<String> = self
+            .buckets
+            .iter_mut()
+            .filter_map(|mut entry| {
+                entry.retain(|t| t.elapsed() < WINDOW_SIZE);
+                if entry.is_empty() {
+                    Some(entry.key().clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let removed = keys_to_remove.len();
+        for key in keys_to_remove {
+            self.buckets.remove(&key);
+        }
+        removed
     }
 }
 
@@ -113,7 +129,10 @@ pub fn spawn_rate_limiter_prune_task(
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    state.rate_limiter.prune();
+                    let removed = state.rate_limiter.prune();
+                    if removed > 0 {
+                        tracing::debug!("Pruned {} rate limit bucket(s)", removed);
+                    }
                 }
                 _ = shutdown_rx.changed() => {
                     tracing::info!("Rate limiter prune task shutting down gracefully...");
@@ -250,11 +269,25 @@ mod tests {
 
         assert_eq!(limiter.buckets.len(), 2);
 
-        limiter.prune();
+        let removed = limiter.prune();
 
         // 过期 bucket 应被删除，有效 bucket 应保留
+        assert_eq!(removed, 1);
         assert_eq!(limiter.buckets.len(), 1);
         assert!(limiter.buckets.contains_key(new_key));
         assert!(!limiter.buckets.contains_key(old_key));
+    }
+
+    #[test]
+    fn test_prune_returns_zero_when_nothing_to_remove() {
+        let limiter = RateLimiter::new();
+        limiter
+            .buckets
+            .entry("client:active".to_string())
+            .or_default()
+            .push(Instant::now());
+
+        assert_eq!(limiter.prune(), 0);
+        assert_eq!(limiter.buckets.len(), 1);
     }
 }

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -1,0 +1,200 @@
+//! API Key 限流模块
+//!
+//! 按 API Key 维度进行滑动窗口限流：
+//! - Client API Key：100 次/分钟
+//! - Agent API Key：150 次/分钟
+//!
+//! 限流键为 `{kind}:{HMAC(key)}`，使用 `auth::hash_api_key` 生成，
+//! 避免在内存中保存原始 API Key。
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use std::time::{Duration, Instant};
+
+use crate::audit::extract_client_ip;
+use crate::error::{AppError, Result};
+use crate::state::AppState;
+
+/// 限流窗口大小
+const WINDOW_SIZE: Duration = Duration::from_secs(60);
+/// Client API Key 每分钟最大请求数
+const CLIENT_LIMIT_PER_MIN: usize = 100;
+/// Agent API Key 每分钟最大请求数
+const AGENT_LIMIT_PER_MIN: usize = 150;
+
+/// 限流维度
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitKind {
+    /// Client / Admin 等使用 Bearer Token 的接口
+    Client,
+    /// Agent 使用 X-API-Key / Bearer Token 的接口
+    Agent,
+}
+
+impl RateLimitKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            RateLimitKind::Client => "client",
+            RateLimitKind::Agent => "agent",
+        }
+    }
+
+    fn limit(&self) -> usize {
+        match self {
+            RateLimitKind::Client => CLIENT_LIMIT_PER_MIN,
+            RateLimitKind::Agent => AGENT_LIMIT_PER_MIN,
+        }
+    }
+}
+
+/// 基于 API Key 的滑动窗口限流器
+#[derive(Debug)]
+pub struct RateLimiter {
+    buckets: dashmap::DashMap<String, Vec<Instant>>,
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RateLimiter {
+    /// 创建新的限流器
+    pub fn new() -> Self {
+        Self {
+            buckets: dashmap::DashMap::new(),
+        }
+    }
+
+    /// 检查并记录一次请求
+    ///
+    /// 超过阈值时返回 `AppError::RateLimited`。
+    pub fn check(&self, kind: RateLimitKind, key_hash: &str) -> Result<()> {
+        let bucket_key = format!("{}:{}", kind.as_str(), key_hash);
+        let limit = kind.limit();
+
+        let mut entry = self.buckets.entry(bucket_key).or_default();
+        entry.retain(|t| t.elapsed() < WINDOW_SIZE);
+
+        if entry.len() >= limit {
+            return Err(AppError::RateLimited);
+        }
+
+        entry.push(Instant::now());
+        Ok(())
+    }
+}
+
+/// Client 接口限流中间件
+///
+/// 从 `Authorization: Bearer <token>` 中提取 Client API Key 并限流。
+/// 未提供 Key 时不限流，由后续认证中间件处理。
+pub async fn client_rate_limit_middleware(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Result<Response> {
+    let _ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
+
+    if let Ok(api_key) = crate::auth::extract_bearer_token(&req)
+        && let Some(secret_key) = state.config.secret_key.as_deref()
+    {
+        let key_hash = crate::auth::hash_api_key(secret_key, &api_key);
+        state.rate_limiter.check(RateLimitKind::Client, &key_hash)?;
+    }
+
+    Ok(next.run(req).await)
+}
+
+/// Agent 接口限流中间件
+///
+/// 从 `X-API-Key` 或 `Authorization: Bearer <token>` 中提取 Agent API Key 并限流。
+pub async fn agent_rate_limit_middleware(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Result<Response> {
+    let _ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
+
+    if let Some(api_key) = crate::auth::extract_api_key(req.headers())
+        && let Some(secret_key) = state.config.secret_key.as_deref()
+    {
+        let key_hash = crate::auth::hash_api_key(secret_key, api_key);
+        state.rate_limiter.check(RateLimitKind::Agent, &key_hash)?;
+    }
+
+    Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiter_allows_under_limit() {
+        let limiter = RateLimiter::new();
+        let hash = "test_hash";
+
+        for _ in 0..CLIENT_LIMIT_PER_MIN {
+            assert!(limiter.check(RateLimitKind::Client, hash).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_rejects_over_limit() {
+        let limiter = RateLimiter::new();
+        let hash = "test_hash";
+
+        for _ in 0..CLIENT_LIMIT_PER_MIN {
+            limiter.check(RateLimitKind::Client, hash).unwrap();
+        }
+
+        assert!(matches!(
+            limiter.check(RateLimitKind::Client, hash).unwrap_err(),
+            AppError::RateLimited
+        ));
+    }
+
+    #[test]
+    fn test_rate_limiter_separate_keys() {
+        let limiter = RateLimiter::new();
+
+        for _ in 0..CLIENT_LIMIT_PER_MIN {
+            limiter.check(RateLimitKind::Client, "key_a").unwrap();
+        }
+
+        // 不同 Key 不受影响
+        assert!(limiter.check(RateLimitKind::Client, "key_b").is_ok());
+    }
+
+    #[test]
+    fn test_rate_limiter_separate_kinds() {
+        let limiter = RateLimiter::new();
+
+        for _ in 0..CLIENT_LIMIT_PER_MIN {
+            limiter.check(RateLimitKind::Client, "shared").unwrap();
+        }
+
+        // Client 维度已超限，但 Agent 维度独立
+        assert!(limiter.check(RateLimitKind::Agent, "shared").is_ok());
+    }
+
+    #[test]
+    fn test_agent_limit_is_150() {
+        let limiter = RateLimiter::new();
+        let hash = "agent_hash";
+
+        for _ in 0..AGENT_LIMIT_PER_MIN {
+            assert!(limiter.check(RateLimitKind::Agent, hash).is_ok());
+        }
+
+        assert!(matches!(
+            limiter.check(RateLimitKind::Agent, hash).unwrap_err(),
+            AppError::RateLimited
+        ));
+    }
+}

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -14,7 +14,6 @@ use axum::{
 };
 use std::time::{Duration, Instant};
 
-use crate::audit::extract_client_ip;
 use crate::error::{AppError, Result};
 use crate::state::AppState;
 
@@ -87,6 +86,42 @@ impl RateLimiter {
         entry.push(Instant::now());
         Ok(())
     }
+
+    /// 清理所有时间戳均已过期或为空的 bucket。
+    ///
+    /// 应由后台任务定期调用，防止空 bucket 无限累积导致内存泄漏。
+    pub fn prune(&self) {
+        self.buckets.retain(|_, timestamps| {
+            timestamps.retain(|t| t.elapsed() < WINDOW_SIZE);
+            !timestamps.is_empty()
+        });
+    }
+}
+
+/// 启动限流器定期清理后台任务。
+///
+/// 每 60 秒调用一次 `RateLimiter::prune()`，并在收到关闭信号时优雅退出。
+pub fn spawn_rate_limiter_prune_task(
+    state: AppState,
+    shutdown_tx: tokio::sync::watch::Sender<()>,
+) -> tokio::task::JoinHandle<()> {
+    let mut shutdown_rx = shutdown_tx.subscribe();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    state.rate_limiter.prune();
+                }
+                _ = shutdown_rx.changed() => {
+                    tracing::info!("Rate limiter prune task shutting down gracefully...");
+                    break;
+                }
+            }
+        }
+    })
 }
 
 /// Client 接口限流中间件
@@ -98,8 +133,6 @@ pub async fn client_rate_limit_middleware(
     req: Request,
     next: Next,
 ) -> Result<Response> {
-    let _ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
-
     if let Ok(api_key) = crate::auth::extract_bearer_token(&req)
         && let Some(secret_key) = state.config.secret_key.as_deref()
     {
@@ -118,8 +151,6 @@ pub async fn agent_rate_limit_middleware(
     req: Request,
     next: Next,
 ) -> Result<Response> {
-    let _ip = extract_client_ip(&req, state.config.server.trust_x_forwarded_for);
-
     if let Some(api_key) = crate::auth::extract_api_key(req.headers())
         && let Some(secret_key) = state.config.secret_key.as_deref()
     {
@@ -196,5 +227,34 @@ mod tests {
             limiter.check(RateLimitKind::Agent, hash).unwrap_err(),
             AppError::RateLimited
         ));
+    }
+
+    #[test]
+    fn test_prune_removes_empty_buckets() {
+        let limiter = RateLimiter::new();
+
+        // 插入一个已过期的时间戳和一个有效的时间戳
+        let old_key = "client:old";
+        let new_key = "client:new";
+
+        limiter
+            .buckets
+            .entry(old_key.to_string())
+            .or_default()
+            .push(Instant::now() - (WINDOW_SIZE + Duration::from_secs(1)));
+        limiter
+            .buckets
+            .entry(new_key.to_string())
+            .or_default()
+            .push(Instant::now());
+
+        assert_eq!(limiter.buckets.len(), 2);
+
+        limiter.prune();
+
+        // 过期 bucket 应被删除，有效 bucket 应保留
+        assert_eq!(limiter.buckets.len(), 1);
+        assert!(limiter.buckets.contains_key(new_key));
+        assert!(!limiter.buckets.contains_key(old_key));
     }
 }

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -93,24 +93,17 @@ impl RateLimiter {
     ///
     /// 返回本次清理掉的 bucket 数量，便于观测与调试。
     pub fn prune(&self) -> usize {
-        let keys_to_remove: Vec<String> = self
-            .buckets
-            .iter_mut()
-            .filter_map(|mut entry| {
-                entry.retain(|t| t.elapsed() < WINDOW_SIZE);
-                if entry.is_empty() {
-                    Some(entry.key().clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let removed = keys_to_remove.len();
-        for key in keys_to_remove {
-            self.buckets.remove(&key);
-        }
-        removed
+        let removed = std::cell::Cell::new(0usize);
+        self.buckets.retain(|_, timestamps| {
+            timestamps.retain(|t| t.elapsed() < WINDOW_SIZE);
+            if timestamps.is_empty() {
+                removed.set(removed.get() + 1);
+                false
+            } else {
+                true
+            }
+        });
+        removed.get()
     }
 }
 

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,6 +1,6 @@
 //! 应用状态
 
-use crate::{config::AppConfig, db::Database};
+use crate::{config::AppConfig, db::Database, rate_limit::RateLimiter};
 use std::sync::Arc;
 
 /// 应用共享状态
@@ -10,6 +10,8 @@ pub struct AppState {
     pub config: Arc<AppConfig>,
     /// 数据库连接
     pub db: Database,
+    /// API Key 限流器
+    pub rate_limiter: Arc<RateLimiter>,
 }
 
 impl AppState {
@@ -28,6 +30,7 @@ impl AppState {
         Ok(Self {
             config: Arc::new(config),
             db,
+            rate_limiter: Arc::new(RateLimiter::new()),
         })
     }
 

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -4,7 +4,8 @@
 
 use axum::Router;
 use open_aaas_server::{
-    auth::hash_api_key, config::AppConfig, db::Database, handlers, state::AppState,
+    auth::hash_api_key, config::AppConfig, db::Database, handlers, rate_limit::RateLimiter,
+    state::AppState,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -45,6 +46,7 @@ pub async fn create_test_app() -> (Router, AppState, SqlitePool) {
     let state = AppState {
         config: Arc::new(config),
         db,
+        rate_limiter: Arc::new(RateLimiter::new()),
     };
 
     // 创建路由

--- a/server/tests/integration/client_api.rs
+++ b/server/tests/integration/client_api.rs
@@ -796,7 +796,8 @@ async fn test_create_task_json_body_too_large() {
 async fn test_create_task_json_invalid_session_id_empty() {
     let app = TestApp::new().await;
     let (_, api_key, _) = create_test_user(app.pool(), "testuser", UserRole::Client).await;
-    let (service_id, _, _) = create_test_service(app.pool(), "test_service", "Test Service", true).await;
+    let (service_id, _, _) =
+        create_test_service(app.pool(), "test_service", "Test Service", true).await;
 
     let body = json!({
         "service_id": service_id,
@@ -831,7 +832,8 @@ async fn test_create_task_json_invalid_session_id_empty() {
 async fn test_create_task_json_invalid_session_id_with_slash() {
     let app = TestApp::new().await;
     let (_, api_key, _) = create_test_user(app.pool(), "testuser", UserRole::Client).await;
-    let (service_id, _, _) = create_test_service(app.pool(), "test_service", "Test Service", true).await;
+    let (service_id, _, _) =
+        create_test_service(app.pool(), "test_service", "Test Service", true).await;
 
     let body = json!({
         "service_id": service_id,
@@ -866,7 +868,8 @@ async fn test_create_task_json_invalid_session_id_with_slash() {
 async fn test_create_task_json_valid_session_id_preserved() {
     let app = TestApp::new().await;
     let (_, api_key, _) = create_test_user(app.pool(), "testuser", UserRole::Client).await;
-    let (service_id, _, _) = create_test_service(app.pool(), "test_service", "Test Service", true).await;
+    let (service_id, _, _) =
+        create_test_service(app.pool(), "test_service", "Test Service", true).await;
 
     let body = json!({
         "service_id": service_id,

--- a/server/tests/integration/mod.rs
+++ b/server/tests/integration/mod.rs
@@ -8,7 +8,7 @@ pub mod services_api;
 use axum::Router;
 use open_aaas_server::{
     auth::hash_api_key, config::AppConfig, db::Database, handlers, models::user::UserRole,
-    state::AppState,
+    rate_limit::RateLimiter, state::AppState,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -67,6 +67,7 @@ impl TestApp {
         let state = AppState {
             config: Arc::new(config.clone()),
             db: db.clone(),
+            rate_limiter: Arc::new(RateLimiter::new()),
         };
 
         let router = handlers::routes(state.clone()).with_state(state.clone());


### PR DESCRIPTION
修复 server 公共接口与认证接口缺少速率限制的问题，防止针对 API Key 的暴力破解与接口泛洪 DoS。

主要变更：
- 新增基于 API Key 的限流：Agent 150/min，Client 100/min，限流键使用 HMAC(key) 隐藏原始 key。
- 新增注册接口与认证失败审计日志，registration_token 做掩码处理。
- 新增 `trust_x_forwarded_for` 配置（默认 false），仅在可信代理后启用。
- 认证失败对外统一返回 `message: "认证失败"`，避免泄露 key 是否存在。
- 429 响应返回 `Retry-After: 60` header。
- 生产启动启用 `ConnectInfo`，确保可获取真实客户端 IP。

Fixes #133
