### PR TITLE
feat: 将 session ID 从 UUID v4 切换为 UUID v7 (#172)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复约 112 个 clippy warning（#134）
 - 升级 `sqlx` 从 `0.8.6` 到 `0.9.0`（#150）
 - 将 `server` 中的动态 SQL 重构为 `sqlx::QueryBuilder`，以适配 sqlx 0.9 的 `SqlSafeStr` 安全要求（#150）
+- 将 session ID 生成从 UUID v4 切换为 UUID v7，提升可审计性和索引效率（#172）
 
 ### Security
 - 消除动态 SQL 拼接，改用参数化查询构建（#150）

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # ID生成
-uuid = { version = "1.10", features = ["v4", "serde"] }
+uuid = { version = "1.10", features = ["v4", "v7", "serde"] }
 
 # 时间处理
 chrono = { version = "0.4", features = ["serde"] }

--- a/server/src/bg_tasks.rs
+++ b/server/src/bg_tasks.rs
@@ -348,7 +348,7 @@ mod tests {
         completed_at: Option<chrono::DateTime<Utc>>,
     ) -> String {
         let task_id = format!("task-{}", Uuid::new_v4());
-        let session_id = format!("session-{}", Uuid::new_v4());
+        let session_id = format!("session-{}", Uuid::now_v7());
         let input = serde_json::json!({"test": "input"});
         let created_at = Utc::now() - chrono::Duration::days(10);
 

--- a/server/src/handlers/agent.rs
+++ b/server/src/handlers/agent.rs
@@ -999,7 +999,7 @@ mod tests {
 
         // 创建 pending 任务
         let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("session-{}", uuid::Uuid::now_v7());
         let input = serde_json::json!({
             "task_prompt": "Test task",
             "output_prompt": "Test output"
@@ -1079,7 +1079,7 @@ mod tests {
     /// 创建指定状态的测试任务
     async fn create_task_with_status(pool: &SqlitePool, service_id: &str, status: &str) -> String {
         let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("session-{}", uuid::Uuid::now_v7());
         let input = serde_json::json!({
             "task_prompt": "Test task",
             "output_prompt": "Test output"
@@ -1110,7 +1110,7 @@ mod tests {
 
         // 创建 pending 任务
         let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("session-{}", uuid::Uuid::now_v7());
         let input = serde_json::json!({
             "task_prompt": "Test task",
             "output_prompt": "Test output"
@@ -1201,7 +1201,7 @@ mod tests {
     /// 创建 pending 任务辅助函数
     async fn create_pending_task(pool: &SqlitePool, service_id: &str) -> String {
         let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("session-{}", uuid::Uuid::now_v7());
         let input = serde_json::json!({
             "task_prompt": "Test task",
             "output_prompt": "Test output"

--- a/server/src/handlers/client.rs
+++ b/server/src/handlers/client.rs
@@ -343,7 +343,7 @@ async fn create_task_inner(
     }
 
     // 3. 处理 session_id：验证或自动生成
-    let session_id = session_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+    let session_id = session_id.unwrap_or_else(|| Uuid::now_v7().to_string());
 
     // 4. 开启事务
     let mut tx = state.db.pool().begin().await.map_err(AppError::Database)?;
@@ -1305,7 +1305,7 @@ mod tests {
         status: &str,
     ) -> String {
         let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("session-{}", uuid::Uuid::now_v7());
         let input = serde_json::json!({
             "task_prompt": "Test task prompt",
             "output_prompt": "Test output prompt"

--- a/server/src/models/task.rs
+++ b/server/src/models/task.rs
@@ -109,7 +109,7 @@ impl Task {
             output: None,
             error_message: None,
             retry_count: 0,
-            session_id: session_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            session_id: session_id.unwrap_or_else(|| Uuid::now_v7().to_string()),
             output_format: None,
             created_at: now,
             assigned_at: None,
@@ -332,6 +332,25 @@ mod tests {
         );
 
         assert_eq!(task.session_id, "custom_session");
+    }
+
+    #[test]
+    fn test_task_new_generates_session_id_v7() {
+        // Arrange
+        use uuid::Uuid;
+
+        // Act
+        let task = Task::new("user_123", "service_456", None);
+        let session_uuid =
+            Uuid::parse_str(&task.session_id).expect("session_id should be a valid UUID");
+
+        // Assert
+        let version = session_uuid.as_bytes()[6] >> 4;
+        assert_eq!(
+            version, 7,
+            "expected UUID v7 session_id, got version {}",
+            version
+        );
     }
 
     #[test]

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -113,7 +113,7 @@ pub async fn create_registered_service(pool: &SqlitePool) -> (String, String, St
 /// 使用默认 admin 用户 (id: 'admin')
 pub async fn create_test_task(pool: &SqlitePool, service_id: &str, status: &str) -> String {
     let task_id = format!("task-{}", uuid::Uuid::new_v4());
-    let session_id = format!("session-{}", uuid::Uuid::new_v4());
+    let session_id = format!("session-{}", uuid::Uuid::now_v7());
     let user_id = "admin"; // 使用 migrations 中创建的默认 admin 用户
 
     let input = serde_json::json!({

--- a/server/tests/integration/client_api.rs
+++ b/server/tests/integration/client_api.rs
@@ -6,6 +6,7 @@ use http_body_util::BodyExt;
 use open_aaas_server::models::user::UserRole;
 use serde_json::json;
 use tower::ServiceExt;
+use uuid::Uuid;
 
 use super::{
     ErrorResponse, GrantPermissionResponse, ServiceStatusResponse, TaskResponse, TestApp,
@@ -686,6 +687,51 @@ async fn test_create_task_json_success_public_service() {
     let task: TaskResponse = serde_json::from_slice(&body).unwrap();
     assert!(!task.id.is_empty());
     assert!(!task.session_id.is_empty());
+
+    app.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_create_task_generates_v7_session_id() {
+    let app = TestApp::new().await;
+
+    let (_, api_key, _) = create_test_user(app.pool(), "testuser", UserRole::Client).await;
+    let (service_id, _, _) =
+        create_test_service(app.pool(), "test_service", "Test Service", true).await;
+
+    let request_body = json!({
+        "service_id": service_id,
+        "task_prompt": "Test task prompt",
+        "output_prompt": "Test output format"
+    });
+
+    let response = app
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/client/tasks")
+                .header("Content-Type", "application/json")
+                .header(auth_header(&api_key).0, auth_header(&api_key).1)
+                .body(Body::from(request_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let task: TaskResponse = serde_json::from_slice(&body).unwrap();
+    let session_uuid =
+        Uuid::parse_str(&task.session_id).expect("session_id should be a valid UUID");
+    let version = session_uuid.as_bytes()[6] >> 4;
+    assert_eq!(
+        version, 7,
+        "expected UUID v7 session_id, got version {}",
+        version
+    );
 
     app.cleanup().await;
 }

--- a/server/tests/integration/mod.rs
+++ b/server/tests/integration/mod.rs
@@ -181,7 +181,7 @@ pub async fn create_test_task(
     status: &str,
 ) -> String {
     let task_id = Uuid::new_v4().to_string();
-    let session_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::now_v7().to_string();
     let now = chrono::Utc::now();
 
     let input = serde_json::json!({


### PR DESCRIPTION
## 修复内容

将 session ID 的生成从 UUID v4 改为 UUID v7，使 session ID 按时间单调递增，便于排序、审计和索引。

## 变更

- `server/Cargo.toml`：启用 uuid crate 的 `v7` feature
- `server/src/models/task.rs`：`Task::new` 中 session_id fallback 改为 `Uuid::now_v7()`
- `server/src/handlers/client.rs`：client create_task handler 中 session_id fallback 改为 `Uuid::now_v7()`
- 同步更新 8 处测试辅助函数中的 session_id 生成
- 新增单元测试 `test_task_new_generates_session_id_v7`
- 新增集成测试 `test_create_task_generates_v7_session_id`
- 更新 CHANGELOG

## 兼容性

- 历史 v4 session ID 无需迁移，新旧可共存
- uuid crate 1.10 已支持 v7，无需升级 major 版本

Fixes #172