### PR TITLE
docs: add AaaS service redefinition and A2A protocol disambiguation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -60,9 +60,13 @@
 
 ## What is OpenAaaS?
 
+**AaaS**—Agent as a Service. Here "Service" refers not to centralized hosting, but to the **publishing, discovery, delegation, and composition** of capabilities: each node publishes its agent capabilities as discoverable units on the network; primary agents outside the network discover these, delegate tasks to nodes, and integrate the results.
+
 > **Intelligence flows, data stays still — bring Agents to the data, instead of handing data over to Agents.**
 
 OpenAaaS is an Agent-to-Agent orchestration network for AI for Science. Every node runs a full agent instance with its own tools, models, and data; data stays where it was created, while agent capabilities flow through the network to work beside it. Together these nodes form a shared capability infrastructure; outside the network, countless primary agents — pi, Claude Code, Cursor, or your own — discover and compose these nodes through the OpenAaaS protocol, reaching data wherever it lives.
+
+The **A2A** protocol, released by Google and donated to the Linux Foundation, likewise targets agent-to-agent interoperability but uses a peer-to-peer direct connection model: each called agent must declare an addressable HTTP endpoint in its Agent Card for clients to reach, and asynchronous scenarios also require bidirectional network reachability for webhook callbacks. In restricted research networks—lab environments without public IPs and under strict outbound firewalls and NAT—the protocol is unusable on the callee side, since the agent can be neither addressed externally nor receive callbacks; on the caller side, however, it works normally within outbound networks. OpenAaaS uses a unidirectional outbound HTTP short-polling model: nodes join the network by simply polling a public server, requiring no public IP and no open inbound ports.
 
 | Demo Video | Screenshots |
 |:---:|:---:|

--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@
 
 ## 什么是 OpenAaaS?
 
+**AaaS**——Agent as a Service。此处的 "Service" 不指传统 SaaS 的中心化托管与订阅，而指能力的**发布、发现、委派与组合**：每个节点将自身 Agent 能力发布为网络中的可发现单元；网络之外的主智能体发现这些能力后，即可向节点委派任务并整合结果。
+
 > **智能流动，数据静止 —— 让 Agent 走到数据身边，而不是把数据交给 Agent。**
 
 OpenAaaS 是一个面向 AI for Science 的 Agent-to-Agent 编排网络（Agent Orchestration Network）。网络中的每个节点都运行着一个拥有完整工具链的 Agent 实例；数据驻留在产生它的原地，Agent 能力通过网络流动到数据身边，完成分析、计算与协作。这些节点构成共享的能力基础设施；网络之外，无数主智能体——pi、Claude Code、Cursor 或自研 Agent——各自通过 OpenAaaS 协议发现和组合这些能力节点，把手伸向数据所在的任意角落。
+
+由 Google 发布、现由 Linux Foundation 托管的 **A2A** 协议同样致力于 Agent 间互操作，但采用点对点直连模型：每个被调用 Agent 必须在 Agent Card 中声明一个可寻址的 HTTP 端点供客户端访问，异步场景还需双向网络可达以接收 webhook 回调。在无公网 IP、受严格出站防火墙和 NAT 约束的科研实验室环境中，该协议对被调用方不可用——Agent 无法被外部寻址，也无法接收回调；但作为发起方，在出站网络中可正常使用。OpenAaaS 采用单向出站 HTTP 短轮询模型，节点仅需主动访问公网服务器即可入网，无需公网 IP、无需开放入站端口。
 
 | 操作视频 | 截图 |
 |:---:|:---:|


### PR DESCRIPTION
## 变更摘要

在 README 中英文版的「## 什么是 OpenAaaS? / What is OpenAaaS?」章节各新增两段：

1. **AaaS 术语锚定**：展开 "AaaS = Agent as a Service"，将 "Service" 重新定义为能力的**发布、发现、委派与组合**，而非传统 SaaS 的中心化托管与订阅。
2. **A2A 协议消歧**：说明 Google 发布、Linux Foundation 托管的 A2A 协议采用点对点直连模型，在科研受限网络（无公网 IP、严格出站防火墙/NAT）中对被调用方不可用；同时说明 OpenAaaS 的单向出站 HTTP 短轮询模型不要求公网 IP 和入站端口。

## 背景

- **术语锚定**：AaaS 中的 "Service" 容易被误读为传统 SaaS 模型，有必要在项目文档中明确界定其含义——强调能力发布与委派，而非中心化托管。
- **A2A 消歧**：A2A 作为同领域协议经常被问及与 OpenAaaS 的关系，文档中给出模型对比和可用性说明，帮助读者在科研实验室防火墙/NAT 场景下做出选择。

## 变更文件

| 文件 | 变更内容 |
|------|----------|
| `README.md` | 「## 什么是 OpenAaaS?」下新增 AaaS 定义展开段 + A2A 消歧段（+4 行） |
| `README.en.md` | `## What is OpenAaaS?` 下新增对应英文段落（+4 行） |

## 说明

- 本次为纯文档变更，无代码改动。
- 不关联 issue。如果后续希望关联某个 issue 可在此添加 `Closes #N` 或 `Refs #N`。
