### PR TITLE
feat(agent-core): 支持任务容器 GPU 挂载

### DIFF
--- a/agent-core/CHANGELOG.md
+++ b/agent-core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ExecutorConfig` 新增 `gpu: Option<GpuConfig>` 配置项（`gpu.vendor` / `gpu.devices`，默认关闭）。开启后任务容器通过 `docker run --gpus` 参数挂载 GPU：v1 仅支持 `nvidia`（`amd` / `intel` 为预留值，不生成 GPU 参数），`devices` 缺省为 `"all"`，也可按索引指定如 `"0,1"`。新增启动 GPU 预检：macOS 与 Windows 原生配置 GPU 会阻断启动，Linux / WSL2 缺 nvidia runtime 或 `docker info` 失败仅警告；崩溃恢复（recover_tasks）时会取消残留容器，防止 GPU 显存泄漏。仅建议管理员在配置文件中显式开启。`config.toml.example` 与 README 已同步更新。
 - `ExecutorConfig` 新增 `enable_host_access: bool` 配置项（默认 `false`）。开启后任务容器启动时注入 `--add-host host.docker.internal:host-gateway`，容器内可通过 `http://host.docker.internal:<port>` 访问宿主机服务。需 Docker 20.10+，仅建议管理员在配置文件中显式开启。`config.toml.example` 与 README 已同步更新。
 
 ### Fixed

--- a/agent-core/README.en.md
+++ b/agent-core/README.en.md
@@ -10,6 +10,7 @@ The Agent scheduler for OpenAaaS, responsible for registering with the Server, p
 |----------|--------------|
 | All platforms | Rust toolchain 1.85+, Docker |
 | Windows | Docker Desktop (WSL2 backend recommended), Windows 10 19041+ or Windows 11 |
