### PR TITLE
release: bump versions for 5 components

### DIFF
--- a/admin-cli/CHANGELOG.md
+++ b/admin-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-28
+
 ### Added
 - 接入 CI 质量门禁：`cargo fmt --check` 与 `cargo clippy --all-targets -- -D warnings`（#134）
 - 接入依赖安全扫描：`cargo audit --file admin-cli/Cargo.lock`（#134）
@@ -33,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 39 个单元/集成测试（含 wiremock HTTP 测试）
 - 安全配置：文件权限 0o600、API Key 脱敏、删除确认
 
+[0.1.2]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.2
 [0.1.1]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.1
 [0.1.0]: https://github.com/Wolido/OpenAaaS/releases/tag/admin-cli-v0.1.0

--- a/admin-cli/Cargo.toml
+++ b/admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-admin"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["OpenAaaS Contributors"]
 description = "OpenAaaS Server Admin CLI"

--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-28
+
 ### Added
 - 接入 CI 质量门禁：`cargo fmt --check` 与 `cargo clippy --all-targets --features test-utils -- -D warnings`（#134）
 - 接入依赖安全扫描：`cargo audit --file agent-core/Cargo.lock`（#134）
@@ -77,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.4.3]: https://github.com/Wolido/OpenAaaS/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Wolido/OpenAaaS/compare/v0.4.1...v0.4.2
 [0.4.0]: https://github.com/Wolido/OpenAaaS/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Wolido/OpenAaaS/compare/v0.3.0...v0.3.1

--- a/agent-core/Cargo.toml
+++ b/agent-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-core"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "OpenAaaS Agent Core - 调度与执行框架"
 

--- a/client-app/CHANGELOG.md
+++ b/client-app/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-07-28
+
 ### Fixed
 - httpFetch scope/权限拒绝错误不再静默回退，直接透传原始错误（#180）
 - httpFetchWithRedirect 重定向链中途失败时回退到 currentUrl 而非原始 input（#180）
@@ -96,3 +98,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial release
+
+[0.7.1]: https://github.com/Wolido/OpenAaaS/compare/client-app-v0.7.0...client-app-v0.7.1

--- a/client-app/src-tauri/Cargo.toml
+++ b/client-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openaaas-client"
-version = "0.7.0"
+version = "0.7.1"
 description = "OpenAaaS Desktop Client"
 authors = ["OpenAaaS"]
 edition = "2024"

--- a/openaaas-mcp-adapter/CHANGELOG.md
+++ b/openaaas-mcp-adapter/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-28
+
 ### Added
 - 接入 CI 依赖安全扫描：`pip-audit`（#134）
 - 提交 `uv.lock` 以锁定依赖版本（#134）
@@ -44,3 +46,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 
 - `toolTimeoutMs` 由 MCP 客户端解析，实际生效情况取决于具体客户端实现；某些客户端或 Agent 工具本身可能仍有独立的超时限制。
+
+[0.3.2]: https://github.com/Wolido/OpenAaaS/releases/tag/v0.3.2

--- a/openaaas-mcp-adapter/pyproject.toml
+++ b/openaaas-mcp-adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openaaas-mcp-adapter"
-version = "0.3.1"
+version = "0.3.2"
 description = "OpenAaaS MCP adapter — connect Claude Desktop, Cursor, Cline to OpenAaaS Server"
 readme = "PYPI_README.md"
 requires-python = ">=3.10"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-28
+
 ### Added
 - 接入 CI 质量门禁：`cargo fmt --check` 与 `cargo clippy --all-targets -- -D warnings`（#134）
 - 接入依赖安全扫描：`cargo audit --file server/Cargo.lock`（#134）
@@ -151,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[0.12.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.11.0...server-v0.12.0
 [0.11.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.10.0...server-v0.11.0
 [0.10.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.9.0...server-v0.10.0
 [0.9.0]: https://github.com/Wolido/OpenAaaS/compare/server-v0.8.0...server-v0.9.0

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open-aaas-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-aaas-server"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## 版本更新

| 组件 | 版本 | 变更摘要 |
|------|------|---------|
| **admin-cli** | v0.1.1 → **v0.1.2** | CI 质量门禁 + cargo audit |
| **server** | v0.11.0 → **v0.12.0** | sqlx 0.8→0.9、UUID v7、参数化查询 |
| **agent-core** | v0.4.2 → **v0.4.3** | reqwest 0.11→0.12、CI 门禁 |
| **client-app** | v0.7.0 → **v0.7.1** | httpFetch 错误透传等 3 个 bug fix |
| **openaaas-mcp-adapter** | v0.3.1 → **v0.3.2** | 修复 20 个 CVE |

## 操作说明

合并后，通过 GitHub Actions `Release` workflow 手动触发各组件发布：
- 选择对应 **component** 和 **version**
- workflow 会自动构建、打 tag、创建 GitHub Release

## 变更

- `**/CHANGELOG.md` — Unreleased → 各版本号
- `**/Cargo.toml` — 版本号更新
- `**/pyproject.toml` — 版本号更新