### PR TITLE
fix(tauri): resolve quick-xml cargo audit advisories

### DIFF
--- a/client-app/src-tauri/Cargo.lock
+++ b/client-app/src-tauri/Cargo.lock
@@ -2266,9 +2266,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2413,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary

Updates the Tauri lockfile to resolve `cargo audit` advisories for the `quick-xml` crate in `client-app/src-tauri/Cargo.lock`.

## Changes

- `client-app/src-tauri/Cargo.lock`
  - `quick-xml`: `0.39.4` → `0.41.0`
  - `plist` (transitive dependency): `1.9.0` → `1.10.0`

## Verification

- Confirmed only `client-app/src-tauri/Cargo.lock` is modified in this PR.
- Ran `cargo audit` in `client-app/src-tauri`; no vulnerabilities are reported for `quick-xml` after the update.
  - Vulnerabilities found: 0
  - Remaining warnings are unrelated unmaintained/unsound notices for gtk-rs and other crates.

## Related

- quick-xml cargo audit advisory resolution for the Tauri client app.
