### PR TITLE
docs(executor-example): clarify that the example is an agent-based executor running pi-coding-agent

### DIFF
--- a/agent-core/executor-example/README.en.md
+++ b/agent-core/executor-example/README.en.md
@@ -2,9 +2,11 @@
 
 <p align="right"><a href="./README.md">中文</a> | English</p>
 
-This is **a sample Docker executor image for OpenAaaS**.
+This is **an agent-based Docker executor image example for OpenAaaS**.
 
-Agent Core executes tasks in isolated Docker containers. This example demonstrates the **minimal interaction contract**: the container reads `task.json`, executes the task, and writes result files to the workspace. You can directly modify based on it, or write your own image entirely — as long as it satisfies the same input/output protocol.
+> The container runs **pi-coding-agent (an LLM agent)**. It is not a simple deterministic script pipeline; instead, `run.sh` extracts `task_prompt` and `output_prompt` from `/workspace/task.json` and passes them to the agent, which then understands the task intent, chooses tools autonomously, and completes the task.
+
+Agent Core executes tasks in isolated Docker containers. This example demonstrates the **minimal interaction contract**: `run.sh` reads `task.json` and invokes the agent to execute the task, and the agent writes result files to the workspace. You can directly modify based on it, or write your own image entirely — as long as it satisfies the same input/output protocol.
 
 ---
 
@@ -26,7 +28,7 @@ When Agent Core starts the container, it completes the following preparations:
 |-------|-------------|
 | `task_id` | Unique task identifier |
 | `task_prompt` | User's original task description |
-| `prompt` | Same as `task_prompt`, for backward compatibility |
+| `prompt` | Not read by this example; Agent Core may pass it alongside `task_prompt`, but `run.sh` only uses `task_prompt` |
 | `output_prompt` | Requirements for output format/content |
 | `session_id` | Session identifier |
 | `input_files` | List of input file names |
