### PR TITLE
chore(client-app): bump version to 0.7.0

### DIFF
--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-17
+
 ### Added
 - 接入 CI 质量门禁：Tauri Rust 侧的 `cargo fmt --check` 与 `cargo clippy --all-targets -- -D warnings`（#134）
 - 接入依赖安全扫描：`cargo audit --file client-app/src-tauri/Cargo.lock`（#134）
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - 修复桌面客户端无法向显式端口 server 注册的问题：http scope 与 CSP 改用端口通配 `*:*`（#178）
+- 升级 quick-xml 与 plist 依赖以修复 cargo audit 安全公告（#173）
 
 ## [0.6.1] - 2026-06-09
 

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openaaas-client",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client-app/src-tauri/Cargo.lock
+++ b/client-app/src-tauri/Cargo.lock
@@ -2127,7 +2127,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openaaas-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.6.1"
+version = "0.7.0"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2024"

--- a/client-app/src-tauri/tauri.conf.json
+++ b/client-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenAaaS Client",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "identifier": "com.openaaas.client",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Description

client-app **0.7.0** 发版 PR：版本号 0.6.1 → 0.7.0。合并后即可手动触发 release workflow（workflow_dispatch）发布 client-app v0.7.0（tag `client-app-v0.7.0` 由 workflow 自动创建，无需手动打 tag）。

本 PR 仅包含 1 个 commit（`135c972`），改动 5 个文件：
- 版本号同步至 0.7.0：`client-app/package.json`、`client-app/src-tauri/tauri.conf.json`、`client-app/src-tauri/Cargo.toml`、`client-app/src-tauri/Cargo.lock`（仅 `openaaas-client` 包条目，未改动其他依赖）
- `client-app/CHANGELOG.md`：`[Unreleased]` 内容归入 `[0.7.0] - 2026-07-17`（保留空 `[Unreleased]` 节），并补充 quick-xml/plist 安全升级条目（#173）

0.7.0 的实际变更内容（CI 质量门禁与 cargo audit #134、显式端口注册修复 #178、quick-xml 安全修复 #173 等）已通过此前 PR（含 #179）合入 main，完整清单见 `client-app/CHANGELOG.md` 的 `[0.7.0]` 节。

验证（本地已通过）：
- `npm test`：4 个测试文件、34 个测试全部通过
- `npm run build`（vue-tsc + vite build）：通过
- `cargo check --locked` / `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`：全部通过

## Checklist

- [x] 代码改动已测试通过
- [x] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
