### PR TITLE
fix(dash): upgrade gitpython to >=3.1.55 to fix 8 security CVEs

### DIFF
--- a/dash/pyproject.toml
+++ b/dash/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "toml>=0.10.2",
     "streamlit-autorefresh>=1.0.0",
+    # Security: override streamlit's transitive dependency to fix 8 CVEs (GHSA-2f96-g7mh-g2hx, GHSA-v396-v7q4-x2qj, GHSA-956x-8gvw-wg5v, GHSA-3rp5-jjmw-4wv2, GHSA-fjr4-x663-mwxc, GHSA-6p8h-3wgx-97gf, GHSA-r9mr-m37c-5fr3, GHSA-94p4-4cq8-9g67)
+    "gitpython>=3.1.55",
 ]
 
 [project.scripts]

--- a/dash/uv.lock
+++ b/dash/uv.lock
@@ -323,7 +323,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -356,14 +356,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]
@@ -799,6 +799,7 @@ name = "open-aaas-dashboard"
 version = "0.5.1"
 source = { editable = "." }
 dependencies = [
+    { name = "gitpython" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "requests" },
@@ -825,6 +826,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2.0" },
+    { name = "gitpython", specifier = ">=3.1.55" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -861,10 +863,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -933,10 +935,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [


### PR DESCRIPTION
## 问题

`dash` 项目的传递依赖 `gitpython==3.1.50`（由 streamlit 引入）存在 8 个 High 严重性安全漏洞，导致 CI 中 `pip-audit` 步骤持续失败，**阻塞了所有 PR 的合并**。

## 修复

将 gitpython 作为显式依赖加入 `dash/pyproject.toml`，约束 `>=3.1.55`，锁定到 3.1.57。

覆盖的 8 个 GHSA：
| GHSA | 类型 | CVSS |
|------|------|------|
| GHSA-2f96-g7mh-g2hx | Git option injection → RCE | 8.8 |
| GHSA-v396-v7q4-x2qj | Clone option smuggling | 8.7 |
| GHSA-956x-8gvw-wg5v | Repo.archive command injection | 8.4 |
| GHSA-3rp5-jjmw-4wv2 | Git-config section injection → RCE | 7.0 |
| GHSA-fjr4-x663-mwxc | Diffable.diff argument injection | 8.1 |
| GHSA-6p8h-3wgx-97gf | --template clone hook RCE | 7.7 |
| GHSA-r9mr-m37c-5fr3 | Kwarg token smuggling → RCE | 8.8 |
| GHSA-94p4-4cq8-9g67 | Repo.create_remote URL env leak | 7.5 |

## 验证

- `pip-audit` 本地验证通过：`No known vulnerabilities found`
- streamlit 对 gitpython 无版本上限约束，完全兼容
- dash 自身代码不直接使用 gitpython，无行为变更风险

## 变更

- `dash/pyproject.toml` — 新增 `gitpython>=3.1.55` 及安全注释
- `dash/uv.lock` — gitpython 3.1.50 → 3.1.57