+| GPU mounting (optional) | NVIDIA GPU and driver; Linux requires nvidia-container-toolkit. See [GPU Mounting](#gpu-mounting-optional) |
 
 > Windows users unfamiliar with Docker Desktop should refer to the [Windows Deployment](#windows-deployment) section below.
 
@@ -40,6 +41,8 @@ docker build -t open-aaas-executor:latest .
 ```
 
 > The image name must match `executor.image` in `config.toml` (default value is `open-aaas-executor:latest`).
+
+> For GPU mounting, the image must ship its own CUDA runtime libraries (e.g. build on `nvidia/cuda`); agent-core only mounts GPU devices and does not provide a CUDA environment. See [GPU Mounting](#gpu-mounting-optional).
 
 ### How It Works
 
@@ -206,6 +209,8 @@ Executor configuration:
   Image: open-aaas-executor:latest
   Capacity: 2
   Timeout: 0 minutes
+  Host access: disabled
+  GPU: disabled
 ```
 
 ## Stop Service
@@ -240,6 +245,8 @@ capacity = 2                         # Concurrent task count
 timeout_minutes = 0                  # Task timeout (minutes), 0 means unlimited
 # memory_limit = "4g"                # Memory limit (optional)
 # enable_host_access = false         # Allow container to access host services (requires Docker 20.10+, defaults to false)
+# gpu.vendor = "nvidia"              # GPU vendor (v1 supports nvidia only; amd / intel reserved, disabled by default)
+# gpu.devices = "all"                # GPUs to mount: "all" or an index list like "0,1"
 working_dir = "/workspace"           # Working directory inside the container
 # script_path = "/workspace/run.sh"  # Script path (for bash/python type)
 custom_entrypoint = ["/bin/sh"]      # Custom ENTRYPOINT (custom type)
@@ -258,7 +265,64 @@ readonly = true                      # Read-only
 
 - **server**: Configuration related to connecting to the Server; `base_url` is required.
 - **agent**: `service_id` and `api_key` are auto-filled by the `register` command; no need to fill manually.
-- **executor**: Task executor configuration. `executor_type` supports `standard` (container default ENTRYPOINT), `bash`, `python`, `custom`; `capacity` controls the number of concurrent tasks. Set `enable_host_access` to `true` (default `false`) to inject `host.docker.internal` pointing to the host, allowing containers to reach host services listening on `0.0.0.0`. Requires Docker 20.10+. For security, only administrators should explicitly enable this in the configuration file. Note: Docker Desktop (macOS/Windows) and OrbStack provide built-in `host.docker.internal` DNS resolution, making this option redundant but harmless on those platforms. It is only required for native Linux Docker Engine.
+- **executor**: Task executor configuration. `executor_type` supports `standard` (container default ENTRYPOINT), `bash`, `python`, `custom`; `capacity` controls the number of concurrent tasks. Set `enable_host_access` to `true` (default `false`) to inject `host.docker.internal` pointing to the host, allowing containers to reach host services listening on `0.0.0.0`. Requires Docker 20.10+. For security, only administrators should explicitly enable this in the configuration file. Note: Docker Desktop (macOS/Windows) and OrbStack provide built-in `host.docker.internal` DNS resolution, making this option redundant but harmless on those platforms. It is only required for native Linux Docker Engine. `gpu.vendor` / `gpu.devices` configure GPU mounting (disabled by default; v1 supports nvidia only). See [GPU Mounting](#gpu-mounting-optional).
 - **paths**: `data_dir` stores logs and runtime data. `[[paths.mounts]]` defines additional directories mounted into the executor container, commonly used for mounting configuration files or shared data.
 
 After the first run, most configurations do not need to be modified manually. If adjustments are needed, simply edit `config.toml` and restart.
+
+## GPU Mounting (Optional)
+
+v1 supports mounting NVIDIA GPUs into task containers (via the `docker run --gpus` flag); disabled by default. Configure it in the `[executor]` section of `config.toml`:
+
+```toml
+[executor]
+gpu.vendor = "nvidia"   # v1 supports nvidia only; amd / intel are reserved and generate no GPU flags
+gpu.devices = "all"     # Mount all GPUs; or specify indices, e.g. "0,1"
+```
+
+Once enabled, every task container gets GPU access. The `status` command shows the current GPU configuration. `gpu.devices` accepts only the default, `"all"`, or a comma-separated list of numeric indices (whitespace-only is treated as `"all"`); invalid values containing spaces, semicolons, letters, or empty segments (e.g. `"0;;1"`) fail configuration loading and abort startup.
+
+### Platform Support
+
+| Platform | Support |
+|----------|---------|
+| Linux | Natively supported; requires nvidia-container-toolkit |
+| Windows (WSL2) | NVIDIA GPUs supported; install the NVIDIA driver on the Windows side |
+| Windows (native Docker Desktop) | Not supported; startup fails if configured. Use the WSL2 backend instead |
+| macOS | Not supported; startup fails if configured |
+
+At startup, agent-core runs a GPU precheck: configuring GPU on macOS or native Windows aborts startup with an error; on Linux / WSL2, a missing nvidia runtime or a failed `docker info` only logs a warning and does not block startup.
+
+### Installing nvidia-container-toolkit (Linux)
+
+Debian / Ubuntu (apt):
+
+```bash
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+```
+
+RHEL / Fedora (dnf):
+
+```bash
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+sudo dnf install -y nvidia-container-toolkit
+```
+
+After installation, configure the Docker runtime and restart Docker:
+
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+> WSL2 users running Docker Desktop do not need the toolkit inside WSL; install the NVIDIA driver on Windows and enable the WSL2 backend. If you run a native Docker Engine inside WSL2, follow the Linux steps above.
+
+### Security & Scheduling Notes
+
+- GPU mounting is quasi-privileged hardware access: once enabled, every task container can access the GPU, with no isolation between tasks. Enable it explicitly only for trusted workloads.
+- GPUs are not counted in `capacity` scheduling. On GPU nodes, set `capacity` to the concurrency your VRAM can sustain, so tasks do not compete for GPU memory.
+- To run CPU and GPU tasks on the same machine, run two agent-core instances: one with GPU enabled, one without, each taking its own kind of tasks.
+- The executor image must ship its own CUDA runtime libraries (e.g. build on `nvidia/cuda`); agent-core only mounts GPU devices and does not provide a CUDA environment.

--- a/agent-core/README.md
+++ b/agent-core/README.md
@@ -10,6 +10,7 @@ OpenAaaS 的 Agent 调度器，负责向 Server 注册、轮询获取任务，�
 |------|------|
 | 所有平台 | Rust 工具链 1.85+、Docker |
 | Windows | Docker Desktop（推荐 WSL2 后端）、Windows 10 19041+ 或 Windows 11 |
+| GPU 挂载（可选） | NVIDIA 显卡与驱动；Linux 需安装 nvidia-container-toolkit，详见 [GPU 挂载](#gpu-挂载可选) |
 
 > Windows 用户如不熟悉 Docker Desktop 配置，建议直接参考下方 [Windows 部署](#windows-部署) 小节。
 
@@ -38,6 +39,8 @@ docker build -t open-aaas-executor:latest .
 ```
 
 > 镜像名需要与 `config.toml` 中的 `executor.image` 保持一致（默认值为 `open-aaas-executor:latest`）。
+
+> 如需 GPU 挂载，镜像需自带 CUDA 运行库（如基于 `nvidia/cuda` 镜像构建）；agent-core 只负责挂载 GPU 设备，不提供 CUDA 环境。详见 [GPU 挂载](#gpu-挂载可选)。
 
 ### 工作原理
 
@@ -204,6 +207,8 @@ Agent 名称: my-agent
   镜像: open-aaas-executor:latest
   容量: 2
   超时: 0 分钟
+  宿主机访问: 已关闭
+  GPU: 未开启
 ```
 
 ## 停止服务
@@ -238,6 +243,8 @@ capacity = 2                         # 并发任务数
 timeout_minutes = 0                  # 任务超时（分钟），0 表示不限制
 # memory_limit = "4g"                # 内存限制（可选）
 # enable_host_access = false         # 允许容器访问宿主机服务（需 Docker 20.10+，默认 false）
+# gpu.vendor = "nvidia"              # GPU 厂商（v1 仅支持 nvidia；amd / intel 预留，默认关闭）
+# gpu.devices = "all"                # 挂载的 GPU："all" 或 "0,1" 等索引列表
 working_dir = "/workspace"           # 容器内工作目录
 # script_path = "/workspace/run.sh"  # 脚本路径（bash/python 类型用）
 custom_entrypoint = ["/bin/sh"]      # 自定义 ENTRYPOINT（custom 类型）
@@ -256,7 +263,64 @@ readonly = true                      # 是否只读
 
 - **server**: 连接 Server 的相关配置，`base_url` 必填。
 - **agent**: `service_id` 和 `api_key` 由 `register` 命令自动填充，无需手动填写。
-- **executor**: 任务执行器配置。`executor_type` 支持 `standard`（容器默认 ENTRYPOINT）、`bash`、`python`、`custom`；`capacity` 控制并发任务数；`enable_host_access`（默认 `false`）设为 `true` 后容器可通过 `host.docker.internal` 访问宿主机服务，需 Docker 20.10+。安全提示：开启后容器可访问宿主机上监听 `0.0.0.0` 的所有服务，仅建议管理员在配置文件中显式开启。提示：Docker Desktop（macOS / Windows）与 OrbStack 等桌面运行时已内置 `host.docker.internal` 解析，开启此功能冗余但无害；仅 Linux 原生 Docker Engine 需要开启。
+- **executor**: 任务执行器配置。`executor_type` 支持 `standard`（容器默认 ENTRYPOINT）、`bash`、`python`、`custom`；`capacity` 控制并发任务数；`enable_host_access`（默认 `false`）设为 `true` 后容器可通过 `host.docker.internal` 访问宿主机服务，需 Docker 20.10+。安全提示：开启后容器可访问宿主机上监听 `0.0.0.0` 的所有服务，仅建议管理员在配置文件中显式开启。提示：Docker Desktop（macOS / Windows）与 OrbStack 等桌面运行时已内置 `host.docker.internal` 解析，开启此功能冗余但无害；仅 Linux 原生 Docker Engine 需要开启。`gpu.vendor` / `gpu.devices` 配置 GPU 挂载（默认关闭，v1 仅支持 nvidia），详见 [GPU 挂载](#gpu-挂载可选)。
 - **paths**: `data_dir` 存放日志和运行时数据。`[[paths.mounts]]` 定义额外挂载到执行器容器的目录，常用于挂载配置文件或共享数据。
 
 首次运行后无需手动修改大部分配置。若需调整，直接编辑 `config.toml` 后重启即可。
+
+## GPU 挂载（可选）
+
+v1 支持将 NVIDIA GPU 挂载进任务容器（通过 `docker run --gpus` 参数），默认关闭。在 `config.toml` 的 `[executor]` 节配置：
+
+```toml
+[executor]
+gpu.vendor = "nvidia"   # v1 仅支持 nvidia；amd / intel 为预留值，配置了也不会生成 GPU 参数
+gpu.devices = "all"     # 挂载全部 GPU；也可按索引指定，如 "0,1"
+```
+
+开启后所有任务容器都会获得 GPU 访问权，`status` 命令会显示当前 GPU 配置。`gpu.devices` 仅支持缺省、`"all"` 或逗号分隔的数字索引（空白按 `"all"` 处理）；含空格、分号、字母或空段（如 `"0;;1"`）的非法值会在配置加载时报错，拒绝启动。
+
+### 平台支持
+
+| 平台 | 支持情况 |
+|------|----------|
+| Linux | 原生支持，需安装 nvidia-container-toolkit |
+| Windows（WSL2） | 支持 NVIDIA GPU，在 Windows 侧安装 NVIDIA 驱动即可 |
+| Windows（原生 Docker Desktop） | 不支持，配置了会启动报错，请改用 WSL2 后端 |
+| macOS | 不支持，配置了会启动报错 |
+
+启动时 agent-core 会执行 GPU 预检：macOS 与 Windows 原生配置 GPU 会直接报错退出；Linux / WSL2 下未检测到 nvidia runtime 或 `docker info` 执行失败时仅警告，不阻断启动。
+
+### 安装 nvidia-container-toolkit（Linux）
+
+Debian / Ubuntu（apt）：
+
+```bash
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+```
+
+RHEL / Fedora（dnf）：
+
+```bash
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+sudo dnf install -y nvidia-container-toolkit
+```
+
+安装后配置 Docker runtime 并重启 Docker：
+
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+> WSL2 用户使用 Docker Desktop 时无需在 WSL 内安装 toolkit，在 Windows 侧安装 NVIDIA 驱动并启用 WSL2 后端即可；在 WSL2 内运行原生 Docker Engine 则按上述 Linux 步骤安装。
+
+### 安全与调度提示
+
+- GPU 挂载属于准特权硬件访问：开启后所有任务容器都能访问 GPU，任务间不做隔离，仅建议在可信任务场景由管理员显式开启。
+- GPU 不参与 `capacity` 调度计数。GPU 节点应根据显存容量自行把 `capacity` 设为可承载的并发数，避免多任务争抢显存。
+- 同一台机器需要混跑 CPU 与 GPU 任务时，建议运行两个 agent-core 实例：一个开启 GPU，一个关闭 GPU，分开接任务。
+- 执行器镜像需自带 CUDA 运行库（如基于 `nvidia/cuda` 镜像构建）；agent-core 只负责挂载 GPU 设备，不提供 CUDA 环境。

--- a/agent-core/config.toml.example
+++ b/agent-core/config.toml.example
@@ -40,6 +40,13 @@ working_dir = "/workspace"
 # 安全风险：开启后任务容器可访问宿主机上监听 0.0.0.0 的所有服务，请谨慎开启
 # 提示：Docker Desktop（macOS / Windows）与 OrbStack 等桌面运行时已内置 host.docker.internal 解析，开启此功能冗余但无害；仅 Linux 原生 Docker Engine 需要开启
 # enable_host_access = false
+# GPU 挂载（可选，v1 仅支持 nvidia；amd / intel 预留，默认关闭）
+# 安全风险：开启后所有任务容器都获得 GPU 访问权（docker --gpus 参数挂载），仅建议管理员显式开启
+# 平台要求：仅 Linux / WSL2 支持（Linux 需安装 nvidia-container-toolkit）；macOS 与 Windows 原生不支持，配置了会启动报错
+# 开启示例（devices 为 "all" 挂载全部 GPU，也可按索引指定如 "0,1"）：
+# 注意：devices 仅支持 "all" 或逗号分隔的数字索引（空白按 "all" 处理）；含空格、分号、字母或空段（如 "0;;1"）的非法值会配置加载报错、拒绝启动
+# gpu.vendor = "nvidia"
+# gpu.devices = "all"
 
 [paths]
 # 数据目录

--- a/agent-core/src/cmd/run.rs
+++ b/agent-core/src/cmd/run.rs
@@ -5,6 +5,7 @@ use agent_core::{
     config::Config,
     executor::Executor,
     executor::docker::DockerExecutor,
+    gpu_precheck::precheck_gpu_on_startup,
     main_support::*,
     scheduler::{Scheduler, SchedulerCommand},
     state::StateManager,
@@ -49,6 +50,9 @@ pub async fn run_foreground(config_path: PathBuf, interactive: bool) -> anyhow::
 
     // 确保挂载目录存在
     config.ensure_mount_dirs().await?;
+
+    // GPU 启动预检（配置了 GPU 时执行；macOS / Windows 直接报错，Linux 缺 runtime 仅警告）
+    precheck_gpu_on_startup(&config.executor.gpu).await?;
 
     // 获取 docker 挂载参数
     let docker_mounts = config.docker_mounts();

--- a/agent-core/src/cmd/status.rs
+++ b/agent-core/src/cmd/status.rs
@@ -39,6 +39,17 @@ pub async fn status(config_path: PathBuf) -> anyhow::Result<()> {
             "已关闭"
         }
     );
+    println!(
+        "  GPU: {}",
+        match &config.executor.gpu {
+            Some(gpu) => format!(
+                "已开启（vendor: {}, devices: {}）",
+                gpu.vendor.as_str(),
+                gpu.devices.as_deref().unwrap_or("all")
+            ),
+            None => "未开启".to_string(),
+        }
+    );
 
     Ok(())
 }

--- a/agent-core/src/config.rs
+++ b/agent-core/src/config.rs
@@ -69,6 +69,66 @@ pub enum ConfigError {
     Directory(String),
 }
 
+/// GPU 厂商
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuVendor {
+    /// NVIDIA（v1 已支持，通过 docker --gpus 参数挂载）
+    Nvidia,
+    /// AMD（预留，v1 未实现）
+    Amd,
+    /// Intel（预留，v1 未实现）
+    Intel,
+}
+
+impl GpuVendor {
+    /// 获取厂商的字符串表示
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            GpuVendor::Nvidia => "nvidia",
+            GpuVendor::Amd => "amd",
+            GpuVendor::Intel => "intel",
+        }
+    }
+}
+
+/// GPU 挂载配置（executor 级全局配置，默认关闭）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpuConfig {
+    /// GPU 厂商
+    pub vendor: GpuVendor,
+    /// 挂载的设备（"all" 或 "0,1" 等索引列表，缺省为 "all"）
+    pub devices: Option<String>,
+}
+
+impl GpuConfig {
+    /// 校验 GPU 配置合法性
+    ///
+    /// devices 仅支持 "all" 或逗号分隔的 GPU 索引（如 "0,1"）；
+    /// 空白字符串按 "all" 处理（与 docker 参数翻译层行为一致），
+    /// 其他非法值（含空格、分号、字母等）拒绝加载，避免生成畸形 docker 参数。
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        let Some(ref devices) = self.devices else {
+            return Ok(());
+        };
+        let devices = devices.trim();
+        if devices.is_empty() || devices == "all" {
+            return Ok(());
+        }
+        let valid = devices
+            .split(',')
+            .all(|seg| !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit()));
+        if valid {
+            Ok(())
+        } else {
+            Err(ConfigError::Parse(format!(
+                "gpu.devices 配置非法: {:?}，仅支持 \"all\" 或逗号分隔的 GPU 索引（如 \"0,1\"）",
+                devices
+            )))
+        }
+    }
+}
+
 /// Agent 配置
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -154,6 +214,9 @@ pub struct ExecutorConfig {
     /// 是否允许任务容器访问宿主机服务（注入 host.docker.internal:host-gateway）
     #[serde(default)]
     pub enable_host_access: bool,
+
+    /// GPU 挂载配置（可选，默认关闭）
+    pub gpu: Option<GpuConfig>,
 }
 
 /// 单个挂载配置
