### PR TITLE
docs(pi-extension): add v1.0.2 release link to CHANGELOG

### DIFF
--- a/pi-extension/CHANGELOG.md
+++ b/pi-extension/CHANGELOG.md
@@ -47,4 +47,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 支持多服务器配置：分别注册、切换默认服务器、删除服务器配置（set_server_url、list_servers、set_default_server、remove_server）
 - 注册信息自动保存到本地配置文件（`~/.pi/agent/openaaas/config.json`）
 
+[1.0.2]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.0.2
 [1.0.1]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.0.1


### PR DESCRIPTION
## Description

`pi-extension-v1.0.2` tag 已补打并推送（指向 PR #241 合并提交 `8df7934`）。本 PR 在 `pi-extension/CHANGELOG.md` 文末补充 `[1.0.2]` 版本链接引用（置于 `[1.0.1]` 之前，版本号降序，与 `admin-cli/CHANGELOG.md` 链接排列风格一致）。

- [x] 在 `pi-extension/CHANGELOG.md` 文末新增：
  `[1.0.2]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.0.2`

## Checklist

- [x] 代码改动已测试通过（纯文档变更，无代码改动）
- [x] 对应组件的 `CHANGELOG.md` 已更新（补充 v1.0.2 版本链接引用）
- [x] 没有引入无关的文件改动（仅 1 行新增）
- [x] PR 标题符合 Conventional Commits 规范（`docs(pi-extension): add v1.0.2 release link to CHANGELOG`）
