### PR TITLE
fix(dash): raise gitpython floor to 3.1.59 (PYSEC-2026-3785..3788)

### DIFF
--- a/dash/pyproject.toml
+++ b/dash/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "toml>=0.10.2",
     "streamlit-autorefresh>=1.0.0",
     # Security: override streamlit's transitive dependency to fix 8 CVEs (GHSA-2f96-g7mh-g2hx, GHSA-v396-v7q4-x2qj, GHSA-956x-8gvw-wg5v, GHSA-3rp5-jjmw-4wv2, GHSA-fjr4-x663-mwxc, GHSA-6p8h-3wgx-97gf, GHSA-r9mr-m37c-5fr3, GHSA-94p4-4cq8-9g67)
-    "gitpython>=3.1.55",
+    "gitpython>=3.1.59",
 ]
 
 [project.scripts]

--- a/dash/tests/test_gitpython_execution_smoke.py
+++ b/dash/tests/test_gitpython_execution_smoke.py
@@ -1,0 +1,182 @@
+"""Smoke tests for the gitpython code path that is really executed at runtime.
+
+Nothing inside ``dash/src`` imports gitpython. The only module that does is
+streamlit itself: ``streamlit.git_util.GitRepo.__init__`` performs a lazy
+``import git`` and then talks to a repository through ``git.Repo``,
+``repo.git.version_info``, ``rev_parse`` and the branch/remote helpers used for
+streamlit's "uncommitted changes" banner.
+
+Because of that, bumping gitpython (3.1.58 -> 3.1.59) is invisible to the rest
+of the suite: the existing tests mock HTTP with ``responses`` and never import
+``git``. These tests create a throwaway repository in a temporary directory and
+drive the same API surface streamlit drives, so a broken upgrade is caught here
+instead of in a deployed dashboard.
+
+NOTE: these tests are *not* part of the security RED gate. They pass on 3.1.58
+as well; they exist to give the GREEN change regression protection.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+# GitPython probes the git binary while ``import git`` runs, so the executable has to
+# be present before the module is imported; otherwise the whole file errors out during
+# collection instead of reporting a missing system dependency.
+if shutil.which("git") is None:  # pragma: no cover - environment guard
+    pytest.skip("git executable is required to exercise gitpython", allow_module_level=True)
+
+import git  # noqa: E402
+
+# Identity used for every commit created below; kept explicit so that a
+# developer's global git config can never influence the outcome.
+TEST_ACTOR = git.Actor("OpenAaaS Dash Tests", "dash-tests@invalid.example")
+
+GITHUB_REMOTE_URL = "https://github.com/openaaas-fixture/openaaas-dash-smoke.git"
+SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@pytest.fixture
+def isolated_git_env(tmp_path, monkeypatch):
+    """Isolate git from user/system configuration so results are deterministic."""
+    empty_config = tmp_path / "empty-gitconfig"
+    empty_config.write_text("", encoding="utf-8")
+    fake_home = tmp_path / "home"
+    (fake_home / ".config").mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(fake_home / ".config"))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(empty_config))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_config))
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
+    monkeypatch.setenv("GIT_OPTIONAL_LOCKS", "0")
+    return fake_home
+
+
+@pytest.fixture
+def temp_git_repo(isolated_git_env, tmp_path):
+    """A real one-commit repository in a temporary directory (never the checkout)."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = git.Repo.init(str(repo_dir))
+
+    payload = repo_dir / "payload.txt"
+    payload.write_text("first\n", encoding="utf-8")
+    repo.index.add([str(payload)])
+    repo.index.commit("feat: first payload", author=TEST_ACTOR, committer=TEST_ACTOR, skip_hooks=True)
+    return repo
+
+
+@pytest.fixture
+def temp_repo_with_github_remote(temp_git_repo):
+    """The temp repo plus an origin remote and an upstream ref (no network I/O)."""
+    branch = temp_git_repo.active_branch.name
+    temp_git_repo.create_remote("origin", GITHUB_REMOTE_URL)
+    # Materialise refs/remotes/<branch> offline so the upstream resolves locally.
+    temp_git_repo.git.update_ref(
+        f"refs/remotes/origin/{branch}", temp_git_repo.head.commit.hexsha
+    )
+    temp_git_repo.git.branch(f"--set-upstream-to=origin/{branch}", branch)
+    return temp_git_repo
+
+
+class TestGitPythonRepositoryOperations:
+    """The plain gitpython API streamlit depends on keeps working."""
+
+    def test_should_expose_head_revision_after_init_add_commit(self, temp_git_repo):
+        """should return a real commit object and matching revision after committing."""
+        repo = temp_git_repo
+
+        head = repo.head.commit
+
+        assert head.summary == "feat: first payload"
+        assert SHA1_RE.match(head.hexsha)
+        assert repo.git.rev_parse("HEAD") == head.hexsha
+        assert [commit.summary for commit in repo.iter_commits()] == ["feat: first payload"]
+        assert repo.is_dirty(untracked_files=True) is False
+
+    def test_should_read_back_committed_blob_content(self, temp_git_repo):
+        """should serve file contents from the object database across revisions."""
+        repo = temp_git_repo
+        payload = Path(repo.working_dir) / "payload.txt"
+        payload.write_text("second\n", encoding="utf-8")
+        repo.index.add([str(payload)])
+        second = repo.index.commit(
+            "feat: second payload", author=TEST_ACTOR, committer=TEST_ACTOR, skip_hooks=True
+        )
+
+        assert (second.tree / "payload.txt").data_stream.read() == b"second\n"
+        assert (second.parents[0].tree / "payload.txt").data_stream.read() == b"first\n"
+        assert [commit.summary for commit in repo.iter_commits()] == [
+            "feat: second payload",
+            "feat: first payload",
+        ]
+
+    def test_should_report_modified_and_untracked_files_after_commit(self, temp_git_repo):
+        """should report working tree state for a modified tracked and a new file."""
+        repo = temp_git_repo
+        (Path(repo.working_dir) / "payload.txt").write_text("dirty\n", encoding="utf-8")
+        (Path(repo.working_dir) / "scratch.txt").write_text("scratch\n", encoding="utf-8")
+
+        assert [item.a_path for item in repo.index.diff(None)] == ["payload.txt"]
+        assert repo.untracked_files == ["scratch.txt"]
+
+
+class TestStreamlitGitPythonCodePath:
+    """streamlit.git_util.GitRepo — the lazy consumer of gitpython — still works.
+
+    GitRepo swallows every exception raised while opening a repository (it falls
+    back to ``self.repo = None``), so the assertions below check the values a
+    *valid* repository produces, not merely "no error was raised".
+    """
+
+    def test_should_report_temp_repo_as_valid(self, temp_git_repo):
+        """should consider a real repository valid and compute its repo-relative module."""
+        from streamlit.git_util import GitRepo
+
+        git_repo = GitRepo(temp_git_repo.working_dir)
+
+        assert git_repo.is_valid() is True
+        assert git_repo.is_head_detached is False
+        assert git_repo.module == "."
+
+    def test_should_return_owner_repo_and_branch_for_github_remote(self, temp_repo_with_github_remote):
+        """should resolve owner/repo, branch and module from a GitHub style remote."""
+        from streamlit.git_util import GitRepo
+
+        branch = temp_repo_with_github_remote.active_branch.name
+        git_repo = GitRepo(temp_repo_with_github_remote.working_dir)
+
+        assert git_repo.get_repo_info() == (
+            "openaaas-fixture/openaaas-dash-smoke",
+            branch,
+            ".",
+        )
+
+    def test_should_list_untracked_files_of_temp_repo(self, temp_git_repo):
+        """should surface untracked files through streamlit's own property."""
+        from streamlit.git_util import GitRepo
+
+        (Path(temp_git_repo.working_dir) / "scratch.txt").write_text("scratch\n", encoding="utf-8")
+
+        assert GitRepo(temp_git_repo.working_dir).untracked_files == ["scratch.txt"]
+
+    def test_should_report_non_repository_path_as_invalid(self, tmp_path, isolated_git_env):
+        """control: a plain directory must not be reported as a repository.
+
+        Without this, a gitpython failure would look identical to "success"
+        because GitRepo turns every error into an invalid repository.
+        """
+        from streamlit.git_util import GitRepo
+
+        not_a_repo = tmp_path / "plain-directory"
+        not_a_repo.mkdir()
+
+        git_repo = GitRepo(str(not_a_repo))
+
+        assert git_repo.is_valid() is False
+        assert git_repo.get_repo_info() is None
+        assert git_repo.untracked_files is None

