### PR TITLE
fix(dash): upgrade gitpython to 3.1.58 to fix 5 GHSA vulnerabilities

### DIFF
--- a/dash/uv.lock
+++ b/dash/uv.lock
@@ -356,14 +356,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

将 dash 组件锁文件中的 gitpython 从 **3.1.57** 升级到 **3.1.58**，修复 security-audit CI job 报告的 5 个 GHSA 漏洞：

- GHSA-9rj7-rf2p-w77r
- GHSA-4gmw-gg2m-w46p
- GHSA-hh9p-6wh2-4mfc
- GHSA-wvpp-8hx9-p66j
- GHSA-jm78-9fvv-mhgr

`dash/pyproject.toml:30` 的约束为 `gitpython>=3.1.55`（宽松下限），3.1.58 已满足，**pyproject.toml 无需改动**，本次仅更新 `dash/uv.lock`（3 行变更：版本号 + sdist/wheel URL 与哈希）。

本地验证：`uv export ... | pip-audit -r -` 输出 `No known vulnerabilities found`。

CI 的 `security-audit` job（ci.yml 与 release.yml）均可恢复绿色。

## Checklist

- [x] 代码改动已测试通过
- [ ] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）— dash 组件无 CHANGELOG.md，与历史 #224 一致
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）