### PR TITLE
fix: sync upgrade sha2 0.11 + hmac 0.13 for server

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -385,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,7 +544,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -548,6 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -858,16 +864,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.13.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -1306,11 +1303,11 @@ dependencies = [
  "dashmap",
  "dotenvy",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http-body-util",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "thiserror",
@@ -1937,7 +1934,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.13.0",
+ "hmac",
  "itoa",
  "log",
  "md-5",
@@ -2003,12 +2000,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,8 +45,8 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 # Webhook签名
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 hex = "0.4"
 
 # URL编码

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -6,7 +6,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sqlx::SqlitePool;


### PR DESCRIPTION
同步升级 server 模块的 sha2 (0.10→0.11) 和 hmac (0.12→0.13)。

## 背景
两个 crate 均已迁移到 digest 0.11，单独升级任一都会导致 server/src/auth.rs 编译失败。

## 修改
- server/Cargo.toml: hmac = "0.13", sha2 = "0.11"
- server/src/auth.rs: 新增 KeyInit trait 导入（hmac 0.13 中 new_from_slice 从 Mac 移到了 KeyInit）
- server/Cargo.lock: 自动更新

## 验证
- cargo build ✅
- cargo test ✅

Closes #156, #145