--- a/dash/tests/test_gitpython_security_floor.py
+++ b/dash/tests/test_gitpython_security_floor.py
@@ -1,0 +1,143 @@
+"""Security floor tests for the gitpython dependency of the dash dashboard.
+
+Background
+----------
+This PR raises the gitpython floor to 3.1.59, the first release unaffected by
+PYSEC-2026-3785 / 3786 / 3787 / 3788 (CVE-2026-78675 .. CVE-2026-78678, one of
+them CVSS 9.8). Before the fix, ``main`` (e727c8b) resolved ``gitpython`` to
+3.1.58 in ``dash/uv.lock`` and declared only ``gitpython>=3.1.55`` in
+``dash/pyproject.toml``, so a vulnerable release was still selectable.
+
+gitpython is not used by ``aaas_dashboard`` directly: it is declared in
+``dash/pyproject.toml`` on purpose as an override of streamlit's transitive
+dependency, and streamlit imports it lazily inside
+``streamlit.git_util.GitRepo.__init__``. So "which gitpython ends up in the
+runtime environment" is a property of the dependency declaration plus the lock
+file, and that is what these tests pin down.
+
+These tests were written as the RED gate of that fix: they failed while the
+resolution could still select a vulnerable release, pass now that the floor is
+raised, and turn red again if the floor ever regresses.
+
+This file is a regression guardrail, not a vulnerability database
+-----------------------------------------------------------------
+``SECURITY_FLOOR``, ``VULNERABLE_VERSION`` and ``ADVISORY`` below are a snapshot
+of the PYSEC-2026-3785..3788 range as it stood when this fix was written. Their
+role is narrow: keep this specific known-bad resolution (3.1.58, or a declared
+floor below 3.1.59) from creeping back in. They will *not* notice a future
+advisory that affects a higher release, and a green run here is therefore not a
+statement that the dependency tree is vulnerability-free. Authoritative
+vulnerability judgements come from ``pip-audit`` in CI (the ``security-audit``
+job of ``.github/workflows/ci.yml``, which audits ``uv export`` of
+``dash/uv.lock``). When a new advisory lands, remediate it through the normal
+dependency update and raise ``SECURITY_FLOOR`` here only deliberately, as an
+explicit follow-up that pins the historical regression.
+"""
+
+import importlib.metadata
+import re
+from pathlib import Path
+
+import toml
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+# The dash package root (dash/), independent of the current working directory.
+DASH_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_FILE = DASH_ROOT / "pyproject.toml"
+UV_LOCK_FILE = DASH_ROOT / "uv.lock"
+
+GITPYTHON_DIST = "gitpython"
+# First release that is not affected by PYSEC-2026-3785..3788.
+SECURITY_FLOOR = Version("3.1.59")
+# Last release that *is* affected; it must not be selectable any more.
+VULNERABLE_VERSION = Version("3.1.58")
+
+ADVISORY = "PYSEC-2026-3785..3788 (CVE-2026-78675..78678)"
+
+# name | optional extras | version specifier | optional environment marker
+REQUIREMENT_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*(?P<specifier>[^;]*?)(?:;.*)?$"
+)
+
+
+def _declared_specifier(project_metadata: dict, package: str) -> SpecifierSet:
+    """Return the version specifier dash declares for *package* (e.g. ``>=3.1.59``)."""
+    requirements = []
+    for requirement in project_metadata["project"]["dependencies"]:
+        parsed = REQUIREMENT_RE.match(requirement)
+        if parsed and parsed.group("name").lower().replace("_", "-") == package:
+            requirements.append(parsed.group("specifier").strip())
+
+    assert len(requirements) == 1, f"expected exactly one {package} requirement, got {requirements}"
+    return SpecifierSet(requirements[0])
+
+
+class TestGitPythonResolvedVersion:
+    """The version that the runtime actually resolves must not be vulnerable."""
+
+    def test_resolved_gitpython_meets_security_floor(self):
+        """should report a gitpython release >= 3.1.59 for the dash environment."""
+        resolved = Version(importlib.metadata.version(GITPYTHON_DIST))
+
+        assert resolved >= SECURITY_FLOOR, (
+            f"{GITPYTHON_DIST} {resolved} is affected by {ADVISORY}; "
+            f"the dashboard environment must resolve >= {SECURITY_FLOOR}"
+        )
+
+    def test_imported_git_module_matches_resolved_distribution(self):
+        """should import the same gitpython version it reports in metadata.
+
+        Guards the floor above against a shadowed or stale copy of ``git``
+        (e.g. a leftover virtualenv), which would make the version check
+        vacuous.
+        """
+        import git
+
+        resolved = importlib.metadata.version(GITPYTHON_DIST)
+
+        assert git.__version__ == resolved, (
+            f"importlib.metadata reports {GITPYTHON_DIST} {resolved} but "
+            f"``import git`` loaded {git.__version__} from {git.__file__}"
+        )
+
+
+class TestGitPythonDependencyDeclaration:
+    """dash's own declaration and lock file must exclude vulnerable releases.
+
+    ``ci.yml`` installs dash with ``pip install -e ".[dev]"``, i.e. *without*
+    consuming uv.lock, so the declaration-level floor is the part of the gate
+    that is enforced in CI as well.
+    """
+
+    def test_declared_gitpython_floor_excludes_vulnerable_release(self):
+        """should not admit gitpython 3.1.58 and should admit 3.1.59."""
+        project_metadata = toml.loads(PYPROJECT_FILE.read_text(encoding="utf-8"))
+
+        specifier = _declared_specifier(project_metadata, GITPYTHON_DIST)
+
+        assert VULNERABLE_VERSION not in specifier, (
+            f"dash declares '{GITPYTHON_DIST}{specifier}', which still installs "
+            f"{VULNERABLE_VERSION} ({ADVISORY})"
+        )
+        assert SECURITY_FLOOR in specifier, (
+            f"dash declares '{GITPYTHON_DIST}{specifier}', which would refuse the "
+            f"fixed release {SECURITY_FLOOR}"
+        )
+
+    def test_uv_lock_resolves_gitpython_at_or_above_security_floor(self):
+        """should pin gitpython to a release >= 3.1.59 in uv.lock."""
+        assert UV_LOCK_FILE.is_file(), f"expected lock file at {UV_LOCK_FILE}"
+        lock = toml.loads(UV_LOCK_FILE.read_text(encoding="utf-8"))
+
+        pinned = [
+            Version(package["version"])
+            for package in lock["package"]
+            if package.get("name") == GITPYTHON_DIST
+        ]
+
+        assert len(pinned) == 1, f"expected exactly one gitpython entry in uv.lock, got {pinned}"
+        assert pinned[0] >= SECURITY_FLOOR, (
+            f"uv.lock pins {GITPYTHON_DIST} {pinned[0]}, which is affected by {ADVISORY}; "
+            f"expected >= {SECURITY_FLOOR}"
+        )

