### PR TITLE
docs: upgrade README narrative — external primary agents as capability infrastructure

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
-<p align="center">An open Agent-to-Agent orchestration network: any agent can discover, delegate to, and compose other full agent instances running on remote nodes.</p>
+<p align="center">An open Agent-to-Agent orchestration network: its nodes are capability anchors — full agent instances — that any external primary agent can discover, delegate to, and compose.</p>
 
 <p align="center">
   <a href="https://www.open-aaas.com">Website</a> ·
@@ -57,7 +57,7 @@
 
 > **Intelligence flows, data stays still — bring Agents to the data, instead of handing data over to Agents.**
 
-OpenAaaS is an Agent-to-Agent orchestration network for AI for Science. Every node runs a full agent instance with its own tools, models, and data; data stays where it was created, while agent capabilities flow through the network to work beside it.
+OpenAaaS is an Agent-to-Agent orchestration network for AI for Science. Every node runs a full agent instance with its own tools, models, and data; data stays where it was created, while agent capabilities flow through the network to work beside it. Together these nodes form a shared capability infrastructure; outside the network, countless primary agents — pi, Claude Code, Cursor, or your own — discover and compose these nodes through the OpenAaaS protocol, reaching data wherever it lives.
 
 | Demo Video | Screenshots |
 |:---:|:---:|
@@ -253,6 +253,9 @@ For Agent Core deployment, see [agent-core/README.md](./agent-core/README.md).
 ## Architecture
 
 ```
+(Outside the network: countless primary agents, each discovering
+ and composing capability nodes on the network)
+
 Client Agent
 (pi mono / Claude Code / Cline / Custom Agent)
         ▲

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>OpenAaaS — Open Us to the Agentic World</strong></p>
 
-<p align="center">一个开放的 Agent-to-Agent 编排网络：任何 Agent 都可以发现、委派并组合运行在远程节点上的其他完整 Agent 实例。</p>
+<p align="center">一个开放的 Agent-to-Agent 编排网络：网络中的节点是完整 Agent 实例构成的能力锚点，任何外部主智能体都可以发现、委派并组合它们。</p>
 
 <p align="center">
   <a href="https://www.open-aaas.com">官网</a> ·
@@ -57,7 +57,7 @@
 
 > **智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。**
 
-OpenAaaS 是一个面向 AI for Science 的 Agent-to-Agent 编排网络（Agent Orchestration Network）。网络中的每个节点都运行着一个拥有完整工具链的 Agent 实例；数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边，完成分析、计算与协作。
+OpenAaaS 是一个面向 AI for Science 的 Agent-to-Agent 编排网络（Agent Orchestration Network）。网络中的每个节点都运行着一个拥有完整工具链的 Agent 实例；数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边，完成分析、计算与协作。这些节点构成共享的能力基础设施；网络之外，无数主智能体——pi、Claude Code、Cursor 或自研 Agent——各自通过 OpenAaaS 协议发现和组合这些能力节点，把手伸向数据所在的任意角落。
 
 | 操作视频 | 截图 |
 |:---:|:---:|
@@ -251,6 +251,8 @@ Agent Core 部署详见 [agent-core/README.md](./agent-core/README.md)。
 ## 架构
 
 ```
+（网络外部：无数主智能体，各自发现并组合网络中的能力节点）
+
 客户端 Agent
 (pi mono / Claude Code / Cline / 自研 Agent)
         ▲


### PR DESCRIPTION
## 改动说明

优化 README 叙事，引入"外部主智能体 + 能力基础设施"视角，三处最小改动：

### 1. Tagline
明确区分"外部主智能体"（pi / Claude Code / Cursor 等）和"网络中的能力锚点"（完整 Agent 实例构成的节点）。

### 2. "什么是 OpenAaaS?" 段落
在原文末尾追加两句，引入"共享的能力基础设施"和"无数主智能体把手伸向数据所在的任意角落"的视角。

### 3. 架构图标注
在"客户端 Agent"上方增加一行标注，可视化"无数主智能体"在网络外部发现和组合能力节点的层次关系。

中英文同步更新。

## 改动范围
- `README.md` — 3 处编辑，+6/-2 行
- `README.en.md` — 3 处编辑，+7/-2 行

未改动其余内容。