### PR TITLE
docs(mcp-adapter): 补充 Codex 安装与配置说明

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -184,6 +184,24 @@ See [pyopenaaas/README.md](./pyopenaaas/README.md).
 - `toolTimeoutMs` sets the maximum wait time for MCP tool calls in milliseconds, suitable for long-running task polling.
 - ⚠️ This parameter is parsed by the MCP client; actual effectiveness depends on the specific client implementation. Some clients or agent tools may have independent timeout limits that override this setting.
 
+Codex users can add the adapter with the CLI:
+
+```bash
+codex mcp add openaaas -- uvx openaaas-mcp-adapter
+```
+
+For long-running task polling, configure `~/.codex/config.toml` (or `.codex/config.toml` in a trusted project):
+
+```toml
+[mcp_servers.openaaas]
+command = "uvx"
+args = ["openaaas-mcp-adapter"]
+startup_timeout_sec = 30
+tool_timeout_sec = 600
+```
+
+Codex expresses `tool_timeout_sec` in seconds. When calling `poll_task`, set `timeout_seconds` below this value and leave headroom for network requests.
+
 After configuring, restart the client to invoke all capabilities in conversation.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ paths = client.download_all_files(task.id)
 - `toolTimeoutMs` 设置 MCP 工具调用的最大等待时间（毫秒），适合长任务轮询场景。
 - ⚠️ 该参数由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制，导致该参数不生效。
 
+Codex 用户可以通过 CLI 添加适配器：
+
+```bash
+codex mcp add openaaas -- uvx openaaas-mcp-adapter
+```
+
+如需支持长任务轮询，在 `~/.codex/config.toml`（或受信任项目的 `.codex/config.toml`）中配置：
+
+```toml
+[mcp_servers.openaaas]
+command = "uvx"
+args = ["openaaas-mcp-adapter"]
+startup_timeout_sec = 30
+tool_timeout_sec = 600
+```
+
+Codex 的 `tool_timeout_sec` 单位为秒；调用 `poll_task` 时，建议将 `timeout_seconds` 设置为小于该值，并预留网络请求时间。
+
 配置后重启客户端，即可在对话中调用全部能力。
 
 <p align="center">

