### PR TITLE
fix(pi-extension): remove stray debug console.log causing TUI error banner

### DIFF
--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -1000,7 +1000,6 @@ export default function (pi: ExtensionAPI) {
   // 监听 tool_result，自动捕获 submit_task
   pi.on("tool_result", async (event, ctx) => {
     if (event.toolName !== "OpenAaaS") return;
-    console.log("[OpenAaaS] tool_result event:", event.toolName, (event.input as any)?.action, (event.details as any)?.task_id);
     const input = event.input as Record<string, unknown>;
     if (input?.action !== "submit_task") return;
 

--- a/pi-extension/package-lock.json
+++ b/pi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-aaas-pi-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-aaas-pi-extension",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-aaas-pi-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "OpenAaaS pi extension",
   "license": "MIT",
   "author": "IDM Explorer Lab",


### PR DESCRIPTION
## Problem

Every OpenAaaS tool call triggered a red error banner in the pi TUI, e.g.:

```
[OpenAaaS] tool_result event: OpenAaaS list_services undefined
```

## Root Cause

The `tool_result` event listener in `pi-extension/index.ts` contained a leftover debug `console.log`. The pi TUI captures extension stdout and displays it as an error banner, so this log surfaced on every tool invocation. (The trailing `undefined` came from logging a `task_id` field that does not exist in the event details.)

## Changes

- Removed the debug `console.log` line from the `tool_result` event listener in `pi-extension/index.ts`.

One-line change, no logic modifications.

## Verification

- Ran the extension locally and invoked OpenAaaS tools (e.g. `list_services`) multiple times.
- Confirmed no red banner appears in the TUI and tool output is unchanged.