### PR TITLE
docs: update pi-extension installation to use pi install command

### DIFF
--- a/client-extension/README.en.md
+++ b/client-extension/README.en.md
@@ -21,13 +21,8 @@ A Python adapter for MCP clients such as Claude Desktop, Cursor, and Cline. Buil
 ### pi-extension
 
 ```bash
-mkdir -p ~/.pi/agent/extensions/openaaas
-cp -r pi-extension/* ~/.pi/agent/extensions/openaaas/
-cd ~/.pi/agent/extensions/openaaas
-npm install
+pi install npm:open-aaas-pi-extension
 ```
-
-> The extension can be placed in any extension directory; the configuration path is fixed at `~/.pi/agent/openaaas/config.json`.
 
 Execute `/reload` in pi to load the extension. A default configuration file will be created automatically on first use. Then you can invoke via conversation:
 

--- a/client-extension/README.md
+++ b/client-extension/README.md
@@ -21,13 +21,8 @@
 ### pi-extension
 
 ```bash
-mkdir -p ~/.pi/agent/extensions/openaaas
-cp -r pi-extension/* ~/.pi/agent/extensions/openaaas/
-cd ~/.pi/agent/extensions/openaaas
-npm install
+pi install npm:open-aaas-pi-extension
 ```
-
-> 扩展可放到任意扩展目录，配置路径已固定为 `~/.pi/agent/openaaas/config.json`。
 
 在 pi 中执行 `/reload` 加载扩展。首次使用时会自动创建默认配置文件，然后即可通过对话调用：
 

--- a/client-extension/pi-extension/README.en.md
+++ b/client-extension/pi-extension/README.en.md
@@ -6,13 +6,8 @@ An OpenAaaS extension for [pi](https://github.com/earendil-works/pi), providing 
 
 ## Installation
 
-Copy the extension directory to pi's global extension directory (you can place it under any extension directory, since the configuration path is now fixed):
-
 ```bash
-mkdir -p ~/.pi/agent/extensions/openaaas
-cp -r /path/to/pi-extension/* ~/.pi/agent/extensions/openaaas/
-cd ~/.pi/agent/extensions/openaaas
-npm install
+pi install npm:open-aaas-pi-extension
 ```
 
 After installation, execute `/reload` in pi to load the extension automatically.

--- a/client-extension/pi-extension/README.md
+++ b/client-extension/pi-extension/README.md
@@ -6,13 +6,8 @@
 
 ## 安装
 
-将扩展目录复制到 pi 全局扩展目录（可放到任意扩展目录，配置路径已固定）：
-
 ```bash
-mkdir -p ~/.pi/agent/extensions/openaaas
-cp -r /path/to/pi-extension/* ~/.pi/agent/extensions/openaaas/
-cd ~/.pi/agent/extensions/openaaas
-npm install
+pi install npm:open-aaas-pi-extension
 ```
 
 安装后，在 pi 中执行 `/reload` 即可自动加载扩展。


### PR DESCRIPTION
## 变更

更新 pi-extension 的安装说明，将旧的手动拷贝方式（`mkdir` + `cp` + `npm install`）替换为更简洁的 `pi install npm:open-aaas-pi-extension` 命令。

### 修改的文件

| 文件 | 改动 |
|------|------|
| `client-extension/pi-extension/README.md` | 安装说明更新（中文） |
| `client-extension/pi-extension/README.en.md` | 安装说明更新（英文） |
| `client-extension/README.md` | Quick Start 安装说明更新（中文），移除重复的 /reload 说明 |
| `client-extension/README.en.md` | Quick Start 安装说明更新（英文），移除重复的 /reload 说明 |

### 说明

pi-extension 已发布至 npm（`open-aaas-pi-extension`），可通过 `pi install npm:open-aaas-pi-extension` 直接安装，无需手动拷贝文件。