### PR TITLE
fix: upgrade GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   rust-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -43,7 +43,7 @@ jobs:
           - component: client-app/src-tauri
             dir: client-app/src-tauri
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -65,16 +65,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci-security-audit
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           version: '0.11.24'
       # cargo-audit 0.21.2 cannot parse CVSS 4.0 entries in the current advisory DB,
@@ -121,8 +121,8 @@ jobs:
   frontend-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -152,8 +152,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # 检出代码
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
           - component: client-app/src-tauri
             dir: client-app/src-tauri
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -192,16 +192,16 @@ jobs:
     needs: rust-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-security-audit
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           version: '0.11.24'
       # cargo-audit 0.21.2 cannot parse CVSS 4.0 entries in the current advisory DB,
@@ -260,7 +260,7 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check platform support
         id: support
@@ -305,7 +305,7 @@ jobs:
 
       - name: Setup Node.js
         if: env.COMPONENT == 'client-app' && steps.support.outputs.supported == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -463,7 +463,7 @@ jobs:
       # 上传构建产物到 artifact storage，供 release job 下载
       - name: Upload artifact
         if: steps.support.outputs.supported == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -485,7 +485,7 @@ jobs:
       TAG: ${{ needs.prepare.outputs.tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -518,7 +518,7 @@ jobs:
     steps:
       # 下载所有构建产物（merge-multiple 会把各 artifact 的文件放到同一目录）
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -531,7 +531,7 @@ jobs:
 
       # 创建 GitHub Release，并上传所有打包文件和校验文件
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: "${{ needs.prepare.outputs.component }} v${{ needs.prepare.outputs.version }}"


### PR DESCRIPTION
GitHub Actions runner 已强制升级到 Node.js 24，旧版本 action（checkout@v4、setup-python@v5 等）不兼容导致 CI 失败。

升级内容：
- actions/checkout@v4 → v7
- actions/setup-python@v5 → v6
- actions/setup-node@v4 → v7
- astral-sh/setup-uv@v5 → v8
- actions/upload-artifact@v4 → v7
- actions/download-artifact@v4 → v8
- softprops/action-gh-release@v2 → v3