### PR TITLE
fix(agent-core): 修复 memory_limit 为 None 时 config.toml 不输出注释示例行

### DIFF
--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 修复 init/生成的配置文件中 `memory_limit` 未设置时不输出的问题，现在会以注释示例形式（`# memory_limit = "4g"`）展示
+
 ## [0.4.3] - 2026-07-28
 
 ### Added

--- a/agent-core/src/config.rs
+++ b/agent-core/src/config.rs
@@ -384,6 +384,9 @@ impl Config {
         if let Some(ref mem) = self.executor.memory_limit {
             lines.push("# 内存限制".to_string());
             lines.push(format!("memory_limit = {}", Self::toml_str(mem)));
+        } else {
+            lines.push("# 内存限制（可选）".to_string());
+            lines.push(r#"# memory_limit = "4g""#.to_string());
         }
         lines.push("# 工作目录（容器内）".to_string());
         lines.push(format!(
@@ -717,6 +720,46 @@ mod tests {
         assert!(toml_str.contains("capacity"));
         assert!(toml_str.contains("timeout_minutes"));
         assert!(toml_str.contains("# OpenAaaS Agent Core 配置文件"));
+    }
+
+    #[test]
+    fn test_runtime_toml_memory_limit_none_outputs_comment() {
+        // Arrange: 默认配置 memory_limit 为 None
+        let config = Config::default();
+
+        // Act
+        let toml_str = config.to_runtime_toml();
+
+        // Assert: None 时应输出注释示例行，与 config.toml.example 一致
+        assert!(
+            toml_str.contains(r#"# memory_limit = "4g""#),
+            "默认配置应输出 memory_limit 的注释示例行"
+        );
+    }
+
+    #[test]
+    fn test_runtime_toml_memory_limit_some_outputs_value() {
+        // Arrange: memory_limit 显式设置为 "4g"
+        let config = Config {
+            executor: ExecutorConfig {
+                memory_limit: Some("4g".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Act
+        let toml_str = config.to_runtime_toml();
+
+        // Assert: Some 时应输出非注释的实际配置行
+        assert!(
+            toml_str.contains(r#"memory_limit = "4g""#),
+            "显式设置 memory_limit 时应输出非注释的配置行"
+        );
+        assert!(
+            !toml_str.contains(r#"# memory_limit = "4g""#),
+            "显式设置 memory_limit 时不应再输出注释示例行"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

`to_runtime_toml()` 在 `memory_limit` 为 `None` 时完全不输出该字段。`config.toml.example` 中有一行 `# memory_limit = "4g"` 作为可选项的注释示例，但 init / 首启向导生成的 `config.toml` 中却看不到这一行——用户无从知晓该字段的存在。

该问题在 #230（enable_host_access 功能）的代码审查中发现。

## 变更

- `src/config.rs`: `to_runtime_toml()` — `memory_limit` 为 `None` 时，输出 `# memory_limit = "4g"`（与 `config.toml.example` 一致）。`Some` 路径行为不变。
- `CHANGELOG.md`: `[Unreleased]` 下 `### Fixed` 新增条目。

## 测试

新增 2 个单元测试：

- `test_runtime_toml_memory_limit_none_outputs_comment` — 验证默认配置（`memory_limit = None`）输出注释示例行。
- `test_runtime_toml_memory_limit_some_outputs_value` — 验证显式设置后输出非注释配置行，且不再输出注释行。