### PR TITLE
chore(deps): split npm Dependabot groups by update type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      npm-dependencies:
+      npm-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "npm"
     directory: "/pi-extension"
@@ -42,9 +50,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      npm-dependencies:
+      npm-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   # Python 项目依赖扫描
   - package-ecosystem: "pip"


### PR DESCRIPTION
## 问题

之前 `dependabot.yml` 中 npm 的两个分组（`/client-app`、`/pi-extension`）使用 `patterns: ["*"]` 将所有包捆成一个 PR。当任何一个包发生主版本断裂（如 pinia 2→4, vite 6→8），整个 PR 就不可合并。

## 修复

将每个 npm 分组拆为两个：

| 分组 | update-types | 行为 |
|------|-------------|------|
| `npm-minor-patch` | minor, patch | ✅ 批量升级，安全 |
| `npm-major` | major | 🔒 每个主版本独立 PR，炸了不影响别人 |

## 关联

配合 #224（修复 pip-audit CI 阻塞），Dependabot 将基于干净的 main 重新创建依赖更新 PR。

## 变更

- `.github/dependabot.yml` — npm 分组按更新类型拆分