### PR TITLE
fix(pi-extension): toast 通知边框改用纯横线，修复 emoji 错位

### DIFF
--- a/pi-extension/CHANGELOG.md
+++ b/pi-extension/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-08-12
+
+### Fixed
+- toast 通知边框去除左右竖线与拐角字符，改用纯横线，修复 emoji 显示宽度不一致导致的错位
+
 ## [1.1.0] - 2026-08-11
 
 ### Added
@@ -60,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 支持多服务器配置：分别注册、切换默认服务器、删除服务器配置（set_server_url、list_servers、set_default_server、remove_server）
 - 注册信息自动保存到本地配置文件（`~/.pi/agent/openaaas/config.json`）
 
+[1.1.1]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.1.1
 [1.1.0]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.1.0
 [1.0.2]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.0.2
 [1.0.1]: https://github.com/Wolido/OpenAaaS/releases/tag/pi-extension-v1.0.1

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -543,7 +543,6 @@ function createToastOverlay(ctx: ExtensionContext): void {
       return {
         render(width: number): string[] {
           const th = theme;
-          const innerW = width - 2;
           const pad = (s: string, len: number) => {
             const vis = visibleWidth(s);
             if (vis > len) {
@@ -561,14 +560,14 @@ function createToastOverlay(ctx: ExtensionContext): void {
             }
             isFirst = false;
 
-            const row = (content: string) => th.fg(toast.titleColor, "│") + pad(content, innerW) + th.fg(toast.titleColor, "│");
-            allLines.push(th.fg(toast.titleColor, `╭${"─".repeat(innerW)}╮`));
+            const row = (content: string) => pad(content, width);
+            allLines.push(th.fg(toast.titleColor, `${"─".repeat(width)}`));
             allLines.push(row(` ${th.fg(toast.titleColor, toast.icon)} ${th.fg("accent", toast.titleText)}`));
             allLines.push(row(""));
             allLines.push(row(` 服务: ${toast.serviceName}`));
             allLines.push(row(` 摘要: ${toast.promptText}`));
             allLines.push(row(` 时长: ${toast.duration}`));
-            allLines.push(th.fg(toast.titleColor, `╰${"─".repeat(innerW)}╯`));
+            allLines.push(th.fg(toast.titleColor, `${"─".repeat(width)}`));
           }
 
           return allLines;

--- a/pi-extension/package-lock.json
+++ b/pi-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-aaas-pi-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-aaas-pi-extension",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-aaas-pi-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenAaaS pi extension",
   "license": "MIT",
   "author": "IDM Explorer Lab",


### PR DESCRIPTION
## 变更说明

pi-extension toast 通知组件（任务完成/失败/取消时右上角弹出的卡片）原边框使用 Unicode 制表符 `│╭╮╰╯`，因 `✅❌🚫` 等 emoji 在不同终端中的显示宽度计算不一致，导致左右竖线错位。本次移除左右竖线与拐角字符，改用纯横线 `─`，实现天然对齐。

## 修改内容

- 内容行去除左右 `│` 竖线，改为纯内容行
- 上下边框 `╭╮╰╯` 拐角字符替换为 `─` 横线

## 验证

- `npm test` 65/65 通过
- 经 code review 确认：边框与内容行宽度对齐、无残留字符引用