--- a/dash/uv.lock
+++ b/dash/uv.lock
@@ -356,14 +356,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2.0" },
-    { name = "gitpython", specifier = ">=3.1.55" },
+    { name = "gitpython", specifier = ">=3.1.59" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Description

**变更**
- `dash/uv.lock`：gitpython 3.1.58 → 3.1.59，4 行最小 diff（version / sdist / wheel / `[package.metadata]` requires-dist），无其它包连带升级。
- `dash/pyproject.toml:30`：`gitpython>=3.1.55` → `gitpython>=3.1.59`。
- 新增 `dash/tests/test_gitpython_security_floor.py`（4 条安全下限门禁）。
- 新增 `dash/tests/test_gitpython_execution_smoke.py`（7 条 gitpython 真实调用冒烟）。

**为什么必须做**
- `security-audit` 工作流的 `pip-audit (dash)` 是 #269~#272 四个 dependabot PR **唯一**的失败步骤。
- 本地用 CI 同款 `uv export` + `pip-audit==2.10.1` 复现：修复前 exit 1 → 修复后 exit 0。
- 同一 job 内此前被该 step 短路跳过的 `pip-audit (openaaas-mcp-adapter)`、`pip-audit (binder)` 已补验，均 exit 0。

**版本选择理由**
- 3.1.59 是官方标注 "Security" 的 release；OSV 全量 43 条 gitpython advisory 无一命中 3.1.59+。
- `uv lock --upgrade-package gitpython` 不带约束会升到当天刚发布的 3.1.62，故精确落版。
- 须用 uv ≥0.12 执行锁文件更新；uv 0.11.24 会连带重写 8 行无关 marker。

**合并后须知**
- main 合入后 **#269~#272 不会自动转绿**：四个 head 分支自带的 `dash/uv.lock` 仍是 3.1.58，需逐个 Update branch / rebase 后重跑。
- #269 与 #271 同改 `client-app/src-tauri/Cargo.lock`，且 #269 已包含 #271 的全部 hunk，不可并行无脑合并。

**残余风险（本 PR 不修，如实列出）**
- `python-tests` job 用 `pip install -e ".[dev]"`，**不读 lock**；实测装到 gitpython 3.1.62 / streamlit 1.63.0，与仓库锁（3.1.59 / 1.58.0）存在漂移。属既有结构问题，动它需要改 `ci.yml`，本 PR 不修，列为技术债。
- 未在 Linux 原生环境实跑过（docker registry 不可达），已在 macOS 用 py3.11/py3.12 + 真实 git 工作树逼近。
- `dash/.venv` 本机遗留 gitpython 3.1.50 未清理。

## Checklist

- [x] 代码改动已测试通过（TDD RED → GREEN → reviewer 三轴通过；新增 4 条门禁 + 7 条真实执行面冒烟）
- [ ] 对应组件的 `CHANGELOG.md` 已更新（在 `[Unreleased]` 下添加了条目）—— `dash/CHANGELOG.md` 不存在，且本次文件清单锁定为上述 4 个路径，未额外改动
- [x] 没有引入无关的文件改动（恰 4 个文件；`uv.lock` 仅 gitpython 4 行，无其它包连带）
- [x] PR 标题符合 Conventional Commits 规范（`fix(dash): xxx`）