@@ -43,11 +45,59 @@ After execution is complete, simply place result files under the workspace (reco
 Agent Core  →  Create workspace + task.json + input/  →  docker run
                                                        │
                                                        ▼
-                                                  Container Execution
+                                                  ┌─────────────┐
+                                                  │ In Container│
+                                                  │             │
+                                                  │ entrypoint  │
+                                                  │    .sh      │
+                                                  │     │       │
+                                                  │     ▼       │
+                                                  │   run.sh    │
+                                                  │     │       │
+                                                  │     ▼       │
+                                                  │ pi-coding   │
+                                                  │   agent     │
+                                                  │ (LLM agent) │
+                                                  │  /  │  \    │
+                                                  │ read write  │
+                                                  │ bash ls ... │
+                                                  │     │       │
+                                                  └─────┼───────┘
                                                        │
                                                        ▼
 Agent Core  ←  Scan output files to report to Server  ←  Results written to workspace
 ```
+
+---
+
+## How the Agent Executes the Task
+
+After the container starts, the internal execution flow is as follows:
+
+1. **`entrypoint.sh` starts the container**
+   - Checks whether `/workspace/task.json` exists
+   - Prints the task ID and timeout
+   - Invokes `/opt/run.sh`
+
+2. **`run.sh` parses `task.json` and prepares the two-stage invocation**
+   - Extracts `task_prompt` and `output_prompt` from `task.json`
+   - Injects `task_prompt` into the Stage 1 prompt template
+   - Prepares the Stage 2 formatting prompt (Stage 2 always runs regardless of whether `output_prompt` is empty)
+
+3. **Stage 1: pi-coding-agent executes the task**
+   - `run.sh` starts the agent with `/opt/main-agent.md` appended as the system prompt
+   - Based on `task_prompt`, the agent inspects input files under `/workspace/input/` and chooses tools autonomously
+   - The task execution output is also `tee`'d to `/workspace/step1.log`
+   - Results are written to `/workspace/output/` (recommended as `response.md`)
+
+4. **Stage 2: format output according to `output_prompt`**
+   - Always executed after Stage 1
+   - `run.sh` invokes pi-coding-agent again, asking it to read `/workspace/output/` and reformat `/workspace/output/response.md` according to `output_prompt`; if `output_prompt` is empty, the agent may simply review or leave it unchanged
+   - This stage is allowed to fail; execution continues to the fallback step on failure
+
+5. **`run.sh` ensures the final output**
+   - If `/workspace/output/response.md` does not exist, `/workspace/step1.log` is copied as the fallback file
+   - Copies the final response to `/workspace/response.md`
 
 ---
 
@@ -66,21 +116,25 @@ docker build -t open-aaas-executor:latest .
 
 | File | Description |
 |------|-------------|
-| `Dockerfile` | Example image definition. Based on `node:22-slim`, installs `jq`/`git`/`python3` and other common tools |
-| `entrypoint.sh` | Container entry script, checks for `task.json` existence then calls the execution script |
-| `run.sh` | **Example execution logic**. In this example, it calls the pi-coding-agent agent framework to process tasks; you can directly replace it with other agent frameworks |
-| `main-agent.md` | System prompt appended to pi in `run.sh`. If you don't use pi, this file can be ignored |
-| `pi/` | Configuration directory for pi-coding-agent. If you don't use pi, you can delete it |
+| `Dockerfile` | Example image definition. Based on `node:22-slim`, installs `jq`/`git`/`python3` and other common tools, and installs `pi-coding-agent` globally |
+| `entrypoint.sh` | Container entry script, checks for `task.json` existence then calls `run.sh` |
+| `run.sh` | **Agent invocation script**. It parses `task.json`, constructs the prompt, and starts pi-coding-agent |
+| `main-agent.md` | System prompt appended to pi via `--append-system-prompt` in `run.sh`, used to constrain agent behavior |
+| `pi/` | Configuration directory for pi-coding-agent, copied into `/home/executor/.pi/` in the container |
+
+> Core relationship: `Dockerfile` installs the pi runtime → `entrypoint.sh` starts → `run.sh` invokes pi → `main-agent.md` and `pi/` together configure the agent's behavior.
 
 ---
 
 ## Customization
 
-### Method 1: Modify Based on This Example
+### Method 1: Modify Based on This Example (Recommended)
 
-This is the fastest way to get started:
+This is the fastest way to get started. Since the core of this example is **agent execution**, it is recommended to adjust from the agent level first:
 
-- **Modify `run.sh`**: Replace execution logic, such as using other Agent frameworks (e.g. Kimi Cli, Open Code, Codex, etc.)
+- **Modify `main-agent.md`**: Adjust the system prompt to change the agent's behavior, output format, and tool usage preferences in this execution environment
+- **Modify `run.sh`**: Adjust the task prompt template, pi invocation parameters, or replace it with another agent framework (e.g. Kimi Cli, Open Code, Codex, etc.)
+- **Modify `pi/`**: Adjust pi-coding-agent configuration, such as available models and tool allowlists
 - **Modify `Dockerfile`**: Add or remove dependencies, change base image
 - **Delete unnecessary files**: If not using pi, delete the `pi/` directory and `main-agent.md`
 

--- a/agent-core/executor-example/README.md
+++ b/agent-core/executor-example/README.md
@@ -2,9 +2,11 @@
 
 <p align="right">中文 | <a href="./README.en.md">English</a></p>
 
-这是 **OpenAaaS 的一个 Docker 执行器镜像示例**。
+这是 **OpenAaaS 的一个基于智能体的 Docker 执行器镜像示例**。
 
-Agent Core 通过 Docker 容器隔离执行任务。这个示例展示了**最小的交互契约**：容器读取 `task.json`，执行任务，将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
+> 这个容器内部运行的是 **pi-coding-agent（一个 LLM 智能体）**。它不是简单的确定性脚本流水线，而是由 `run.sh` 从 `/workspace/task.json` 中提取 `task_prompt` 与 `output_prompt`，交由智能体理解任务意图、自主选择工具并完成任务的执行环境。
+
+Agent Core 通过 Docker 容器隔离执行任务。本示例展示了**最小的交互契约**：`run.sh` 读取 `task.json` 并调用智能体执行任务，智能体将结果文件写入 workspace。你可以直接基于它修改，也可以完全自己写一个镜像——只要满足同样的输入输出协议即可。
 
 ---
 
@@ -26,7 +28,7 @@ Agent Core 启动容器时，会完成以下准备：
 |------|------|
 | `task_id` | 任务唯一标识 |
 | `task_prompt` | 用户原始任务描述 |
-| `prompt` | 同 `task_prompt`，向后兼容 |
+| `prompt` | 本示例未读取；Agent Core 可能同时传入该字段，但 `run.sh` 仅使用 `task_prompt` |
 | `output_prompt` | 对输出格式/内容的要求 |
 | `session_id` | 会话标识 |
 | `input_files` | 输入文件名列表 |
@@ -43,11 +45,59 @@ Agent Core 启动容器时，会完成以下准备：
 Agent Core  →  创建 workspace + task.json + input/  →  docker run
                                                        │
                                                        ▼
-                                                  容器执行
+                                                  ┌─────────────┐
+                                                  │   容器内部   │
+                                                  │             │
+                                                  │ entrypoint  │
+                                                  │    .sh      │
+                                                  │     │       │
+                                                  │     ▼       │
+                                                  │   run.sh    │
+                                                  │     │       │
+                                                  │     ▼       │
+                                                  │ pi-coding   │
+                                                  │   agent     │
+                                                  │  (LLM 智能体)│
+                                                  │  /  │  \    │
+                                                  │ read write  │
+                                                  │ bash ls ... │
+                                                  │     │       │
+                                                  └─────┼───────┘
                                                        │
                                                        ▼
 Agent Core  ←  扫描输出文件上报 Server  ←  结果写入 workspace
 ```
+
+---
+
+## 智能体如何执行任务
+
+容器启动后，内部执行流程如下：
+
+1. **`entrypoint.sh` 启动容器**
+   - 检查 `/workspace/task.json` 是否存在
+   - 输出任务 ID 与超时时间
+   - 调用 `/opt/run.sh`
+
+2. **`run.sh` 解析 `task.json` 并准备两阶段调用**
+   - 从 `task.json` 中提取 `task_prompt` 与 `output_prompt`
+   - 将 `task_prompt` 注入第一阶段提示词模板
+   - 准备第二阶段格式整理提示词（第二阶段始终执行，不受 `output_prompt` 是否为空影响）
+
+3. **第一阶段：pi-coding-agent 执行任务**
+   - `run.sh` 以 `/opt/main-agent.md` 作为追加系统提示词启动智能体
+   - 智能体根据 `task_prompt` 自主检查 `/workspace/input/` 中的输入文件并选择工具
+   - 任务执行过程的输出会同时 `tee` 到 `/workspace/step1.log`
+   - 执行结果写入 `/workspace/output/`（推荐保存为 `response.md`）
+
+4. **第二阶段：按 `output_prompt` 整理输出**
+   - 第一阶段执行完成后总是触发
+   - `run.sh` 再次调用 pi-coding-agent，要求它读取 `/workspace/output/` 并根据 `output_prompt` 重新整理 `/workspace/output/response.md`；若 `output_prompt` 为空，智能体可能仅做检查或保持文件不变
+   - 此阶段允许失败；失败后仍会继续执行后续兜底逻辑
+
+5. **`run.sh` 确保最终输出**
+   - 如果 `/workspace/output/response.md` 不存在，则将 `/workspace/step1.log` 复制为兜底文件
+   - 将最终响应复制到 `/workspace/response.md`
 
 ---
 
@@ -66,21 +116,25 @@ docker build -t open-aaas-executor:latest .
 
 | 文件 | 说明 |
 |------|------|
-| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装了 `jq`/`git`/`python3` 等常用工具 |
-| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用执行脚本 |
-| `run.sh` | **示例的执行逻辑**。本示例中用它调用 pi-coding-agent 这个 agent 框架处理任务，你可以直接替换为其他 agent 框架 |
-| `main-agent.md` | `run.sh` 中给 pi 追加的系统提示词。如果你不用 pi，这个文件可以忽略 |
-| `pi/` | pi-coding-agent 的配置目录。如果你不用 pi，可以删除 |
+| `Dockerfile` | 示例镜像定义。基于 `node:22-slim`，安装 `jq`/`git`/`python3` 等常用工具，并全局安装 `pi-coding-agent` |
+| `entrypoint.sh` | 容器入口脚本，检查 `task.json` 存在后调用 `run.sh` |
+| `run.sh` | **智能体调用脚本**。它负责解析 `task.json`、构造提示词并启动 pi-coding-agent |
+| `main-agent.md` | `run.sh` 中通过 `--append-system-prompt` 追加给 pi 的系统提示词，用于约束智能体行为 |
+| `pi/` | pi-coding-agent 的配置目录，会被复制到容器内 `/home/executor/.pi/` |
+
+> 核心关系：`Dockerfile` 安装 pi 运行时 → `entrypoint.sh` 启动 → `run.sh` 调用 pi → `main-agent.md` 与 `pi/` 共同配置智能体行为。
 
 ---
 
 ## 自定义
 
-### 方式一：基于本示例修改
+### 方式一：基于本示例修改（推荐）
 
-这是最快的上手方式：
+这是最快的上手方式。由于本示例的核心是**智能体执行**，建议优先从智能体层面调整：
 
-- **修改 `run.sh`**：替换执行逻辑，比如使用其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
+- **修改 `main-agent.md`**：调整系统提示词，改变智能体在这个执行环境中的行为、输出格式、工具使用偏好等
+- **修改 `run.sh`**：调整任务提示词模板、调用 pi 的参数，或者替换为其他 Agent 框架（如 Kimi Cli、Open Code、Codex 等）
+- **修改 `pi/`**：调整 pi-coding-agent 的配置，例如可用模型、工具白名单等
 - **修改 `Dockerfile`**：增减依赖、换基础镜像
 - **删除不需要的文件**：如果不用 pi，删掉 `pi/` 目录和 `main-agent.md`
 


### PR DESCRIPTION
This PR improves the documentation for `agent-core/executor-example` to make it clear that the example executor is **agent-based** and runs `pi-coding-agent` inside the container, rather than being a simple deterministic script pipeline.

Changes in both `README.md` (Chinese) and `README.en.md` (English):
- Updated the opening description to state that the container runs an LLM agent.
- Added a new "How the Agent Executes the Task" section describing the internal flow from `entrypoint.sh` → `run.sh` → `pi-coding-agent` → Stage 2 formatting.
- Clarified that `run.sh` extracts `task_prompt` and `output_prompt` from `task.json` and passes them to the agent.
- Clarified the roles of `main-agent.md`, `pi/`, `Dockerfile`, and `entrypoint.sh`.
- Updated the customization guide to recommend starting with `main-agent.md` and `pi/` for agent-level changes.

No functional code changes are included.