--- a/openaaas-mcp-adapter/PYPI_README.md
+++ b/openaaas-mcp-adapter/PYPI_README.md
@@ -44,6 +44,26 @@ In Cursor Settings → MCP, add a new server with the following configuration:
 }
 ```
 
+### Codex
+
+Add the adapter with the Codex CLI:
+
+```bash
+codex mcp add openaaas -- uvx openaaas-mcp-adapter
+```
+
+For long-running task polling, configure `~/.codex/config.toml` (or `.codex/config.toml` in a trusted project):
+
+```toml
+[mcp_servers.openaaas]
+command = "uvx"
+args = ["openaaas-mcp-adapter"]
+startup_timeout_sec = 30
+tool_timeout_sec = 600
+```
+
+Keep `poll_task(timeout_seconds=...)` below `tool_timeout_sec` so Codex has enough time to receive the tool result. Restart the Codex app, CLI session, or IDE extension after changing the configuration.
+
 ## Standard Workflow
 
 Once the adapter is connected, ask your AI agent to follow these steps:

--- a/openaaas-mcp-adapter/README.en.md
+++ b/openaaas-mcp-adapter/README.en.md
@@ -24,7 +24,7 @@ This is the **most recommended method**, suitable for all users.
 
 ---
 
-### Client Configuration
+### Claude Desktop, Cursor, or Cline Configuration
 
 Configure Claude Desktop, Cursor, or Cline:
 
@@ -44,6 +44,39 @@ Configure Claude Desktop, Cursor, or Cline:
 - ⚠️ This parameter is parsed by the MCP client; actual behavior depends on the specific client implementation. Some clients or the Agent tool itself may have independent timeout limits, causing this parameter to not take effect.
 
 After modifying the configuration, restart the client for it to take effect.
+
+---
+
+### Codex Configuration
+
+Add the adapter with the Codex CLI:
+
+```bash
+codex mcp add openaaas -- uvx openaaas-mcp-adapter
+```
+
+Verify the configuration:
+
+```bash
+codex mcp get openaaas
+codex mcp list
+```
+
+Codex stores global MCP configuration in `~/.codex/config.toml`. You can also use a project-scoped `.codex/config.toml` in a trusted project. To support long-running `poll_task` calls, use:
+
+```toml
+[mcp_servers.openaaas]
+command = "uvx"
+args = ["openaaas-mcp-adapter"]
+startup_timeout_sec = 30
+tool_timeout_sec = 600
+```
+
+- `tool_timeout_sec` is the maximum time, in seconds, that Codex waits for one MCP tool call.
+- When calling `poll_task`, keep `timeout_seconds` below `tool_timeout_sec` and leave headroom for network requests. For example, pair `timeout_seconds=540` with `tool_timeout_sec=600`.
+- Avoid unbounded polling in Codex because the MCP client can still terminate the call when its own tool timeout is reached.
+
+Restart the Codex app, CLI session, or IDE extension after configuring. In the Codex TUI, use `/mcp` to inspect the connection.
 
 ---
 

--- a/openaaas-mcp-adapter/README.md
+++ b/openaaas-mcp-adapter/README.md
@@ -24,7 +24,7 @@ uvx openaaas-mcp-adapter
 
 ---
 
-### 客户端配置
+### Claude Desktop、Cursor 或 Cline 配置
 
 配置 Claude Desktop、Cursor 或 Cline：
 
@@ -44,6 +44,39 @@ uvx openaaas-mcp-adapter
 - ⚠️ 该参数由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制，导致该参数不生效。
 
 配置修改后，重启客户端即可生效。
+
+---
+
+### Codex 配置
+
+通过 Codex CLI 添加适配器：
+
+```bash
+codex mcp add openaaas -- uvx openaaas-mcp-adapter
+```
+
+使用以下命令确认配置：
+
+```bash
+codex mcp get openaaas
+codex mcp list
+```
+
+Codex 将 MCP 配置保存在全局 `~/.codex/config.toml` 中；也可以在受信任项目中使用项目级 `.codex/config.toml`。如需支持长时间运行的 `poll_task`，配置如下：
+
+```toml
+[mcp_servers.openaaas]
+command = "uvx"
+args = ["openaaas-mcp-adapter"]
+startup_timeout_sec = 30
+tool_timeout_sec = 600
+```
+
+- `tool_timeout_sec` 是 Codex 等待单次 MCP Tool 调用的最长时间，单位为秒。
+- 调用 `poll_task` 时，建议将 `timeout_seconds` 设置为小于 `tool_timeout_sec`，并为网络请求预留时间。例如：`timeout_seconds=540` 搭配 `tool_timeout_sec=600`。
+- 避免在 Codex 中进行不设上限的轮询，否则 MCP 客户端仍可能在自身工具超时后终止调用。
+
+配置后重启 Codex App、CLI 会话或 IDE 扩展。在 Codex TUI 中可使用 `/mcp` 查看连接状态。
 
 ---
 


### PR DESCRIPTION
## Description

补充 OpenAaaS MCP Adapter 在 Codex 中的安装与配置说明。

主要改动：

- 增加 `codex mcp add` 安装命令
- 增加全局和项目级 `config.toml` 配置示例
- 说明 `startup_timeout_sec` 和 `tool_timeout_sec`
- 说明 Codex 工具超时与 `poll_task` 轮询超时的关系
- 增加 MCP 连接检查及客户端重启说明
- 同步更新中文、英文和 PyPI 文档

现有文档主要提供 Claude Desktop、Cursor 和 Cline 使用的
`mcpServers` JSON 配置。Codex 使用 `config.toml`，且工具超时字段为
`tool_timeout_sec`，因此不能直接复制现有配置。

本次补充的配置已在本地完成安装、连接及轮询验证。

## Checklist

- [x] 文档配置和示例已验证通过
- [x] CHANGELOG 不适用：本次为纯文档更新
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范