@@ -253,6 +316,7 @@ impl Default for ExecutorConfig {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         }
     }
 }
@@ -304,6 +368,9 @@ impl Config {
         let mut config: Config =
             toml::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))?;
         config.normalize();
+        if let Some(ref gpu) = config.executor.gpu {
+            gpu.validate()?;
+        }
 
         Ok(config)
     }
@@ -409,6 +476,19 @@ impl Config {
             lines.push("enable_host_access = true".to_string());
         } else {
             lines.push("# enable_host_access = false".to_string());
+        }
+        if let Some(ref gpu) = self.executor.gpu {
+            lines.push("# GPU 挂载（v1 仅支持 nvidia；amd / intel 预留）".to_string());
+            lines.push(format!(
+                "gpu.vendor = {}",
+                Self::toml_str(gpu.vendor.as_str())
+            ));
+            let devices = gpu.devices.as_deref().unwrap_or("all");
+            lines.push(format!("gpu.devices = {}", Self::toml_str(devices)));
+        } else {
+            lines.push("# GPU 挂载（可选，v1 仅支持 nvidia；amd / intel 预留）".to_string());
+            lines.push(r#"# gpu.vendor = "nvidia""#.to_string());
+            lines.push(r#"# gpu.devices = "all""#.to_string());
         }
         lines.push("# 工作目录（容器内）".to_string());
         lines.push(format!(
@@ -890,6 +970,7 @@ name = "my-agent"
                 custom_entrypoint: None,
                 custom_args: None,
                 enable_host_access: false,
+                gpu: None,
             },
             paths: PathConfig {
                 data_dir: Some(PathBuf::from("/test/data")),
@@ -1159,6 +1240,7 @@ name = "my-agent"
                 custom_entrypoint: None,
                 custom_args: None,
                 enable_host_access: false,
+                gpu: None,
             },
             paths: PathConfig {
                 data_dir: Some(data_temp.path().join("custom_data")),
@@ -1473,6 +1555,7 @@ memory_limit = "1g"
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         assert_eq!(config.get_entrypoint(), Some(vec!["bash".to_string()]));
     }
@@ -1490,6 +1573,7 @@ memory_limit = "1g"
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         assert_eq!(
             config.get_command_args("task-123"),
@@ -1656,5 +1740,98 @@ enable_host_access = true
 
         // Assert
         assert!(config.executor.enable_host_access);
+    }
+
+    // ========== GPU 支持测试（TDD 红阶段） ==========
+
+    #[test]
+    fn test_runtime_toml_gpu_disabled_outputs_comment() {
+        // Arrange: 默认配置 gpu 为 None
+        let config = Config::default();
+
+        // Act
+        let toml_str = config.to_runtime_toml();
+
+        // Assert: 应包含精确的 GPU 注释示例行
+        assert!(
+            toml_str.contains(r#"# gpu.vendor = "nvidia""#),
+            "默认配置的 to_runtime_toml 输出应包含 `# gpu.vendor = \"nvidia\"` 注释示例行，实际输出:\n{}",
+            toml_str
+        );
+        assert!(
+            toml_str.contains(r#"# gpu.devices = "all""#),
+            "默认配置的 to_runtime_toml 输出应包含 `# gpu.devices = \"all\"` 注释示例行，实际输出:\n{}",
+            toml_str
+        );
+    }
+
+    // ========== gpu.devices 合法性校验测试 ==========
+
+    #[test]
+    fn test_gpu_config_validate_accepts_valid_devices() {
+        // devices 缺省 / "all" / 单个索引 / 逗号分隔索引均为合法值
+        for devices in [
+            None,
+            Some("all".to_string()),
+            Some("0".to_string()),
+            Some("0,1".to_string()),
+        ] {
+            let gpu = GpuConfig {
+                vendor: GpuVendor::Nvidia,
+                devices: devices.clone(),
+            };
+            assert!(gpu.validate().is_ok(), "devices={:?} 应为合法值", devices);
+        }
+    }
+
+    #[test]
+    fn test_gpu_config_validate_rejects_invalid_devices() {
+        // 含分号 / 空格 / 字母 / 空段的 devices 均为非法值
+        for devices in [
+            "0;1".to_string(),
+            "0 1".to_string(),
+            "abc".to_string(),
+            "0,,1".to_string(),
+        ] {
+            let gpu = GpuConfig {
+                vendor: GpuVendor::Nvidia,
+                devices: Some(devices.clone()),
+            };
+            let err = gpu
+                .validate()
+                .expect_err(&format!("devices={:?} 应为非法值", devices));
+            assert!(
+                err.to_string().contains("gpu.devices"),
+                "错误信息应指明 gpu.devices 配置非法，实际: {}",
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_from_path_rejects_invalid_gpu_devices() {
+        // Arrange: 写入含非法 gpu.devices 的配置文件
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[executor.gpu]
+vendor = "nvidia"
+devices = "0;1"
+"#,
+        )
+        .unwrap();
+
+        // Act
+        let result = Config::load_from_path(&config_path).await;
+
+        // Assert: 加载应失败并给出明确错误
+        let err = result.expect_err("非法 gpu.devices 应导致加载失败");
+        assert!(
+            err.to_string().contains("gpu.devices"),
+            "错误信息应指明 gpu.devices 配置非法，实际: {}",
+            err
+        );
     }
 }

--- a/agent-core/src/executor/docker.rs
+++ b/agent-core/src/executor/docker.rs
@@ -1,7 +1,7 @@
 //! Docker 执行器实现
 
 use super::{Executor, ExecutorError, Task, TaskResult};
-use crate::config::ExecutorConfig;
+use crate::config::{ExecutorConfig, GpuConfig, GpuVendor};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -27,6 +27,31 @@ impl LoadGuard {
 impl Drop for LoadGuard {
     fn drop(&mut self) {
         self.load.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// 将 GPU 配置翻译为 docker run 参数
+///
+/// - 未配置 GPU 时返回空
+/// - v1 仅支持 nvidia：devices 为 "all"（或缺省）时生成 `--gpus all`，
+///   否则生成 `--gpus device=<索引列表>`
+/// - amd / intel 为预留枚举，v1 不生成参数
+pub fn gpu_run_args(gpu: &Option<GpuConfig>) -> Vec<String> {
+    let Some(gpu) = gpu else {
+        return Vec::new();
+    };
+
+    match gpu.vendor {
+        GpuVendor::Nvidia => {
+            let devices = gpu.devices.as_deref().unwrap_or("all").trim();
+            if devices.is_empty() || devices == "all" {
+                vec!["--gpus".to_string(), "all".to_string()]
+            } else {
+                vec!["--gpus".to_string(), format!("device={}", devices)]
+            }
+        }
+        // amd / intel 后端 v1 未实现，不生成 GPU 参数
+        GpuVendor::Amd | GpuVendor::Intel => Vec::new(),
     }
 }
 
@@ -134,6 +159,15 @@ impl DockerExecutor {
             );
             cmd.arg("--add-host")
                 .arg("host.docker.internal:host-gateway");
+        }
+
+        // GPU 挂载（可选，默认关闭，v1 仅支持 nvidia）
+        let gpu_args = gpu_run_args(&self.config.gpu);
+        if !gpu_args.is_empty() {
+            info!("任务 {} 已开启 GPU 挂载: {:?}", task.task_id, gpu_args);
+        }
+        for arg in gpu_args {
+            cmd.arg(arg);
         }
 
         // 内存限制
@@ -437,6 +471,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         }
     }
 
@@ -753,6 +788,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -781,6 +817,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -806,6 +843,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -835,6 +873,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -861,6 +900,7 @@ mod tests {
             custom_entrypoint: None,
             custom_args: None,
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -887,6 +927,7 @@ mod tests {
             custom_entrypoint: Some(vec!["/bin/sh".to_string(), "-c".to_string()]),
             custom_args: Some(vec!["echo".to_string(), "hello".to_string()]),
             enable_host_access: false,
+            gpu: None,
         };
         let temp_dir = TempDir::new().unwrap();
         let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
@@ -912,6 +953,7 @@ mod tests {
         // Arrange
         let config = ExecutorConfig {
             enable_host_access: true,
+            gpu: None,
             executor_type: ExecutorType::Standard,
             image: "test-executor:latest".to_string(),
             capacity: 5,
@@ -949,6 +991,7 @@ mod tests {
         // Arrange
         let config = ExecutorConfig {
             enable_host_access: false,
+            gpu: None,
             executor_type: ExecutorType::Standard,
             image: "test-executor:latest".to_string(),
             capacity: 5,
@@ -973,6 +1016,174 @@ mod tests {
         assert!(
             !args.contains(&"--add-host".to_string()),
             "enable_host_access 为 false 时不应包含 --add-host"
+        );
+    }
+
+    #[test]
+    fn test_build_run_command_no_gpus_when_gpu_not_configured() {
+        // Arrange: 未配置 gpu
+        let config = ExecutorConfig {
+            enable_host_access: false,
+            gpu: None,
+            executor_type: ExecutorType::Standard,
+            image: "test-executor:latest".to_string(),
+            capacity: 5,
+            timeout_minutes: 10,
+            memory_limit: None,
+            working_dir: "/workspace".to_string(),
+            script_path: None,
+            custom_entrypoint: None,
+            custom_args: None,
+        };
+        let temp_dir = TempDir::new().unwrap();
+        let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
+
+        let task = create_test_task("test-task-no-gpu");
+        let workspace = temp_dir.path().join("workspace");
+
+        // Act
+        let cmd = executor.build_run_command(&task, &workspace, &[]);
+        let args = command_args(&cmd);
+
+        // Assert
+        assert!(
+            !args.contains(&"--gpus".to_string()),
+            "未配置 gpu 时不应包含 --gpus 参数，实际参数: {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn test_build_run_command_gpus_all_when_nvidia_with_all_devices() {
+        // Arrange: nvidia + devices 缺省（等同 "all"）
+        for devices in [None, Some("all".to_string())] {
+            let config = ExecutorConfig {
+                enable_host_access: false,
+                gpu: Some(GpuConfig {
+                    vendor: GpuVendor::Nvidia,
+                    devices: devices.clone(),
+                }),
+                executor_type: ExecutorType::Standard,
+                image: "test-executor:latest".to_string(),
+                capacity: 5,
+                timeout_minutes: 10,
+                memory_limit: None,
+                working_dir: "/workspace".to_string(),
+                script_path: None,
+                custom_entrypoint: None,
+                custom_args: None,
+            };
+            let temp_dir = TempDir::new().unwrap();
+            let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
+
+            let task = create_test_task("test-task-gpu-all");
+            let workspace = temp_dir.path().join("workspace");
+
+            // Act
+            let cmd = executor.build_run_command(&task, &workspace, &[]);
+            let args = command_args(&cmd);
+
+            // Assert
+            let pos = args
+                .iter()
+                .position(|arg| arg == "--gpus")
+                .unwrap_or_else(|| panic!("devices={:?} 时应包含 --gpus 参数", devices));
+            assert_eq!(
+                args[pos + 1],
+                "all",
+                "devices={:?} 时 --gpus 后应紧跟 all",
+                devices
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_run_command_gpus_device_list_when_nvidia_with_indices() {
+        // Arrange: nvidia + devices = "0,1"
+        let config = ExecutorConfig {
+            enable_host_access: false,
+            gpu: Some(GpuConfig {
+                vendor: GpuVendor::Nvidia,
+                devices: Some("0,1".to_string()),
+            }),
+            executor_type: ExecutorType::Standard,
+            image: "test-executor:latest".to_string(),
+            capacity: 5,
+            timeout_minutes: 10,
+            memory_limit: None,
+            working_dir: "/workspace".to_string(),
+            script_path: None,
+            custom_entrypoint: None,
+            custom_args: None,
+        };
+        let temp_dir = TempDir::new().unwrap();
+        let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
+
+        let task = create_test_task("test-task-gpu-indices");
+        let workspace = temp_dir.path().join("workspace");
+
+        // Act
+        let cmd = executor.build_run_command(&task, &workspace, &[]);
+        let args = command_args(&cmd);
+
+        // Assert
+        let pos = args
+            .iter()
+            .position(|arg| arg == "--gpus")
+            .expect("应包含 --gpus 参数");
+        assert_eq!(args[pos + 1], "device=0,1", "--gpus 后应紧跟 device=0,1");
+    }
+
+    #[test]
+    fn test_build_run_command_gpus_before_image_with_host_access_and_memory() {
+        // Arrange: --add-host 与 -m 共存时验证 --gpus 的参数顺序
+        let config = ExecutorConfig {
+            enable_host_access: true,
+            gpu: Some(GpuConfig {
+                vendor: GpuVendor::Nvidia,
+                devices: Some("0,1".to_string()),
+            }),
+            executor_type: ExecutorType::Standard,
+            image: "test-executor:latest".to_string(),
+            capacity: 5,
+            timeout_minutes: 10,
+            memory_limit: Some("2g".to_string()),
+            working_dir: "/workspace".to_string(),
+            script_path: None,
+            custom_entrypoint: None,
+            custom_args: None,
+        };
+        let temp_dir = TempDir::new().unwrap();
+        let executor = DockerExecutor::new(config, temp_dir.path().to_path_buf());
+
+        let task = create_test_task("test-task-gpu-order");
+        let workspace = temp_dir.path().join("workspace");
+
+        // Act
+        let cmd = executor.build_run_command(&task, &workspace, &[]);
+        let args = command_args(&cmd);
+
+        // Assert: --add-host < --gpus < -m < image
+        let pos_add_host = args
+            .iter()
+            .position(|arg| arg == "--add-host")
+            .expect("应包含 --add-host 参数");
+        let pos_gpus = args
+            .iter()
+            .position(|arg| arg == "--gpus")
+            .expect("应包含 --gpus 参数");
+        let pos_memory = args
+            .iter()
+            .position(|arg| arg == "-m")
+            .expect("应包含 -m 参数");
+        let pos_image = args
+            .iter()
+            .position(|arg| arg == "test-executor:latest")
+            .expect("应包含 image 参数");
+        assert!(
+            pos_add_host < pos_gpus && pos_gpus < pos_memory && pos_memory < pos_image,
+            "参数顺序应为 --add-host < --gpus < -m < image，实际参数: {:?}",
+            args
         );
     }
 

--- a/agent-core/src/gpu_precheck.rs
+++ b/agent-core/src/gpu_precheck.rs
@@ -1,0 +1,120 @@
+//! GPU 平台启动预检
+//!
+//! 配置了 GPU 挂载时在启动阶段检查平台与 Docker 环境：
+//! - macOS / Windows：不支持 GPU 挂载，硬错误（fail-fast）
+//! - Linux / WSL2：检查 nvidia container runtime，缺失时仅警告不阻断
+//! - docker info 不可用：按未知处理，仅警告不误报
+
+use crate::config::GpuConfig;
+use tracing::{info, warn};
+
+/// GPU 预检结果
+#[derive(Debug, Clone, PartialEq)]
+pub enum GpuPrecheckResult {
+    /// 未配置 GPU，跳过预检
+    NotConfigured,
+    /// 预检通过
+    Ok,
+    /// 存在风险，仅警告（不阻断启动）
+    Warning(String),
+    /// 平台不支持，硬错误（阻断启动）
+    Unsupported(String),
+}
+
+/// GPU 平台预检（可注入平台标识与 docker info 输出，便于测试）
+///
+/// - `platform`：平台标识（取值同 `std::env::consts::OS`，WSL2 为 "linux"）
+/// - `docker_info`：`docker info` 的标准输出；`None` 表示命令执行失败
+pub fn check_gpu_platform(
+    gpu: &Option<GpuConfig>,
+    platform: &str,
+    docker_info: Option<&str>,
+) -> GpuPrecheckResult {
+    let Some(gpu) = gpu else {
+        return GpuPrecheckResult::NotConfigured;
+    };
+
+    match platform {
+        "macos" => {
+            return GpuPrecheckResult::Unsupported(format!(
+                "macOS 不支持 Docker GPU 挂载（vendor: {}），请移除 [executor] 的 gpu 配置或在 Linux / WSL2 上运行",
+                gpu.vendor.as_str()
+            ));
+        }
+        "windows" => {
+            return GpuPrecheckResult::Unsupported(
+                "Windows 原生 Docker 不支持 GPU 挂载（v1），请使用 WSL2 后端运行".to_string(),
+            );
+        }
+        _ => {}
+    }
+
+    // Linux / WSL2（WSL2 的平台标识同样为 "linux"）
+    let Some(info) = docker_info else {
+        return GpuPrecheckResult::Warning(
+            "无法获取 docker info 输出，跳过 nvidia runtime 检查；如任务无法使用 GPU，请确认已安装 nvidia-container-toolkit"
+                .to_string(),
+        );
+    };
+
+    if has_nvidia_runtime(info) {
+        GpuPrecheckResult::Ok
+    } else {
+        GpuPrecheckResult::Warning(format!(
+            "docker info 中未检测到 nvidia runtime，配置了 GPU（vendor: {}）的任务可能无法启动；请安装 nvidia-container-toolkit",
+            gpu.vendor.as_str()
+        ))
+    }
+}
+
+/// 从 docker info 输出中判断是否存在 nvidia runtime
+fn has_nvidia_runtime(docker_info: &str) -> bool {
+    docker_info
+        .lines()
+        .find(|line| line.contains("Runtimes"))
+        .map(|line| line.contains("nvidia"))
+        .unwrap_or_else(|| docker_info.contains("nvidia"))
+}
+
+/// 启动时执行 GPU 预检（真实环境：读取当前平台并调用 docker info）
+///
+/// 未配置 GPU 时直接跳过；Unsupported 返回错误阻断启动，Warning 仅记日志。
+pub async fn precheck_gpu_on_startup(gpu: &Option<GpuConfig>) -> anyhow::Result<()> {
+    if gpu.is_none() {
+        return Ok(());
+    }
+
+    let docker_info = match tokio::process::Command::new("docker")
+        .arg("info")
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+        Ok(output) => {
+            warn!(
+                "docker info 执行失败: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            None
+        }
+        Err(e) => {
+            warn!("执行 docker info 失败: {}", e);
+            None
+        }
+    };
+
+    match check_gpu_platform(gpu, std::env::consts::OS, docker_info.as_deref()) {
+        GpuPrecheckResult::NotConfigured => Ok(()),
+        GpuPrecheckResult::Ok => {
+            info!("GPU 预检通过");
+            Ok(())
+        }
+        GpuPrecheckResult::Warning(msg) => {
+            warn!("GPU 预检警告: {}", msg);
+            Ok(())
+        }
+        GpuPrecheckResult::Unsupported(msg) => anyhow::bail!("GPU 预检失败: {}", msg),
+    }
+}

--- a/agent-core/src/lib.rs
+++ b/agent-core/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod client;
 pub mod config;
 pub mod executor;
+pub mod gpu_precheck;
 pub mod main_support;
 pub mod scheduler;
 pub mod state;

--- a/agent-core/src/scheduler.rs
+++ b/agent-core/src/scheduler.rs
@@ -138,6 +138,11 @@ impl<E: Executor + 'static> Scheduler<E> {
             for task in running_tasks {
                 warn!("恢复任务: {} -> 标记为失败", task.task_id);
 
+                // 取消可能残留的容器（防止 GPU 显存泄漏）；失败仅记日志，不阻断恢复流程
+                if let Err(e) = self.executor.cancel(&task.task_id).await {
+                    warn!("恢复任务 {} 时取消容器失败: {}", task.task_id, e);
+                }
+
                 // 更新本地状态
                 self.state
                     .update_task_status(&task.task_id, "failed", Some("Agent 重启，任务中断"))
@@ -784,5 +789,220 @@ mod tests {
 
         let cmd3 = receiver.recv().await;
         assert!(matches!(cmd3, Some(SchedulerCommand::CancelTask(ref id)) if id == "task-2"));
+    }
+
+    // ========== GPU 支持测试：recover_tasks 应调用 cancel（TDD 红阶段） ==========
+
+    #[tokio::test]
+    async fn test_recover_tasks_calls_executor_cancel_for_single_running_task() {
+        // Arrange
+        let config = create_test_config();
+        let client = create_test_client();
+        let mock_executor = MockExecutor::new();
+        let executor_for_scheduler = mock_executor.clone();
+        let state = StateManager::init_in_memory().await.unwrap();
+
+        // 插入一个 running 状态的任务
+        let running_task = LocalTask {
+            task_id: "recover-cancel-1".to_string(),
+            server_task_id: "recover-cancel-1".to_string(),
+            status: "running".to_string(),
+            container_id: Some("container-1".to_string()),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+            output_path: None,
+            error_message: None,
+        };
+        state.upsert_task(&running_task).await.unwrap();
+
+        let scheduler = Scheduler::new(config, client, executor_for_scheduler, state);
+
+        // Act
+        let result = scheduler.recover_tasks().await;
+
+        // Assert
+        assert!(result.is_ok(), "recover_tasks should succeed");
+        assert_eq!(
+            mock_executor.cancel_call_count(),
+            1,
+            "recover_tasks should call executor.cancel() once for each running task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_tasks_calls_executor_cancel_for_multiple_running_tasks() {
+        // Arrange
+        let config = create_test_config();
+        let client = create_test_client();
+        let mock_executor = MockExecutor::new();
+        let executor_for_scheduler = mock_executor.clone();
+        let state = StateManager::init_in_memory().await.unwrap();
+
+        // 插入 3 个 running 状态的任务
+        for i in 1..=3 {
+            let task = LocalTask {
+                task_id: format!("recover-cancel-{}", i),
+                server_task_id: format!("recover-cancel-{}", i),
+                status: "running".to_string(),
+                container_id: Some(format!("container-{}", i)),
+                started_at: Some(Utc::now()),
+                completed_at: None,
+                output_path: None,
+                error_message: None,
+            };
+            state.upsert_task(&task).await.unwrap();
+        }
+
+        let scheduler = Scheduler::new(config, client, executor_for_scheduler, state);
+
+        // Act
+        let result = scheduler.recover_tasks().await;
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(
+            mock_executor.cancel_call_count(),
+            3,
+            "recover_tasks should call executor.cancel() for each running task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_tasks_no_cancel_when_no_running_tasks() {
+        // Arrange
+        let config = create_test_config();
+        let client = create_test_client();
+        let mock_executor = MockExecutor::new();
+        let executor_for_scheduler = mock_executor.clone();
+        let state = StateManager::init_in_memory().await.unwrap();
+
+        // 不插入任何 running 任务（但插入一个 completed 任务验证不影响）
+        let completed_task = LocalTask {
+            task_id: "already-done".to_string(),
+            server_task_id: "already-done".to_string(),
+            status: "completed".to_string(),
+            container_id: None,
+            started_at: Some(Utc::now()),
+            completed_at: Some(Utc::now()),
+            output_path: None,
+            error_message: None,
+        };
+        state.upsert_task(&completed_task).await.unwrap();
+
+        let scheduler = Scheduler::new(config, client, executor_for_scheduler, state);
+
+        // Act
+        let result = scheduler.recover_tasks().await;
+
+        // Assert
+        assert!(result.is_ok());
+        assert_eq!(
+            mock_executor.cancel_call_count(),
+            0,
+            "recover_tasks should NOT call cancel when there are no running tasks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_tasks_still_marks_tasks_as_failed() {
+        // Arrange: 验证现有行为不回归 — running 任务应被标记为 failed
+        let config = create_test_config();
+        let client = create_test_client();
+        let mock_executor = MockExecutor::new();
+        let executor_for_scheduler = mock_executor.clone();
+        let state = StateManager::init_in_memory().await.unwrap();
+
+        let running_task = LocalTask {
+            task_id: "recover-failed-1".to_string(),
+            server_task_id: "recover-failed-1".to_string(),
+            status: "running".to_string(),
+            container_id: Some("container-1".to_string()),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+            output_path: None,
+            error_message: None,
+        };
+        state.upsert_task(&running_task).await.unwrap();
+
+        let scheduler = Scheduler::new(config, client, executor_for_scheduler, state);
+
+        // Act
+        let result = scheduler.recover_tasks().await;
+
+        // Assert: recover_tasks 成功，且任务状态已更新为 failed
+        assert!(result.is_ok(), "recover_tasks should complete successfully");
+        let task = scheduler
+            .state
+            .get_task("recover-failed-1")
+            .await
+            .unwrap()
+            .expect("任务应存在");
+        assert_eq!(task.status, "failed", "running 任务应被标记为 failed");
+        assert!(
+            task.error_message
+                .as_deref()
+                .unwrap_or("")
+                .contains("Agent 重启"),
+            "error_message 应说明 Agent 重启导致任务中断，实际: {:?}",
+            task.error_message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recover_tasks_continues_when_executor_cancel_fails() {
+        // Arrange: executor.cancel 失败不应阻断恢复流程
+        let config = create_test_config();
+        let client = create_test_client();
+        let mock_executor = MockExecutor::new();
+        mock_executor
+            .set_cancel_result(Err(crate::executor::ExecutorError::Io(
+                "docker 守护进程不可用".to_string(),
+            )))
+            .await;
+        let executor_for_scheduler = mock_executor.clone();
+        let state = StateManager::init_in_memory().await.unwrap();
+
+        let running_task = LocalTask {
+            task_id: "recover-cancel-fail-1".to_string(),
+            server_task_id: "recover-cancel-fail-1".to_string(),
+            status: "running".to_string(),
+            container_id: Some("container-1".to_string()),
+            started_at: Some(Utc::now()),
+            completed_at: None,
+            output_path: None,
+            error_message: None,
+        };
+        state.upsert_task(&running_task).await.unwrap();
+
+        let scheduler = Scheduler::new(config, client, executor_for_scheduler, state);
+
+        // Act: cancel 失败时 recover_tasks 不应 panic，也不应返回 Err
+        let result = scheduler.recover_tasks().await;
+
+        // Assert: 恢复流程不被阻断，任务仍被标记为 failed
+        assert!(result.is_ok(), "cancel 失败不应阻断 recover_tasks");
+        assert_eq!(
+            mock_executor.cancel_call_count(),
+            1,
+            "recover_tasks should still attempt executor.cancel()"
+        );
+        let task = scheduler
+            .state
+            .get_task("recover-cancel-fail-1")
+            .await
+            .unwrap()
+            .expect("任务应存在");
+        assert_eq!(
+            task.status, "failed",
+            "cancel 失败时任务仍应被标记为 failed"
+        );
+        assert!(
+            task.error_message
+                .as_deref()
+                .unwrap_or("")
+                .contains("Agent 重启"),
+            "error_message 应说明 Agent 重启导致任务中断，实际: {:?}",
+            task.error_message
+        );
     }
 }

--- a/agent-core/src/state.rs
+++ b/agent-core/src/state.rs
@@ -129,6 +129,18 @@ impl StateManager {
         Ok(tasks)
     }
 
+    /// 按 task_id 查询单个任务（仅用于测试）
+    #[cfg(any(test, feature = "test-utils"))]
+    #[doc(hidden)]
+    pub async fn get_task(&self, task_id: &str) -> Result<Option<LocalTask>, StateError> {
+        let task = sqlx::query_as::<_, LocalTask>("SELECT * FROM local_tasks WHERE task_id = ?1")
+            .bind(task_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(task)
+    }
+
     /// 更新任务状态
     pub async fn update_task_status(
         &self,

--- a/agent-core/tests/gpu_config.rs
+++ b/agent-core/tests/gpu_config.rs
@@ -1,0 +1,157 @@
+//! GPU 配置测试（TDD 红阶段）
+//!
+//! 这些测试验证 GPU 配置字段的预期行为。
+//! 当前会编译失败，因为以下类型/字段尚未实现：
+//! - `GpuVendor` 枚举
+//! - `GpuConfig` 结构体
+//! - `ExecutorConfig.gpu` 字段
+//! - `ExecutorConfig.gpu_devices` 字段
+//!
+//! 这是预期的红阶段行为，待 coder 实现后应变绿。
+
+use agent_core::config::{Config, ExecutorConfig, GpuConfig, GpuVendor};
+
+/// GPU 配置 TOML roundtrip：nvidia + devices=all
+#[test]
+fn test_gpu_config_toml_roundtrip_nvidia_all() {
+    // Arrange
+    let toml_str = r#"
+[executor]
+gpu.vendor = "nvidia"
+gpu.devices = "all"
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert!(
+        config.executor.gpu.is_some(),
+        "GPU config should be parsed from TOML"
+    );
+    let gpu = config.executor.gpu.as_ref().unwrap();
+    assert_eq!(gpu.vendor, GpuVendor::Nvidia, "Vendor should be Nvidia");
+    assert_eq!(
+        gpu.devices.as_deref(),
+        Some("all"),
+        "Devices should be 'all'"
+    );
+}
+
+/// GPU 配置 TOML roundtrip：nvidia + 特定设备索引
+#[test]
+fn test_gpu_config_toml_roundtrip_nvidia_specific_devices() {
+    // Arrange
+    let toml_str = r#"
+[executor]
+gpu.vendor = "nvidia"
+gpu.devices = "0,1"
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    let gpu = config
+        .executor
+        .gpu
+        .as_ref()
+        .expect("GPU config should be present");
+    assert_eq!(gpu.vendor, GpuVendor::Nvidia);
+    assert_eq!(gpu.devices.as_deref(), Some("0,1"));
+}
+
+/// 旧配置（无 gpu 字段）应正常加载，gpu 默认为 None
+#[test]
+fn test_old_config_without_gpu_field_loads_successfully() {
+    // Arrange: 模拟旧配置文件，不含 gpu 字段
+    let toml_str = r#"
+[executor]
+image = "custom-executor:v1"
+capacity = 4
+"#;
+
+    // Act
+    let config: Config = toml::from_str(toml_str).unwrap();
+
+    // Assert
+    assert!(
+        config.executor.gpu.is_none(),
+        "Old config without gpu field should load with gpu = None"
+    );
+}
+
+/// ExecutorConfig 默认值：gpu 应为 None
+#[test]
+fn test_executor_config_default_gpu_is_none() {
+    // Arrange & Act
+    let executor = ExecutorConfig::default();
+
+    // Assert
+    assert!(
+        executor.gpu.is_none(),
+        "Default ExecutorConfig should have gpu = None"
+    );
+}
+
+/// to_runtime_toml：gpu 启用时应输出实际值
+#[test]
+fn test_runtime_toml_gpu_enabled_outputs_value() {
+    // Arrange
+    let config = Config {
+        executor: ExecutorConfig {
+            gpu: Some(GpuConfig {
+                vendor: GpuVendor::Nvidia,
+                devices: Some("all".to_string()),
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Act
+    let toml_str = config.to_runtime_toml();
+
+    // Assert: 应输出非注释的 gpu.vendor 行
+    assert!(
+        toml_str.contains(r#"gpu.vendor = "nvidia""#),
+        "Enabled GPU config should output non-commented vendor line, actual:\n{}",
+        toml_str
+    );
+    assert!(
+        toml_str.contains(r#"gpu.devices = "all""#),
+        "Enabled GPU config should output devices line, actual:\n{}",
+        toml_str
+    );
+}
+
+/// 非法 vendor 值应导致反序列化失败
+#[test]
+fn test_gpu_invalid_vendor_fails_deserialization() {
+    // Arrange: "apple" 不是合法的 GpuVendor
+    let toml_str = r#"
+[executor]
+gpu.vendor = "apple"
+"#;
+
+    // Act & Assert: 应反序列化失败
+    let result: Result<Config, _> = toml::from_str(toml_str);
+    assert!(
+        result.is_err(),
+        "Invalid vendor 'apple' should fail deserialization"
+    );
+}
+
+/// GpuVendor 枚举应支持 nvidia/amd/intel 三个变体
+#[test]
+fn test_gpu_vendor_enum_variants() {
+    // Arrange & Act
+    let nvidia = GpuVendor::Nvidia;
+    let amd = GpuVendor::Amd;
+    let intel = GpuVendor::Intel;
+
+    // Assert: 三个变体应存在且可比较
+    assert_ne!(nvidia, amd);
+    assert_ne!(nvidia, intel);
+    assert_ne!(amd, intel);
+}

--- a/agent-core/tests/gpu_docker.rs
+++ b/agent-core/tests/gpu_docker.rs
@@ -1,0 +1,162 @@
+//! GPU Docker 参数翻译测试（TDD 红阶段）
+//!
+//! 这些测试验证 GPU 配置到 Docker 运行参数的翻译逻辑。
+//! 当前会编译失败，因为以下尚未实现：
+//! - `GpuVendor` 枚举
+//! - `GpuConfig` 结构体
+//! - `ExecutorConfig.gpu` 字段
+//! - `agent_core::executor::docker::gpu_run_args()` 函数
+//!
+//! 这是预期的红阶段行为，待 coder 实现后应变绿。
+
+use agent_core::config::{GpuConfig, GpuVendor};
+use agent_core::executor::docker::gpu_run_args;
+
+/// gpu 为 None 时，不应生成任何 GPU 参数
+#[test]
+fn test_gpu_run_args_none_returns_empty() {
+    // Arrange
+    let gpu = None;
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    assert!(
+        args.is_empty(),
+        "No GPU args should be generated when gpu is None, got: {:?}",
+        args
+    );
+}
+
+/// nvidia + devices=all → ["--gpus", "all"]
+#[test]
+fn test_gpu_run_args_nvidia_all() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    assert_eq!(
+        args,
+        vec!["--gpus", "all"],
+        "Nvidia + all should produce ['--gpus', 'all']"
+    );
+}
+
+/// nvidia + devices="0,1" → ["--gpus", "device=0,1"]
+#[test]
+fn test_gpu_run_args_nvidia_specific_devices() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("0,1".to_string()),
+    });
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    assert_eq!(
+        args,
+        vec!["--gpus", "device=0,1"],
+        "Nvidia + '0,1' should produce ['--gpus', 'device=0,1']"
+    );
+}
+
+/// GPU 参数值中不应包含 shell 引号（防止注入）
+#[test]
+fn test_gpu_run_args_no_shell_quotes() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("0,1".to_string()),
+    });
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    for arg in &args {
+        assert!(
+            !arg.contains('\'') && !arg.contains('"'),
+            "GPU args must not contain shell quotes, got: {:?}",
+            args
+        );
+    }
+}
+
+/// AMD 和 Intel 在 v1 中未实现，应返回空
+#[test]
+fn test_gpu_run_args_amd_intel_returns_empty_v1() {
+    // Arrange
+    let amd_gpu = Some(GpuConfig {
+        vendor: GpuVendor::Amd,
+        devices: Some("all".to_string()),
+    });
+    let intel_gpu = Some(GpuConfig {
+        vendor: GpuVendor::Intel,
+        devices: Some("all".to_string()),
+    });
+
+    // Act
+    let amd_args = gpu_run_args(&amd_gpu);
+    let intel_args = gpu_run_args(&intel_gpu);
+
+    // Assert: v1 仅支持 nvidia
+    assert!(
+        amd_args.is_empty(),
+        "AMD GPU args should be empty in v1, got: {:?}",
+        amd_args
+    );
+    assert!(
+        intel_args.is_empty(),
+        "Intel GPU args should be empty in v1, got: {:?}",
+        intel_args
+    );
+}
+
+/// devices 为 None 时应默认为 "all"
+#[test]
+fn test_gpu_run_args_devices_none_defaults_to_all() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: None, // None 应默认为 "all"
+    });
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    assert_eq!(
+        args,
+        vec!["--gpus", "all"],
+        "Nvidia + None devices should default to 'all'"
+    );
+}
+
+/// 多设备索引格式正确
+#[test]
+fn test_gpu_run_args_multiple_device_indices() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("0,2,3".to_string()),
+    });
+
+    // Act
+    let args = gpu_run_args(&gpu);
+
+    // Assert
+    assert_eq!(
+        args,
+        vec!["--gpus", "device=0,2,3"],
+        "Multiple device indices should be formatted correctly"
+    );
+}

--- a/agent-core/tests/gpu_precheck.rs
+++ b/agent-core/tests/gpu_precheck.rs
@@ -1,0 +1,207 @@
+//! GPU 平台预检测试（TDD 红阶段）
+//!
+//! 这些测试验证 GPU 平台预检逻辑。
+//! 当前会编译失败，因为以下尚未实现：
+//! - `agent_core::gpu_precheck` 模块
+//! - `check_gpu_platform()` 函数
+//! - `GpuPrecheckResult` 枚举
+//! - `GpuVendor` 枚举
+//! - `GpuConfig` 结构体
+//!
+//! 这是预期的红阶段行为，待 coder 实现后应变绿。
+
+use agent_core::config::{GpuConfig, GpuVendor};
+use agent_core::gpu_precheck::{GpuPrecheckResult, check_gpu_platform};
+
+/// GPU 未配置时，预检应跳过（NotConfigured）
+#[test]
+fn test_gpu_not_configured_returns_not_configured() {
+    // Arrange
+    let gpu = None;
+    let platform = "linux";
+    let docker_info = Some("Runtimes: nvidia runc");
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    assert_eq!(
+        result,
+        GpuPrecheckResult::NotConfigured,
+        "When GPU is not configured, precheck should return NotConfigured"
+    );
+}
+
+/// macOS 上配置了 GPU 应返回 Unsupported（fail-fast）
+#[test]
+fn test_macos_with_gpu_returns_unsupported() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "macos";
+    let docker_info = None; // macOS 上不需要 docker info
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    match result {
+        GpuPrecheckResult::Unsupported(msg) => {
+            assert!(
+                msg.to_lowercase().contains("macos") || msg.to_lowercase().contains("mac"),
+                "Error message should mention macOS, got: {}",
+                msg
+            );
+        }
+        _ => panic!(
+            "macOS with GPU configured should return Unsupported, got: {:?}",
+            result
+        ),
+    }
+}
+
+/// Linux + nvidia runtime 存在 → Ok
+#[test]
+fn test_linux_with_nvidia_runtime_returns_ok() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "linux";
+    let docker_info = Some(
+        r#"
+Client: Docker Engine - Community
+ Version:           20.10.7
+ Runtimes:          nvidia runc
+ Default Runtime:   runc
+"#,
+    );
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    assert_eq!(
+        result,
+        GpuPrecheckResult::Ok,
+        "Linux with nvidia runtime should return Ok"
+    );
+}
+
+/// Linux + nvidia runtime 缺失 → Warning（不失败）
+#[test]
+fn test_linux_without_nvidia_runtime_returns_warning() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "linux";
+    let docker_info = Some(
+        r#"
+Client: Docker Engine - Community
+ Version:           20.10.7
+ Runtimes:          runc
+ Default Runtime:   runc
+"#,
+    );
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    match result {
+        GpuPrecheckResult::Warning(msg) => {
+            assert!(
+                msg.to_lowercase().contains("nvidia") || msg.to_lowercase().contains("runtime"),
+                "Warning message should mention nvidia or runtime, got: {}",
+                msg
+            );
+        }
+        _ => panic!(
+            "Linux without nvidia runtime should return Warning, got: {:?}",
+            result
+        ),
+    }
+}
+
+/// Linux + docker info 命令失败 → Warning（按未知处理）
+#[test]
+fn test_linux_docker_info_fails_returns_warning() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "linux";
+    let docker_info = None; // docker info 命令失败
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    match result {
+        GpuPrecheckResult::Warning(msg) => {
+            assert!(!msg.is_empty(), "Warning message should not be empty");
+        }
+        _ => panic!(
+            "Linux with docker info failure should return Warning, got: {:?}",
+            result
+        ),
+    }
+}
+
+/// WSL2 平台应视为 Linux
+#[test]
+fn test_wsl2_platform_treated_as_linux() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "linux"; // WSL2 报告为 "linux"
+    let docker_info = Some("Runtimes: nvidia runc");
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    assert_eq!(
+        result,
+        GpuPrecheckResult::Ok,
+        "WSL2 (reported as linux) with nvidia runtime should return Ok"
+    );
+}
+
+/// Windows 原生 Docker 应返回 Unsupported（v1 不支持）
+#[test]
+fn test_windows_with_gpu_returns_unsupported() {
+    // Arrange
+    let gpu = Some(GpuConfig {
+        vendor: GpuVendor::Nvidia,
+        devices: Some("all".to_string()),
+    });
+    let platform = "windows";
+    let docker_info = None;
+
+    // Act
+    let result = check_gpu_platform(&gpu, platform, docker_info);
+
+    // Assert
+    match result {
+        GpuPrecheckResult::Unsupported(msg) => {
+            assert!(
+                msg.to_lowercase().contains("windows"),
+                "Error message should mention Windows, got: {}",
+                msg
+            );
+        }
+        _ => panic!(
+            "Windows with GPU configured should return Unsupported in v1, got: {:?}",
+            result
+        ),
+    }
+}


### PR DESCRIPTION
## 变更清单

- **配置**：`agent-core/src/config.rs` 新增 `GpuVendor`（nvidia / amd / intel，v1 仅实现 nvidia，amd / intel 为预留值）与 `GpuConfig`（vendor + devices），`ExecutorConfig` 新增 `gpu: Option<GpuConfig>`（默认关闭）；`to_runtime_toml()` 输出带注释示例；`GpuConfig::validate()` 对非法 devices 值（空格、分号、字母、空段如 `"0;;1"`）fail-fast 报错、拒绝启动
- **Docker 参数**：`agent-core/src/executor/docker.rs` 新增 `gpu_run_args()` 翻译层——nvidia + `all` → `--gpus all`，nvidia + `"0,1"` → `--gpus device=0,1`；参数经 `Command` 逐 arg 传递，不含 shell 引号；由 `build_run_command()` 注入
- **平台预检**：新增 `agent-core/src/gpu_precheck.rs` 模块，挂载在 `cmd/run.rs` 启动流程——macOS / Windows 原生配置 GPU 会启动报错；Linux 缺 nvidia runtime 仅警告；`docker info` 失败按未知处理
- **调度器**：`agent-core/src/scheduler.rs` `recover_tasks()` 补 `executor.cancel()`，清理 Agent 重启时的残留容器，防止 GPU 显存泄漏；清理失败仅告警，不阻断任务上报
- **状态管理**：`agent-core/src/state.rs` 新增 test-utils 门控的 `get_task()`，仅用于测试，生产 API 零变化
- **展示**：`agent-core/src/cmd/status.rs` 执行器配置块显示 GPU 状态
- **测试**：新增 `tests/gpu_config.rs`、`tests/gpu_docker.rs`、`tests/gpu_precheck.rs` 及 config / scheduler / docker 内嵌测试，共 29 个 GPU 相关测试
- **文档**：`config.toml.example`、`README.md`、`README.en.md` 新增 GPU 挂载章节（配置示例、平台支持、nvidia-container-toolkit 安装指引、安全警告、capacity 提示）；`CHANGELOG.md` 记录至 Unreleased → Added

## 测试与验证

- 全套 **199 个测试**通过（含 29 个新增 GPU 相关测试）
- `cargo fmt --check` 通过
- `cargo clippy --all-targets --features test-utils -- -D warnings` 零警告
- Reviewer 已批准

## 使用说明

在 `config.toml` 的 executor 配置块中开启：

```toml
gpu.vendor = "nvidia"   # v1 仅支持 nvidia；amd / intel 为预留值
gpu.devices = "all"     # 挂载全部 GPU；也可按索引指定如 "0,1"
```

- `devices` 仅支持 `"all"` 或逗号分隔的数字索引；含空格、分号、字母或空段的值会在配置加载时报错、拒绝启动
- **平台限制**：仅 Linux / WSL2 支持，Linux 需先安装 nvidia-container-toolkit；macOS 与 Windows 原生不支持，配置了会启动报错
- **安全提示**：开启后所有任务容器都获得 GPU 访问权，仅建议管理员在配置文件中显式开启

## 后续计划

- CDI（Container Device Interface）挂载方式
- AMD / Intel GPU 后端
- 任务级 GPU 声明（按任务粒度分配设备）
