### PR TITLE
ci: bump Node.js from 20 to 24 for frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: client-app/package-lock.json
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,7 @@ jobs:
         if: env.COMPONENT == 'client-app' && steps.support.outputs.supported == 'true'
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: client-app/package-lock.json
 


### PR DESCRIPTION
## Description

**动机**：PR #228 引入的 jsdom 30 + undici 8 要求 Node >=22.22.2（undici 8 要求 >=22.19.0，`worker_threads.markAsUncloneable` 需 Node >=22.10）。当前 CI 在 Node 20 上跑 frontend-tests 会报 `webidl.util.markAsUncloneable is not a function`。

**变更**：
- `.github/workflows/ci.yml`：frontend-tests job 的 `setup-node` 从 Node 20 升到 **24**（当前 LTS），满足全部依赖 engines 要求。
- `.github/workflows/release.yml`：client-app 组件的 `setup-node` 同步从 20 升到 **24**，保持版本一致。

**影响**：仅修改 CI/release 流水线中的 Node 版本号，无其他配置改动。

## Checklist

- [x] 代码改动已测试通过（依赖 CI 验证）
- [ ] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）
- [x] 没有引入无关的文件改动
- [x] PR 标题符合 Conventional Commits 规范（如 `feat(agent-core): xxx`）
