### PR TITLE
docs(root): clarify Agent-to-Agent delegation positioning in READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,7 +82,7 @@ Raw data always stays where it was created, while remote agents work directly be
 | | Traditional Cloud | OpenAaaS |
 |---|---|---|
 | Data Flow | Local → Cloud → Local | **Raw data stays in place** |
-| Network Transfer | Raw data (TB scale) | Task descriptions and results (KB–MB scale) |
+| Network Transfer | Raw data (TB scale) | Task descriptions (delegation requests) and results (KB–MB scale) |
 | Firewall Requirements | Inbound ports required | **Outbound HTTP only** |
 | Sensitive Data | Must leave the domain | **Never leaves the lab** |
 
@@ -164,11 +164,15 @@ See [pyopenaaas/README.md](./pyopenaaas/README.md).
   "mcpServers": {
     "openaaas": {
       "command": "uvx",
-      "args": ["openaaas-mcp-adapter"]
+      "args": ["openaaas-mcp-adapter"],
+      "toolTimeoutMs": 600000
     }
   }
 }
 ```
+
+- `toolTimeoutMs` sets the maximum wait time for MCP tool calls in milliseconds, suitable for long-running task polling.
+- ⚠️ This parameter is parsed by the MCP client; actual effectiveness depends on the specific client implementation. Some clients or agent tools may have independent timeout limits that override this setting.
 
 After configuring, restart the client to invoke all capabilities in conversation.
 
@@ -279,7 +283,7 @@ OpenAaaS/
 ├── dash/             # Debug and Admin Tools (Python/Streamlit)
 ├── client-extension/ # Client Extensions — pi plugin, Kimi plugin, MCP adapter
 ├── pyopenaaas/       # Python SDK
-└── binder/         # Example notebooks and scripts
+└── binder/           # Example notebooks and scripts
 ```
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -6,6 +6,8 @@
 
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
+<p align="center">An open Agent-to-Agent orchestration network: any agent can discover, delegate to, and compose other full agent instances running on remote nodes.</p>
+
 <p align="center">
   <a href="https://www.open-aaas.com">Website</a> ·
   <a href="https://arxiv.org/abs/2605.13618">Paper</a> ·
@@ -55,11 +57,11 @@
 
 > **Intelligence flows, data stays still — bring Agents to the data, instead of handing data over to Agents.**
 
-OpenAaaS is an Agent Orchestration Network for AI for Science: data stays where it was created, and Agent capabilities flow through the network to reach it.
+OpenAaaS is an Agent-to-Agent orchestration network for AI for Science. Every node runs a full agent instance with its own tools, models, and data; data stays where it was created, while agent capabilities flow through the network to work beside it.
 
 | Demo Video | Screenshots |
 |:---:|:---:|
-| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **Connect to Network**<br><img width="372" height="113" alt="Screenshot 2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**View Node List**<br><img width="379" height="406" alt="Screenshot 2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**Task Result Returned**<br><img width="371" height="391" alt="Screenshot 2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
+| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **Connect to Network**<br><img width="372" height="113" alt="Screenshot 2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**View Node List**<br><img width="379" height="406" alt="Screenshot 2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**Delegation Result Returned**<br><img width="371" height="391" alt="Screenshot 2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
 **Paper**: Technical design and implementation details in [arXiv:2605.13618](https://arxiv.org/abs/2605.13618).
 
@@ -69,11 +71,13 @@ OpenAaaS is an Agent Orchestration Network for AI for Science: data stays where 
 
 ### 1. Agent Orchestration, Nodes as Agents
 
-The network schedules not scripts, but full Agent instances with complete toolchains. Inside the Docker container on each node runs a complete Agent capable of autonomous decision-making, execution, and sub-Agent invocation. Any Agent (Claude Code, pi mono, Kimi, etc.) can discover, delegate to, and compose other Agents across global nodes as easily as calling a tool.
+OpenAaaS orchestrates not scripts, functions, or fixed APIs, but full agent instances running on remote nodes. Inside the Docker container on each node runs a complete agent with its own local tools, models, and data, capable of autonomous decision-making, execution, and sub-agent invocation.
+
+For example, Claude Code can discover a data-analysis agent running on a lab server and delegate a task to it; that node agent may then spawn sub-agents to clean, model, or visualize its local data. Any agent (Claude Code, pi mono, Kimi, etc.) can join the network, discover, delegate to, and compose other agents.
 
 ### 2. Data Stays Put, Zero Migration
 
-Raw data always stays where it was created, while remote Agents work directly beside it. The network only transmits task descriptions and results (KB–MB scale), never touching raw data (TB scale).
+Raw data always stays where it was created, while remote agents work directly beside it. Different labs, servers, or instruments can collaborate on a single complex task: each node processes only its own local data, and the network carries only task descriptions (delegation requests) and results (KB–MB scale), never raw data (TB scale).
 
 | | Traditional Cloud | OpenAaaS |
 |---|---|---|
@@ -84,7 +88,9 @@ Raw data always stays where it was created, while remote Agents work directly be
 
 ### 3. Zero-Normalization Plug-and-Play
 
-No unified data format required — JSON, CSV, Excel, MATLAB, HDF5, vendor-specific binary formats are all handled in place. Zero-config node onboarding: `open-aaas-server run` auto-generates `config.toml` and SQLite on first launch. Self-describing API + progressive capability discovery — Agents understand and invoke all services without plugins.
+No unified data format required — JSON, CSV, Excel, MATLAB, HDF5, vendor-specific binary formats are all handled in place. Existing scripts, models, database queries, instrument interfaces, or internal tools are packaged inside a **full agent instance** Docker image; that instance registers itself on the network as an agent node for other agents to discover and delegate to. Remote agents see a full agent, not a callable function.
+
+Zero-config node onboarding: `open-aaas-server run` auto-generates `config.toml` and SQLite on first launch. Self-describing network interface + progressive capability discovery — agents can discover and use capabilities of other agent nodes without plugins.
 
 ### 4. Near-Data Computing, Low-Barrier Deployment
 
@@ -93,6 +99,8 @@ Single Rust binary + embedded SQLite, zero-dependency deployment, copy and run. 
 ---
 
 ## How to use?
+
+Any method below lets your agent join the OpenAaaS network, discover remote agents, and delegate tasks to them.
 
 Public server: **<https://api.open-aaas.com>**
 
@@ -128,16 +136,18 @@ See [client-app/README.md](./client-app/README.md).
 pip install pyopenaaas
 ```
 
+> In OpenAaaS, `submit_task` means your agent submits a delegation request to another full agent instance on a remote node, not calling a remote function.
+
 ```python
 import pyopenaaas
 
 client = pyopenaaas.Client()
 client.register(name="your-name")
 
-services = client.list_services()
+agents = client.list_services()  # list full agent instances on the network
 task = client.submit_task(
-    service_id=services[0].id,
-    task_prompt="Your task description",
+    service_id=agents[0].id,      # delegate to this full agent instance
+    task_prompt="Your task description",  # interpreted and executed by the target agent
 )
 task = client.wait_for_task(task.id)
 paths = client.download_all_files(task.id)
@@ -172,15 +182,15 @@ See [client-extension/openaaas-mcp-adapter/README.md](./client-extension/openaaa
 
 Just say in the conversation:
 
-> "Set my OpenAaaS server to <https://api.open-aaas.com> and submit a data analysis task"
+> "Set my OpenAaaS server to <https://api.open-aaas.com> and delegate a data analysis task to a suitable node agent"
 
-The client Agent automatically completes registration, service discovery, task submission, and result retrieval.
+The client agent automatically completes registration, node discovery, task delegation, and result retrieval.
 
 <video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
 
 ### Generic Agent Framework
 
-If your Agent has no OpenAaaS plugin, simply have it access <https://api.open-aaas.com>. No authentication required; complete API documentation and usage instructions are returned. The Agent can then automatically complete registration, service discovery, and task submission after reading them.
+If your agent has no OpenAaaS plugin, simply have it access <https://api.open-aaas.com>. No authentication required; complete API documentation and usage instructions are returned. The agent can then automatically complete registration, node discovery, and task delegation after reading them.
 
 ---
 
@@ -226,19 +236,19 @@ For Agent Core deployment, see [agent-core/README.md](./agent-core/README.md).
 Client Agent
 (pi mono / Claude Code / Kimi Cli / Cline / Custom Agent)
         ▲
-        │ Control flow: task description, heartbeat, results (KB scale)
+        │ Control flow: delegation request, heartbeat, results (KB scale)
         ▼
 ───────────────────────────────────────────────────────────────────
 OpenAaaS Server (Network Hub)
 Rust + SQLite — Lightweight indexing layer
-  • Service registration  • Task routing  • Node heartbeat  • File relay
+  • Node registration  • Delegation routing  • Node heartbeat  • File relay
         ▲
         │ Short polling (unidirectional outbound HTTP)
         ▼
 ───────────────────────────────────────────────────────────────────
 Agent Core (Network Node)
 Rust + Docker — Deployed locally where data resides
-  • Register capabilities to the network  • Poll for tasks
+  • Register capabilities to the network  • Poll to claim delegated tasks
   • Container sandbox isolation execution  • Report results
         │
         ▼
@@ -252,9 +262,9 @@ Rust + Docker — Deployed locally where data resides
 
 | Layer | Component | Responsibility |
 |------|------|------|
-| Client Agent | pi mono / Kimi Cli / Codex / Open Code / Custom Agent | Understand tasks, discover network nodes, schedule remote Agents, integrate results |
-| Network Hub | Server — Capability registration and scheduling center (Rust + SQLite) | Service registration, task routing, node heartbeat, file relay |
-| Network Node | agent-core — Capability execution node + Docker, runs a **full Agent instance** in container | Register capabilities to the network, poll for tasks, launch full Agent in sandbox isolation, report results |
+| Client Agent | pi mono / Kimi Cli / Codex / Open Code / Custom Agent | Understand tasks, discover network nodes, delegate to remote agents, integrate results |
+| Network Hub | Server — Node registration and delegation routing center (Rust + SQLite) | Node registration, delegation routing, node heartbeat, file relay |
+| Network Node | agent-core — Network node that runs a **full agent instance** beside local data (Rust + Docker) | Register capabilities to the network, poll to claim delegated tasks, launch full agent in sandbox isolation, report results |
 
 ---
 
@@ -263,7 +273,8 @@ Rust + Docker — Deployed locally where data resides
 ```
 OpenAaaS/
 ├── server/           # Network Hub (Scheduling Center) (Rust)
-├── agent-core/       # Network Node (Execution Node) (Rust)
+├── agent-core/       # Network Node: runs full agent instances where data lives (Rust)
+├── admin-cli/        # Command-line admin tool (Rust)
 ├── client-app/       # Desktop Client (Tauri + Vue 3)
 ├── dash/             # Debug and Admin Tools (Python/Streamlit)
 ├── client-extension/ # Client Extensions — pi plugin, Kimi plugin, MCP adapter

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
+<p align="center">一个开放的 Agent-to-Agent 编排网络：任何 Agent 都可以发现、委派并组合运行在远程节点上的其他完整 Agent 实例。</p>
+
 <p align="center">
   <a href="https://www.open-aaas.com">官网</a> ·
   <a href="https://arxiv.org/abs/2605.13618">论文</a> ·
@@ -55,11 +57,11 @@
 
 > **智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。**
 
-OpenAaaS 是一个面向 AI for Science 的 Agent 编排网络（Agent Orchestration Network）：数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边。
+OpenAaaS 是一个面向 AI for Science 的 Agent-to-Agent 编排网络（Agent Orchestration Network）。网络中的每个节点都运行着一个拥有完整工具链的 Agent 实例；数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边，完成分析、计算与协作。
 
 | 操作视频 | 截图 |
 |:---:|:---:|
-| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **接入网络**<br><img width="372" height="113" alt="截屏2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**查看节点列表**<br><img width="379" height="406" alt="截屏2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**任务结果返回**<br><img width="371" height="391" alt="截屏2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
+| <video src="https://github.com/user-attachments/assets/5bee5e09-2866-4285-b00e-15210f274177"></video> | **接入网络**<br><img width="372" height="113" alt="截屏2026-05-07 09 36 25" src="https://github.com/user-attachments/assets/d3773d67-9d47-45db-9f5e-3ca96f990981" /><br>**查看节点列表**<br><img width="379" height="406" alt="截屏2026-05-07 09 37 22" src="https://github.com/user-attachments/assets/d74571ac-b300-411e-9371-b51822531926" /><br>**委派结果返回**<br><img width="371" height="391" alt="截屏2026-05-07 09 38 09" src="https://github.com/user-attachments/assets/16c9984b-e730-476c-93e7-1aae78f76a5d" /> |
 
 **论文**：技术设计与实现细节详见 [arXiv:2605.13618](https://arxiv.org/abs/2605.13618)。
 
@@ -69,22 +71,24 @@ OpenAaaS 是一个面向 AI for Science 的 Agent 编排网络（Agent Orchestra
 
 ### 1. Agent 编排，节点即 Agent
 
-网络调度的对象不是脚本，而是拥有完整工具链的 Agent 实例。每个节点上的 Docker 容器内运行完整 Agent，能够自主决策、自主执行、自主调用子 Agent。任意 Agent（Claude Code、pi mono、Kimi 等）都可以像调用工具一样发现、委派并组合全球节点的其他 Agent。
+OpenAaaS 编排的不是脚本、函数或固定 API，而是运行在远程节点上的完整 Agent 实例。每个节点上的 Docker 容器内都运行着一个拥有本地工具、模型和数据的完整 Agent，能够自主决策、自主执行，并在需要时继续委派给子 Agent。
+
+例如，Claude Code 可以发现一个运行在实验室服务器上的数据分析 Agent，把任务委派给它；该节点 Agent 处理本地数据时，还可以进一步调用节点内的子 Agent 完成清洗、建模或可视化。任意 Agent（Claude Code、pi mono、Kimi 等）都可以加入网络，发现、委派并组合其他节点的 Agent。
 
 ### 2. 数据原地处理，零迁移
 
-原始数据始终留在产生它的位置，远程 Agent 直接在数据旁工作。网络只传输任务描述与结果（KB~MB 级），不触碰原始数据（TB 级）。
+原始数据始终留在产生它的位置，远程 Agent 直接在数据旁工作。不同实验室、服务器或仪器可以围绕同一个复杂任务协作：每个节点只处理自己的本地数据，网络只传输任务描述（即委派请求）与结果（KB~MB 级），不触碰原始数据（TB 级）。
 
 | | 传统云端方案 | OpenAaaS |
 |---|---|---|
 | 数据流向 | 本地 → 云端 → 本地 | **原始数据原地不动** |
-| 网络传输 | 原始数据（TB 级） | 任务描述与结果（KB~MB 级） |
+| 网络传输 | 原始数据（TB 级） | 委派请求与结果（KB~MB 级） |
 | 防火墙要求 | 需开放入站端口 | **仅出站 HTTP 即可** |
 | 敏感数据 | 必须出域 | **不出实验室** |
 
 ### 3. 免规范化接入，即插即用
 
-无需统一数据格式，JSON/CSV/Excel/MATLAB/HDF5/厂商二进制格式均可原地处理。节点零配置入网：`open-aaas-server run` 首次启动自动生成 `config.toml` 和 SQLite。自描述 API + 渐进式能力发现，Agent 无需插件即可理解并调用全部服务。
+无需统一数据格式，JSON/CSV/Excel/MATLAB/HDF5/厂商二进制格式均可原地处理。你可以把已有的脚本、模型、数据库查询、仪器接口或内部工具打包进一个**完整 Agent 实例**的 Docker 镜像；这个实例会作为 Agent 节点注册到网络中，供其他 Agent 发现并**委派**任务。远程 Agent 看到的不是一个可被调用的函数，而是一个能自主决策、使用本地工具链完成任务的完整 Agent。节点零配置入网：`open-aaas-server run` 首次启动自动生成 `config.toml` 和 SQLite。自描述网络接口 + 渐进式能力发现，Agent 无需插件即可发现并使用其他 Agent 节点的能力。
 
 ### 4. 近数据端计算，低门槛部署
 
@@ -93,6 +97,8 @@ Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker �
 ---
 
 ## 如何使用？
+
+以下任一方式都可以让你的 Agent 加入 OpenAaaS 网络，发现远程 Agent 并向它们委派任务。
 
 公共服务器：**<https://api.open-aaas.com>**
 
@@ -128,16 +134,18 @@ Rust 单二进制 + SQLite 嵌入式，零依赖部署，复制即用。Docker �
 pip install pyopenaaas
 ```
 
+> 在 OpenAaaS 中，`submit_task` 是指让你的 Agent 向远程节点上的另一个完整 Agent 实例提交委派请求，而不是调用一个远程函数。
+
 ```python
 import pyopenaaas
 
 client = pyopenaaas.Client()
 client.register(name="your-name")
 
-services = client.list_services()
+agents = client.list_services()  # 获取网络中的 Agent 节点列表
 task = client.submit_task(
-    service_id=services[0].id,
-    task_prompt="你的任务描述",
+    service_id=agents[0].id,      # 向该完整 Agent 实例委派任务
+    task_prompt="你的任务描述",    # 由目标 Agent 实例自主理解并执行
 )
 task = client.wait_for_task(task.id)
 paths = client.download_all_files(task.id)
@@ -176,15 +184,15 @@ paths = client.download_all_files(task.id)
 
 在对话中直接说：
 
-> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后提交一个数据分析任务"
+> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后向合适的节点 Agent 委派一个数据分析任务"
 
-客户端 Agent 自动完成注册、服务发现、任务提交和结果获取。
+客户端 Agent 自动完成注册、节点发现、任务委派和结果获取。
 
 <video src="https://github.com/user-attachments/assets/4e2873ee-1581-46c7-b8f2-cfcd6da097ef" controls></video>
 
 ### 通用 Agent 框架
 
-如果你的 Agent 没有 OpenAaaS 插件，直接访问 <https://api.open-aaas.com>。无需认证，返回完整 API 文档和使用说明，Agent 读取后即可自动完成注册、服务发现、任务提交。
+如果你的 Agent 没有 OpenAaaS 插件，直接访问 <https://api.open-aaas.com>。无需认证，返回完整 API 文档和使用说明，Agent 读取后即可自动完成注册、节点发现、任务委派。
 
 ---
 
@@ -230,19 +238,19 @@ Agent Core 部署详见 [agent-core/README.md](./agent-core/README.md)。
 客户端 Agent
 (pi mono / Claude Code / Kimi Cli / Cline / 自研 Agent)
         ▲
-        │ 控制流：任务描述、心跳、结果（KB 级）
+        │ 控制流：委派请求、心跳、结果（KB 级）
         ▼
 ───────────────────────────────────────────────────────────────────
 OpenAaaS Server（网络枢纽）
 Rust + SQLite — 轻量索引层
-  • 服务注册  • 任务路由  • 节点心跳  • 文件中转
+  • 节点注册  • 委派路由  • 节点心跳  • 文件中转
         ▲
         │ 短轮询（单向出站 HTTP）
         ▼
 ───────────────────────────────────────────────────────────────────
 Agent Core（网络节点）
 Rust + Docker — 部署在数据本地
-  • 向网络注册能力  • 轮询认领任务
+  • 向网络注册能力  • 轮询认领委派任务
   • 容器沙箱隔离执行  • 上报结果
         │
         ▼
@@ -256,9 +264,9 @@ Rust + Docker — 部署在数据本地
 
 | 层级 | 组件 | 职责 |
 |------|------|------|
-| 客户端 Agent | pi mono / Kimi Cli / Codex / Open Code / 自研 Agent | 理解任务、发现网络节点、调度远端 Agent、整合结果 |
-| 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 服务注册、任务路由、节点心跳、文件中转 |
-| 网络节点 | agent-core — 能力执行节点 + Docker，容器内运行**完整 Agent 实例** | 向网络注册自身能力、轮询认领任务、在沙箱中启动完整 Agent 实例隔离执行、上报结果 |
+| 客户端 Agent | pi mono / Kimi Cli / Codex / Open Code / 自研 Agent | 理解任务、发现网络中的其他 Agent、委派任务并整合结果 |
+| 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 节点注册、委派路由、节点心跳、文件中转 |
+| 网络节点 | agent-core — 在数据本地运行完整 Agent 实例的网络节点 (Rust + Docker) | 向网络注册自身能力、轮询认领任务、在沙箱中启动完整 Agent 实例隔离执行、上报结果 |
 
 ---
 
@@ -267,12 +275,13 @@ Rust + Docker — 部署在数据本地
 ```
 OpenAaaS/
 ├── server/           # 网络枢纽（调度中心） (Rust)
-├── agent-core/       # 网络节点（执行节点） (Rust)
+├── agent-core/       # 网络节点：在数据本地运行完整 Agent 实例 (Rust)
+├── admin-cli/        # 命令行管理员工具 (Rust)
 ├── client-app/       # 桌面客户端 (Tauri + Vue 3)
 ├── dash/             # 调试与管理员工具 (Python/Streamlit)
 ├── client-extension/ # 客户端扩展 — pi 插件、kimi 插件、MCP 适配器
 ├── pyopenaaas/       # Python SDK
-└── binder/         # 示例 notebook 与脚本
+└── binder/           # 示例 notebook 与脚本
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ paths = client.download_all_files(task.id)
 
 在对话中直接说：
 
-> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后向合适的节点 Agent 委派一个数据分析任务"
+> "帮我设置 OpenAaaS 的服务器地址为 <https://api.open-aaas.com>，然后向合适的远程 Agent 节点委派一个数据分析任务"
 
 客户端 Agent 自动完成注册、节点发现、任务委派和结果获取。
 
@@ -265,7 +265,7 @@ Rust + Docker — 部署在数据本地
 | 层级 | 组件 | 职责 |
 |------|------|------|
 | 客户端 Agent | pi mono / Kimi Cli / Codex / Open Code / 自研 Agent | 理解任务、发现网络中的其他 Agent、委派任务并整合结果 |
-| 网络枢纽 | Server — 能力注册与调度中心 (Rust + SQLite) | 节点注册、委派路由、节点心跳、文件中转 |
+| 网络枢纽 | Server — 节点注册与委派路由中心 (Rust + SQLite) | 节点注册、委派路由、节点心跳、文件中转 |
 | 网络节点 | agent-core — 在数据本地运行完整 Agent 实例的网络节点 (Rust + Docker) | 向网络注册自身能力、轮询认领任务、在沙箱中启动完整 Agent 实例隔离执行、上报结果 |
 
 ---


### PR DESCRIPTION
## Summary

This PR clarifies OpenAaaS' positioning as an **Agent-to-Agent orchestration / delegation network** where each network node runs a **full agent instance** with its own tools, models, and local data.

## Changes

- Rewrote key sections in both "README.md" and "README.en.md" to avoid phrasing that could be read as "agents calling remote scripts/functions/APIs".
- Emphasized that the network schedules and delegates to complete agent instances, not isolated functions.
- Preserved the original slogan: **"智能流动，数据静止 / Intelligence flows, data stays still."**
- Updated terminology throughout (e.g., "task" -> "delegation", "service" -> "agent/node" where appropriate).

## Files affected

- "README.md"
- "README.en.md"

## Notes

- No functional code changes; documentation only.
- No issue is being fixed by this PR.